### PR TITLE
fix: threaded view crash, thread expansion duplicates and folder context, migration bootstrap

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -252,6 +252,8 @@ router.get('/thread/:threadId', async (req, res) => {
   const { threadId } = req.params;
   if (!threadId) return res.status(400).json({ error: 'threadId required' });
 
+  const { folder } = req.query;
+
   const accountsResult = await query(
     'SELECT id FROM email_accounts WHERE user_id = $1 AND enabled = true',
     [req.session.userId]
@@ -259,20 +261,35 @@ router.get('/thread/:threadId', async (req, res) => {
   const userAccountIds = accountsResult.rows.map(r => r.id);
   if (!userAccountIds.length) return res.json({ messages: [] });
 
+  // Deduplicate by message_id: the same email can be stored under multiple IMAP folders
+  // (e.g. Gmail stores every message in both its label-folder and [Gmail]/All Mail).
+  // Prefer the INBOX copy when one exists.
+  // When a specific folder is requested (e.g. INBOX), restrict results to that folder so
+  // the expansion is consistent with what the list view shows.
+  const folderFilter = folder ? `AND m.folder = $3` : '';
+  const params = folder ? [userAccountIds, threadId, folder] : [userAccountIds, threadId];
+
   const result = await query(`
-    SELECT m.id, m.uid, m.folder, m.message_id, m.thread_id, m.subject,
-           m.from_name, m.from_email, m.to_addresses, m.cc_addresses,
-           m.reply_to, m.in_reply_to,
-           m.date, m.snippet, m.is_read, m.is_starred,
-           m.has_attachments, m.account_id,
-           a.name AS account_name, a.email_address AS account_email, a.color AS account_color
-    FROM messages m
-    JOIN email_accounts a ON m.account_id = a.id
-    WHERE m.is_deleted = false
-      AND m.account_id = ANY($1)
-      AND COALESCE(m.thread_id, m.id::text) = $2
-    ORDER BY m.date ASC
-  `, [userAccountIds, threadId]);
+    WITH deduped AS (
+      SELECT DISTINCT ON (m.message_id)
+             m.id, m.uid, m.folder, m.message_id, m.thread_id, m.subject,
+             m.from_name, m.from_email, m.to_addresses, m.cc_addresses,
+             m.reply_to, m.in_reply_to,
+             m.date, m.snippet, m.is_read, m.is_starred,
+             m.has_attachments, m.account_id,
+             a.name AS account_name, a.email_address AS account_email, a.color AS account_color
+      FROM messages m
+      JOIN email_accounts a ON m.account_id = a.id
+      WHERE m.is_deleted = false
+        AND m.account_id = ANY($1)
+        AND COALESCE(m.thread_id, m.id::text) = $2
+        ${folderFilter}
+      ORDER BY m.message_id,
+               CASE WHEN m.folder = 'INBOX' THEN 0 ELSE 1 END,
+               m.date ASC
+    )
+    SELECT * FROM deduped ORDER BY date ASC
+  `, params);
 
   res.json({ messages: result.rows });
 });

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -171,7 +171,7 @@ router.get('/messages', async (req, res) => {
                COALESCE(m.thread_id, m.id::text) AS thread_id,
                m.subject, m.from_name, m.from_email,
                m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
-               m.date, m.snippet, m.is_starred,
+               m.date, m.snippet, m.is_read, m.is_starred,
                m.has_attachments, m.account_id,
                a.name  AS account_name,
                a.email_address AS account_email,

--- a/backend/src/services/migrations.js
+++ b/backend/src/services/migrations.js
@@ -37,27 +37,6 @@ export async function runMigrations() {
 
     const migrations = await getMigrationFiles();
 
-    // Bootstrap for existing installs: if no migrations have been recorded yet but
-    // the schema already exists, stamp all known migrations as applied without running
-    // them — initDb() already applied everything idempotently on prior startups.
-    if (applied.size === 0) {
-      const { rows: tableRows } = await client.query(`
-        SELECT 1 FROM information_schema.tables
-        WHERE table_schema = 'public' AND table_name = 'email_accounts'
-      `);
-      if (tableRows.length > 0) {
-        for (const { version } of migrations) {
-          await client.query(
-            'INSERT INTO schema_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING',
-            [version]
-          );
-        }
-        await client.query('COMMIT');
-        console.log(`Migrations: stamped ${migrations.length} migration(s) as applied on existing install`);
-        return;
-      }
-    }
-
     let ran = 0;
     for (const { version, sql } of migrations) {
       if (applied.has(version)) continue;

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -1016,7 +1016,8 @@ export default function MessageList() {
     if (!threadMessages[tid]) {
       setLoadingThread(tid);
       try {
-        const data = await api.getThread(tid);
+        const effectiveFolder = selectedAccountId ? selectedFolder : 'INBOX';
+        const data = await api.getThread(tid, effectiveFolder);
         setThreadMessages(tid, data.messages || []);
       } catch (err) {
         console.error('Failed to load thread:', err);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -99,7 +99,10 @@ export const api = {
   },
   getMessageBody: (id, remoteImages = false) =>
     request('GET', `/mail/messages/${id}/body${remoteImages ? '?remoteImages=1' : ''}`),
-  getThread: (threadId) => request('GET', `/mail/thread/${encodeURIComponent(threadId)}`),
+  getThread: (threadId, folder) => {
+    const qs = folder ? `?folder=${encodeURIComponent(folder)}` : '';
+    return request('GET', `/mail/thread/${encodeURIComponent(threadId)}${qs}`);
+  },
   markRead: (id, read) => request('PATCH', `/mail/messages/${id}/read`, { read }),
   markStarred: (id, starred) => request('PATCH', `/mail/messages/${id}/star`, { starred }),
   markAllRead: (accountId, folder) => request('POST', '/mail/mark-all-read', { accountId, folder }),


### PR DESCRIPTION
Four independent bug fixes — no schema changes, no new dependencies.

## Changes

### fix: add missing `is_read` column to threaded messages CTE (closes #30)

The `ranked` CTE referenced `m.is_read` inside a window function but never projected it in the `SELECT` list. The outer query's `SELECT is_read FROM ranked` caused PostgreSQL error `42703`, crashing every request to `GET /messages?threaded=true` (i.e. whenever **Group conversations** is enabled).

One-line fix: add `m.is_read` to the CTE's `SELECT`.

### fix: deduplicate thread expansion and restrict to current folder (closes #31, closes #32)

Two related bugs in `GET /mail/thread/:threadId`:

**Duplicate messages (#31):** The same email stored in multiple IMAP folders (Gmail stores every message in both its label-folder and `[Gmail]/All Mail`) appeared as separate rows. Fix: `DISTINCT ON (message_id)`, preferring the INBOX copy via `CASE WHEN folder = 'INBOX' THEN 0 ELSE 1 END`.

**Folder context mismatch (#32):** Expanding a thread in INBOX view could reveal messages from non-INBOX folders (e.g. `[Gmail]/Important`), inconsistent with the flat list which shows only INBOX messages. Fix: accept an optional `?folder=` query parameter; when provided the expansion is restricted to that folder. The frontend now passes the current folder when fetching thread expansions — `INBOX` for the unified inbox, the selected folder for per-account views.

### fix: remove migrations bootstrap that silently skips new migrations (closes #33)

The `applied.size === 0` fast-path stamped all current migrations as applied on existing installs with no migration history. Any migration added later was never run on those installs — it got marked applied before executing. `0001_baseline.sql` is fully idempotent (`CREATE TABLE IF NOT EXISTS`, `INSERT … ON CONFLICT DO NOTHING` throughout), so removing the fast-path is safe: `0001` runs harmlessly on existing schemas and any subsequent migrations apply normally.

---

> **Note:** this PR supersedes #28, which fixed the same `is_read` crash with a one-line patch. The fix here is identical; #28 can be closed.