### PR TITLE
fix: keep MessageList mounted on mobile to preserve scroll and expansion state

### DIFF
--- a/frontend/src/components/MailApp.jsx
+++ b/frontend/src/components/MailApp.jsx
@@ -281,10 +281,16 @@ export default function MailApp() {
           }}>
             <Sidebar />
           </div>
-          {/* Single active pane */}
-          <div style={{ flex: 1, display: 'flex', overflow: 'hidden', height: '100%' }}>
-            {selectedMessageId ? <MessagePane /> : <MessageList />}
+          {/* Keep both mounted so scroll position and expansion state survive
+              navigating into a message and pressing back. */}
+          <div style={{ flex: 1, display: selectedMessageId ? 'none' : 'flex', overflow: 'hidden', height: '100%' }}>
+            <MessageList />
           </div>
+          {selectedMessageId && (
+            <div style={{ flex: 1, display: 'flex', overflow: 'hidden', height: '100%' }}>
+              <MessagePane />
+            </div>
+          )}
         </>
       ) : (
         <>


### PR DESCRIPTION
Fixes #38

## Problem

On mobile, `MailApp` conditionally renders either `MessageList` or `MessagePane` based on whether a message is selected:

```jsx
{selectedMessageId ? <MessagePane /> : <MessageList />}
```

This means `MessageList` is **unmounted** every time a message is opened. When the user presses back, a fresh `MessageList` mounts with no memory of what came before:

- Scroll position resets to the top
- Any expanded thread collapses

## Fix

Keep `MessageList` always mounted and toggle visibility with `display: none` instead. `MessagePane` is only rendered when needed (unchanged behaviour from the user's perspective, but the DOM is preserved).

```jsx
<div style={{ flex: 1, display: selectedMessageId ? 'none' : 'flex', ... }}>
  <MessageList />
</div>
{selectedMessageId && <MessagePane />}
```

Scroll position and thread expansion state survive navigation back from a message with no extra bookkeeping needed.