### PR TITLE
fix: preload warning

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,10 +22,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
-  <!-- Preload critical display font so it's ready before first paint -->
-  <link rel="preload" as="style"
-    href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,300;1,400;1,600&display=swap">
-
   <!--
     Default font set: DM Sans + Fraunces + JetBrains Mono
     Other font sets loaded dynamically by fonts.js on user preference change


### PR DESCRIPTION
## Summary

Removes the redundant preload for the Cormorant Garamond font stylesheet that was not actually being used. This eliminates the Chrome warning about a preloaded resource not being consumed shortly after load.

## Changes

- Removed unnecessary preload reference for the Cormorant Garamond stylesheet
- Reduced unnecessary browser preload work and console noise

## Testing

- Verified the Chrome warning no longer appears
- Font rendering seems unchanged

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
