### PR TITLE
fix: add missing is_read column to threaded messages CTE

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -171,7 +171,7 @@ router.get('/messages', async (req, res) => {
                COALESCE(m.thread_id, m.id::text) AS thread_id,
                m.subject, m.from_name, m.from_email,
                m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
-               m.date, m.snippet, m.is_starred,
+               m.date, m.snippet, m.is_starred, m.is_read,
                m.has_attachments, m.account_id,
                a.name  AS account_name,
                a.email_address AS account_email,


### PR DESCRIPTION
Fixes #27.

The `is_read` column is used in the `COUNT(*) FILTER (WHERE NOT m.is_read)` window function inside the `ranked` CTE, but it was never included in the CTE's `SELECT` list. The outer query then references `is_read` from `ranked`, which PostgreSQL rejects with error `42703` (undefined_column).

This crashes the backend on every request to `GET /api/mail/messages?threaded=true` (triggered by the "Group conversations" setting), causing a restart loop and an empty inbox.

**Change:** add `m.is_read` to the inner CTE `SELECT` on line 174.