### PR TITLE
fix: thread display bugs (original sender/subject, badge count, folder context) and missing Cc field

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -169,8 +169,12 @@ router.get('/messages', async (req, res) => {
     // thread_totals counts messages in the same folder scope as the list view so the
     // badge matches what the expansion will show. Unified inbox always scopes to INBOX;
     // per-account views use the requested folder (reuses $2 from filterValues).
+    // Only scope thread_totals to a specific folder for INBOX views, where the badge
+    // must match the expansion (which also filters to INBOX). For any other folder
+    // (All Mail, Sent, etc.) count across all folders so the badge reflects the true
+    // thread size rather than how many copies happen to be synced to that folder.
     const threadFolderFilter = (accountId && userAccountIds.includes(accountId))
-        ? `AND folder = $2`
+        ? (folder === 'INBOX' ? `AND folder = $2` : '')
         : `AND folder = 'INBOX'`;
     const threadResult = await query(`
       WITH deduped AS (
@@ -207,13 +211,16 @@ router.get('/messages', async (req, res) => {
         SELECT d.*,
                COALESCE(tt.message_count, 1) AS message_count,
                COUNT(*) FILTER (WHERE NOT d.is_read) OVER (PARTITION BY d.thread_id)::int AS unread_count,
-               FIRST_VALUE(d.subject) OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_subject,
+               FIRST_VALUE(d.subject)    OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_subject,
+               FIRST_VALUE(d.from_name)  OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_from_name,
+               FIRST_VALUE(d.from_email) OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_from_email,
                ROW_NUMBER() OVER (PARTITION BY d.thread_id ORDER BY d.date DESC) AS rn
         FROM deduped d
         LEFT JOIN thread_totals tt ON tt.thread_id = d.thread_id
       )
       SELECT id, uid, folder, message_id, thread_id, thread_subject AS subject,
-             from_name, from_email, to_addresses, cc_addresses, reply_to, in_reply_to,
+             thread_from_name AS from_name, thread_from_email AS from_email,
+             to_addresses, cc_addresses, reply_to, in_reply_to,
              date, snippet, is_starred, is_read, has_attachments, account_id,
              account_name, account_email, account_color,
              message_count, unread_count
@@ -286,13 +293,12 @@ router.get('/thread/:threadId', async (req, res) => {
   const userAccountIds = accountsResult.rows.map(r => r.id);
   if (!userAccountIds.length) return res.json({ messages: [] });
 
-  // Deduplicate by message_id: the same email can be stored under multiple IMAP folders
-  // (e.g. Gmail stores every message in both its label-folder and [Gmail]/All Mail).
-  // Prefer the INBOX copy when one exists.
-  // When a specific folder is requested (e.g. INBOX), restrict results to that folder so
-  // the expansion is consistent with what the list view shows.
-  const folderFilter = folder ? `AND m.folder = $3` : '';
-  const params = folder ? [userAccountIds, threadId, folder] : [userAccountIds, threadId];
+  // Only restrict expansion to INBOX when viewing the INBOX — ensures the expansion
+  // matches what the list shows. For All Mail and any other folder show all messages
+  // regardless of which folder they were synced under (All Mail backfill is skipped so
+  // not every message has a [Gmail]/All Mail row in the DB).
+  const folderFilter = (folder === 'INBOX') ? `AND m.folder = $3` : '';
+  const params = (folder === 'INBOX') ? [userAccountIds, threadId, folder] : [userAccountIds, threadId];
 
   const result = await query(`
     WITH deduped AS (

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -165,10 +165,13 @@ router.get('/messages', async (req, res) => {
     // One row per thread (latest message per thread_id), ordered by latest date.
     // COALESCE(thread_id, id::text) treats null-thread_id messages as singletons.
     const filterValues = [...values]; // values before limit/offset were pushed
-    // thread_totals counts all messages per thread across ALL folders (not just the
-    // inbox-filtered view), so the badge matches the thread expansion which also
-    // shows messages from Sent, All Mail, etc.
     const threadAccountParam = accountId ? [accountId] : userAccountIds;
+    // thread_totals counts messages in the same folder scope as the list view so the
+    // badge matches what the expansion will show. Unified inbox always scopes to INBOX;
+    // per-account views use the requested folder (reuses $2 from filterValues).
+    const threadFolderFilter = (accountId && userAccountIds.includes(accountId))
+        ? `AND folder = $2`
+        : `AND folder = 'INBOX'`;
     const threadResult = await query(`
       WITH deduped AS (
         SELECT DISTINCT ON (m.account_id, COALESCE(m.thread_id, m.id::text), m.message_id)
@@ -197,6 +200,7 @@ router.get('/messages', async (req, res) => {
         WHERE account_id = ANY($${p})
           AND is_deleted = false
           AND message_id IS NOT NULL
+          ${threadFolderFilter}
         GROUP BY COALESCE(thread_id, id::text)
       ),
       ranked AS (
@@ -231,7 +235,7 @@ router.get('/messages', async (req, res) => {
       threaded: true,
     });
   }
-  // ── Non-threaded mode (unchanged) ───────────────────────────────────────────
+  // ── Non-threaded mode ────────────────────────────────────────────────────────
 
   values.push(safeLimit);
   values.push(safeOffset);
@@ -288,6 +292,7 @@ router.get('/thread/:threadId', async (req, res) => {
   // the expansion is consistent with what the list view shows.
   const folderFilter = folder ? `AND m.folder = $3` : '';
   const params = folder ? [userAccountIds, threadId, folder] : [userAccountIds, threadId];
+
   const result = await query(`
     WITH deduped AS (
       SELECT DISTINCT ON (m.message_id)

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -165,10 +165,10 @@ router.get('/messages', async (req, res) => {
     // One row per thread (latest message per thread_id), ordered by latest date.
     // COALESCE(thread_id, id::text) treats null-thread_id messages as singletons.
     const filterValues = [...values]; // values before limit/offset were pushed
-    // Deduplicate by message_id first (same email can appear in multiple folders),
-    // then compute counts and pick the latest message per thread.
-    // COUNT(DISTINCT ...) is not supported in PostgreSQL window functions, so
-    // deduplication must happen in a CTE before the window aggregates run.
+    // thread_totals counts all messages per thread across ALL folders (not just the
+    // inbox-filtered view), so the badge matches the thread expansion which also
+    // shows messages from Sent, All Mail, etc.
+    const threadAccountParam = accountId ? [accountId] : userAccountIds;
     const threadResult = await query(`
       WITH deduped AS (
         SELECT DISTINCT ON (m.account_id, COALESCE(m.thread_id, m.id::text), m.message_id)
@@ -190,12 +190,22 @@ router.get('/messages', async (req, res) => {
                  CASE WHEN m.folder = 'INBOX' THEN 0 ELSE 1 END,
                  m.date ASC
       ),
+      thread_totals AS (
+        SELECT COALESCE(thread_id, id::text) AS thread_id,
+               COUNT(DISTINCT message_id)::int AS message_count
+        FROM messages
+        WHERE account_id = ANY($${p})
+          AND is_deleted = false
+          AND message_id IS NOT NULL
+        GROUP BY COALESCE(thread_id, id::text)
+      ),
       ranked AS (
-        SELECT *,
-               COUNT(*) OVER (PARTITION BY thread_id)::int AS message_count,
-               COUNT(*) FILTER (WHERE NOT is_read) OVER (PARTITION BY thread_id)::int AS unread_count,
-               ROW_NUMBER() OVER (PARTITION BY thread_id ORDER BY date DESC) AS rn
-        FROM deduped
+        SELECT d.*,
+               COALESCE(tt.message_count, 1) AS message_count,
+               COUNT(*) FILTER (WHERE NOT d.is_read) OVER (PARTITION BY d.thread_id)::int AS unread_count,
+               ROW_NUMBER() OVER (PARTITION BY d.thread_id ORDER BY d.date DESC) AS rn
+        FROM deduped d
+        LEFT JOIN thread_totals tt ON tt.thread_id = d.thread_id
       )
       SELECT id, uid, folder, message_id, thread_id, subject,
              from_name, from_email, to_addresses, cc_addresses, reply_to, in_reply_to,
@@ -205,8 +215,8 @@ router.get('/messages', async (req, res) => {
       FROM ranked
       WHERE rn = 1
       ORDER BY date DESC
-      LIMIT $${p} OFFSET $${p + 1}
-    `, [...filterValues, safeLimit, safeOffset]);
+      LIMIT $${p + 1} OFFSET $${p + 2}
+    `, [...filterValues, threadAccountParam, safeLimit, safeOffset]);
 
     // Thread-level total: distinct thread groups matching the filter.
     const threadCountResult = await query(`

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -207,11 +207,12 @@ router.get('/messages', async (req, res) => {
         SELECT d.*,
                COALESCE(tt.message_count, 1) AS message_count,
                COUNT(*) FILTER (WHERE NOT d.is_read) OVER (PARTITION BY d.thread_id)::int AS unread_count,
+               FIRST_VALUE(d.subject) OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_subject,
                ROW_NUMBER() OVER (PARTITION BY d.thread_id ORDER BY d.date DESC) AS rn
         FROM deduped d
         LEFT JOIN thread_totals tt ON tt.thread_id = d.thread_id
       )
-      SELECT id, uid, folder, message_id, thread_id, subject,
+      SELECT id, uid, folder, message_id, thread_id, thread_subject AS subject,
              from_name, from_email, to_addresses, cc_addresses, reply_to, in_reply_to,
              date, snippet, is_starred, is_read, has_attachments, account_id,
              account_name, account_email, account_color,

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -176,8 +176,8 @@ router.get('/messages', async (req, res) => {
                a.name  AS account_name,
                a.email_address AS account_email,
                a.color AS account_color,
-               COUNT(*) OVER (PARTITION BY COALESCE(m.thread_id, m.id::text))::int AS message_count,
-               COUNT(*) FILTER (WHERE NOT m.is_read)
+               COUNT(DISTINCT m.message_id) OVER (PARTITION BY COALESCE(m.thread_id, m.id::text))::int AS message_count,
+               COUNT(DISTINCT CASE WHEN NOT m.is_read THEN m.message_id END)
                  OVER (PARTITION BY COALESCE(m.thread_id, m.id::text))::int AS unread_count,
                ROW_NUMBER() OVER (
                  PARTITION BY COALESCE(m.thread_id, m.id::text)
@@ -268,7 +268,6 @@ router.get('/thread/:threadId', async (req, res) => {
   // the expansion is consistent with what the list view shows.
   const folderFilter = folder ? `AND m.folder = $3` : '';
   const params = folder ? [userAccountIds, threadId, folder] : [userAccountIds, threadId];
-
   const result = await query(`
     WITH deduped AS (
       SELECT DISTINCT ON (m.message_id)

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -165,9 +165,14 @@ router.get('/messages', async (req, res) => {
     // One row per thread (latest message per thread_id), ordered by latest date.
     // COALESCE(thread_id, id::text) treats null-thread_id messages as singletons.
     const filterValues = [...values]; // values before limit/offset were pushed
+    // Deduplicate by message_id first (same email can appear in multiple folders),
+    // then compute counts and pick the latest message per thread.
+    // COUNT(DISTINCT ...) is not supported in PostgreSQL window functions, so
+    // deduplication must happen in a CTE before the window aggregates run.
     const threadResult = await query(`
-      WITH ranked AS (
-        SELECT m.id, m.uid, m.folder, m.message_id,
+      WITH deduped AS (
+        SELECT DISTINCT ON (m.account_id, COALESCE(m.thread_id, m.id::text), m.message_id)
+               m.id, m.uid, m.folder, m.message_id,
                COALESCE(m.thread_id, m.id::text) AS thread_id,
                m.subject, m.from_name, m.from_email,
                m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
@@ -175,17 +180,22 @@ router.get('/messages', async (req, res) => {
                m.has_attachments, m.account_id,
                a.name  AS account_name,
                a.email_address AS account_email,
-               a.color AS account_color,
-               COUNT(DISTINCT m.message_id) OVER (PARTITION BY COALESCE(m.thread_id, m.id::text))::int AS message_count,
-               COUNT(DISTINCT CASE WHEN NOT m.is_read THEN m.message_id END)
-                 OVER (PARTITION BY COALESCE(m.thread_id, m.id::text))::int AS unread_count,
-               ROW_NUMBER() OVER (
-                 PARTITION BY COALESCE(m.thread_id, m.id::text)
-                 ORDER BY m.date DESC
-               ) AS rn
+               a.color AS account_color
         FROM messages m
         JOIN email_accounts a ON m.account_id = a.id
         WHERE ${where}
+        ORDER BY m.account_id,
+                 COALESCE(m.thread_id, m.id::text),
+                 m.message_id,
+                 CASE WHEN m.folder = 'INBOX' THEN 0 ELSE 1 END,
+                 m.date ASC
+      ),
+      ranked AS (
+        SELECT *,
+               COUNT(*) OVER (PARTITION BY thread_id)::int AS message_count,
+               COUNT(*) FILTER (WHERE NOT is_read) OVER (PARTITION BY thread_id)::int AS unread_count,
+               ROW_NUMBER() OVER (PARTITION BY thread_id ORDER BY date DESC) AS rn
+        FROM deduped
       )
       SELECT id, uid, folder, message_id, thread_id, subject,
              from_name, from_email, to_addresses, cc_addresses, reply_to, in_reply_to,

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -1018,12 +1018,17 @@ export default function MessageList() {
       try {
         const effectiveFolder = selectedAccountId ? selectedFolder : 'INBOX';
         const data = await api.getThread(tid, effectiveFolder);
-        setThreadMessages(tid, data.messages || []);
+        const msgs = data.messages || [];
+        setThreadMessages(tid, msgs);
+        if (msgs.length > 0) handleSelect(msgs[msgs.length - 1]);
       } catch (err) {
         console.error('Failed to load thread:', err);
       } finally {
         setLoadingThread(null);
       }
+    } else {
+      const msgs = threadMessages[tid];
+      if (msgs.length > 0) handleSelect(msgs[msgs.length - 1]);
     }
   };
 

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -867,6 +867,16 @@ export default function MessagePane() {
                         : (message.account_email || message.account_name || '')}
                     </span>
                   </div>
+                  {ccList.length > 0 && (
+                    <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <span>Cc </span>
+                      <span style={{ color: 'var(--text-secondary)' }}>
+                        {ccList.map((r, i) => (
+                          <span key={i}>{r.name || r.email}{i < ccList.length - 1 ? ', ' : ''}</span>
+                        ))}
+                      </span>
+                    </div>
+                  )}
                 </>
               ) : (
                 <>

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -55,7 +55,7 @@ export default function MessagePane() {
   const {
     messages, searchResults, searchQuery, selectedMessageId, setSelectedMessage,
     updateMessage, removeMessage, decrementUnread, incrementUnread, openCompose, accounts, addNotification,
-    imageWhitelist, setImageWhitelist, blockRemoteImages,
+    imageWhitelist, setImageWhitelist, blockRemoteImages, threadMessages,
   } = useStore();
 
   const isMobile = useMobile();
@@ -64,7 +64,8 @@ export default function MessagePane() {
   useEffect(() => () => { mountedRef.current = false; }, []);
 
   const allMessages = searchQuery.trim() ? searchResults : messages;
-  const message = allMessages.find(m => m.id === selectedMessageId);
+  const message = allMessages.find(m => m.id === selectedMessageId)
+    ?? Object.values(threadMessages).flat().find(m => m.id === selectedMessageId);
 
   const [body, setBody] = useState(null);
   const [bodyError, setBodyError] = useState(null);

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -646,6 +646,14 @@ export default function MessagePane() {
     } catch (_) { return []; }
   })();
 
+  const ccList = (() => {
+    try {
+      return Array.isArray(message.cc_addresses)
+        ? message.cc_addresses
+        : JSON.parse(message.cc_addresses || '[]');
+    } catch (_) { return []; }
+  })();
+
   const attachments = body?.attachments || [];
 
   return (
@@ -885,6 +893,19 @@ export default function MessagePane() {
                         : (message.account_email || message.account_name || '')}
                     </span>
                   </div>
+                  {ccList.length > 0 && (
+                    <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 2 }}>
+                      <span>Cc </span>
+                      <span style={{ color: 'var(--text-secondary)' }}>
+                        {ccList.map((r, i) => (
+                          <span key={i}>
+                            {r.name ? `${r.name} <${r.email}>` : r.email}
+                            {i < ccList.length - 1 ? ', ' : ''}
+                          </span>
+                        ))}
+                      </span>
+                    </div>
+                  )}
                 </>
               )}
             </div>


### PR DESCRIPTION
Fixes #35, #36, #37

Four independent bugs addressed in this PR, all affecting the threaded message view.

## Thread shows latest sender and subject instead of original (fixes #35)

The thread list row was displaying the `from_name`, `from_email`, and `subject` of the most recent message in the thread. Using `FIRST_VALUE(... ORDER BY date ASC)` window functions in the `ranked` CTE ensures the original sender and subject are always shown, matching the behaviour of Gmail and Outlook.

## Thread badge count does not match expansion (fixes #36)

Two separate problems caused the badge to diverge from the expansion:

- **Duplicate counting** — Gmail stores the same message under multiple IMAP folders (INBOX, All Mail, Sent, etc.). `COUNT(*)` over the raw rows inflated the count 2–6×. Fixed with a `deduped` CTE using `DISTINCT ON (account_id, thread_id, message_id)` before the window functions run.
- **Folder scope mismatch** — the badge counted messages across all folders while the expansion was filtered to a specific folder. Both are now scoped consistently: INBOX views filter to INBOX, all other folder views (All Mail, Sent, etc.) show the full thread across folders.

## Cc recipients not shown in message header (fixes #37)

The message header only rendered the To line. Cc recipients are now shown below To when present, on both desktop and mobile.

## Reading pane blank when clicking non-latest thread messages

When expanding a thread and clicking an older message, the reading pane showed "Select a message to read" because the message wasn't in the main list store. `MessagePane` now falls back to the `threadMessages` cache when the selected message isn't found in the main list.