### PR TITLE
fix: deprecated meta tag

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,7 @@
   <link rel="manifest" href="/manifest.json"/>
 
   <!-- iOS home-screen PWA -->
+  <meta name="mobile-web-app-capable" content="yes"/>
   <meta name="apple-mobile-web-app-capable" content="yes"/>
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"/>
   <meta name="apple-mobile-web-app-title" content="MailFlow"/>


### PR DESCRIPTION
## Summary

Fixes deprecated mobile-web-app-capable meta tag by adding:

<meta name="mobile-web-app-capable" content="yes" />

## Changes

- Added the mobile-web-app-capable meta tag to the application HTML.

## Testing

- Verified the meta tag is present in the rendered HTML.
- Confirmed no build or linting errors after the change.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
