### PR TITLE
Fix message body load error caused by UTF-8 null bytes (0x00)

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -33,6 +33,13 @@ function areValidUUIDs(ids) {
   return ids.every(id => typeof id === 'string' && UUID_RE.test(id));
 }
 
+// Strip NUL bytes from strings before DB writes. PostgreSQL UTF-8 text columns
+// reject 0x00, and malformed MIME bodies can contain embedded NUL characters.
+function sanitizeDbText(value) {
+  if (typeof value !== 'string') return value;
+  return value.replace(/\0/g, '');
+}
+
 // Process IMAP operations in bounded batches so a 500-message bulk action
 // does not spawn hundreds of parallel temporary IMAP connections.
 async function runInBatches(items, concurrency, fn) {
@@ -383,7 +390,7 @@ router.get('/messages/:id/body', async (req, res) => {
     let html = message.body_html ? stripEmailHead(message.body_html) : null;
     if (html !== message.body_html) {
       // Update cache so subsequent views don't need to re-strip
-      query('UPDATE messages SET body_html = $1 WHERE id = $2', [html, id]).catch(() => {});
+      query('UPDATE messages SET body_html = $1 WHERE id = $2', [sanitizeDbText(html), id]).catch(() => {});
     }
     // Rewrite eBay imageser URLs to direct image URLs for emails cached before this fix.
     // imageser requires eBay session cookies (never sent cross-site) and returns 1 byte
@@ -392,7 +399,7 @@ router.get('/messages/:id/body', async (req, res) => {
       const rewritten = rewriteEbayImageserUrls(html);
       if (rewritten !== html) {
         html = rewritten;
-        query('UPDATE messages SET body_html = $1 WHERE id = $2', [html, id]).catch(() => {});
+        query('UPDATE messages SET body_html = $1 WHERE id = $2', [sanitizeDbText(html), id]).catch(() => {});
       }
     }
     // Backfill snippet when absent, or regenerate if garbled (undecoded HTML entities
@@ -400,7 +407,7 @@ router.get('/messages/:id/body', async (req, res) => {
     if (!message.snippet || snippetIsGarbled(message.snippet)) {
       const snip = snippetFromBody(message.body_text, html);
       if (snip) {
-        query('UPDATE messages SET snippet = $1 WHERE id = $2', [snip, id]).catch(() => {});
+        query('UPDATE messages SET snippet = $1 WHERE id = $2', [sanitizeDbText(snip), id]).catch(() => {});
       }
     }
 
@@ -423,8 +430,9 @@ router.get('/messages/:id/body', async (req, res) => {
 
     const { html, text, attachments } = await imapManager.fetchMessageBody(account, message.uid, message.folder);
 
-    const safeHtml = html ? sanitizeEmail(html) : null;
-    const snip = snippetFromBody(text, safeHtml || html);
+    const safeHtml = html ? sanitizeDbText(sanitizeEmail(html)) : null;
+    const safeText = sanitizeDbText(text);
+    const snip = sanitizeDbText(snippetFromBody(safeText, safeHtml || html));
 
     // Only cache when we actually got body content — don't overwrite a prior
     // successful cache with null if a transient IMAP fetch returns nothing.
@@ -434,7 +442,7 @@ router.get('/messages/:id/body', async (req, res) => {
          SET body_html = $1, body_text = $2, attachments = $3,
              snippet = CASE WHEN $5 != '' THEN $5 ELSE snippet END
          WHERE id = $4`,
-        [safeHtml, text, JSON.stringify(attachments || []), id, snip]
+        [safeHtml, safeText, JSON.stringify(attachments || []), id, snip]
       );
     }
 
@@ -447,7 +455,7 @@ router.get('/messages/:id/body', async (req, res) => {
       responseHtml = blockRemoteImages(safeHtml);
       hasBlockedRemoteImages = true;
     }
-    res.json({ html: responseHtml, text, attachments: attachments || [], hasBlockedRemoteImages });
+    res.json({ html: responseHtml, text: safeText, attachments: attachments || [], hasBlockedRemoteImages });
   } catch (err) {
     const msg = err.message || 'Unknown error';
     console.error('Body fetch error:', msg);

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -1757,7 +1757,7 @@ export class ImapManager {
              SET body_html = $1, body_text = $2, attachments = $3,
                  snippet = CASE WHEN $5 != '' THEN $5 ELSE snippet END
              WHERE id = $4`,
-            [safeHtml, text, JSON.stringify(attachments || []), msg.id, snip]
+            [sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(attachments || []), msg.id, sanitizeStr(snip)]
           );
         }
       } catch (err) {
@@ -1903,7 +1903,9 @@ export class ImapManager {
         lock.release();
       }
 
-      return { html, text, attachments };
+      // Some malformed emails include NUL bytes that PostgreSQL rejects in text
+      // columns. Strip them once here so all callers are safe.
+      return { html: sanitizeStr(html), text: sanitizeStr(text), attachments };
     });
 
     try {


### PR DESCRIPTION
## Summary

This PR fixes a message body loading failure caused by malformed emails containing NUL bytes (`0x00`).  
Those bytes were reaching PostgreSQL text columns and triggering:

`invalid byte sequence for encoding "UTF8": 0x00`

## Changes

- Added defensive string sanitization to strip NUL bytes before message-body-related DB writes.
- Updated `GET /mail/messages/:id/body` flow to sanitize:
  - cached `body_html` updates,
  - snippet backfills,
  - fetched `body_html` / `body_text` / snippet before `UPDATE messages`.
- Updated `imapManager.fetchMessageBody()` to sanitize returned `html`/`text` so all downstream callers are protected.
- Updated body prefetch cache writes to sanitize `body_html`, `body_text`, and snippet.

## Testing

- Ran syntax checks:
  - `node --check backend/src/routes/mail.js`
  - `node --check backend/src/services/imapManager.js`
- Set up the full local environment and validated the flow end-to-end; no issues found.


---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
