### PR TITLE
fix: show sender_name in compose From dropdown

### DIFF
--- a/frontend/src/components/ComposeModal.jsx
+++ b/frontend/src/components/ComposeModal.jsx
@@ -403,17 +403,18 @@ export default function ComposeModal() {
             >
               {accounts.map(a => {
                 const aliases = a.aliases || [];
+                const displayName = a.sender_name || a.name;
                 if (!aliases.length) {
                   return (
                     <option key={a.id} value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                      {a.name} &lt;{a.email_address}&gt;
+                      {displayName} &lt;{a.email_address}&gt;
                     </option>
                   );
                 }
                 return (
                   <optgroup key={a.id} label={a.name} style={{ background: 'var(--bg-tertiary)' }}>
                     <option value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                      {a.name} &lt;{a.email_address}&gt;
+                      {displayName} &lt;{a.email_address}&gt;
                     </option>
                     {aliases.map(alias => (
                       <option key={alias.id} value={`alias:${alias.id}:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
@@ -776,17 +777,18 @@ export default function ComposeModal() {
           >
             {accounts.map(a => {
               const aliases = a.aliases || [];
+              const displayName = a.sender_name || a.name;
               if (!aliases.length) {
                 return (
                   <option key={a.id} value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                    {a.name} &lt;{a.email_address}&gt;
+                    {displayName} &lt;{a.email_address}&gt;
                   </option>
                 );
               }
               return (
                 <optgroup key={a.id} label={a.name} style={{ background: 'var(--bg-tertiary)' }}>
                   <option value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                    {a.name} &lt;{a.email_address}&gt;
+                    {displayName} &lt;{a.email_address}&gt;
                   </option>
                   {aliases.map(alias => (
                     <option key={alias.id} value={`alias:${alias.id}:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>


### PR DESCRIPTION
## Summary

The sender name feature from #44 correctly stores `sender_name` and uses it in the backend `From:` header, but the compose modal's From dropdown still renders `a.name` (the display label) instead of the effective sender name.

This means a user who sets a Sender name in account settings would see the old display name in the compose window, making it appear as though the setting had no effect — even though outgoing emails would actually use the correct name.

**Changed:** Both the mobile and desktop From dropdowns now render `sender_name || name` for the option label (while `optgroup` labels keep using `name` as the account identifier).

Closes #44