### PR TITLE
Fix: message flicker on delete

### DIFF
--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -8,6 +8,7 @@ import { useMobile } from '../hooks/useMobile.js';
 import ContextMenu from './ContextMenu.jsx';
 import { shortcutBus } from '../utils/shortcutBus.js';
 import { pendingMarkReadMap, completedMarkReadMap, setPending } from '../utils/pendingReads.js';
+import { applyDeleteGuard, clearDeleteGuard, clearPendingDelete, setCompletedDelete, setPendingDelete } from '../utils/pendingDeletes.js';
 
 // Folder icon for move picker
 function FolderIcon({ specialUse, size = 13 }) {
@@ -99,7 +100,8 @@ export default function MessageList() {
   // Apply optimistic read guard to a batch of messages from the server.
   // Prevents a concurrent sync refresh from reverting a pending or recently-completed
   // mark-read before the IMAP flag has propagated back to the DB.
-  const applyReadGuard = useCallback((msgs) => {
+  const applyReadGuards = useCallback((msgs) => {
+    msgs = applyDeleteGuard(msgs);
     if (pendingMarkReadMap.size === 0 && completedMarkReadMap.size === 0) return msgs;
     return msgs.map(m => {
       const inFlight = pendingMarkReadMap.has(m.id);
@@ -209,7 +211,7 @@ export default function MessageList() {
         const data = await api.getMessages(params);
         if (cancelled) return;
         setMessagesTotal(data.total);
-        setMessages(data.messages);
+        setMessages(applyReadGuards(data.messages));
         setMessagesOffset(data.messages.length);
         setHasMoreMessages(data.messages.length < data.total);
 
@@ -249,7 +251,7 @@ export default function MessageList() {
       if (unreadOnly) params.unreadOnly = 'true';
       if (useStore.getState().threadedView) params.threaded = 'true';
       const data = await api.getMessages(params);
-      appendMessages(applyReadGuard(data.messages));
+      appendMessages(applyReadGuards(data.messages));
       setMessagesOffset(currentOffset + data.messages.length);
       setHasMoreMessages(currentOffset + data.messages.length < data.total);
     } catch (err) {
@@ -257,7 +259,7 @@ export default function MessageList() {
     } finally {
       setLoadingMessages(false);
     }
-  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages, hasMoreMessages]);
+  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages, hasMoreMessages, applyReadGuards]);
 
   // Listen for backfill refresh events from WebSocket
   useEffect(() => {
@@ -284,7 +286,7 @@ export default function MessageList() {
             setMessagesTotal(data.total);
             // If the unread filter is on and the currently open message was just marked
             // read, the server won't return it — preserve it so the user can keep reading.
-            let msgs = applyReadGuard(data.messages);
+            let msgs = applyReadGuards(data.messages);
             const activeId = useStore.getState().selectedMessageId;
             if (unreadOnly && activeId && !msgs.some(m => m.id === activeId)) {
               const kept = useStore.getState().messages.find(m => m.id === activeId);
@@ -304,7 +306,7 @@ export default function MessageList() {
     };
     window.addEventListener('mailflow:refresh', handler);
     return () => window.removeEventListener('mailflow:refresh', handler);
-  }, [selectedAccountId, selectedFolder, unreadOnly, searchQuery]);
+  }, [selectedAccountId, selectedFolder, unreadOnly, searchQuery, applyReadGuards]);
 
   // Search
   const SEARCH_PAGE = 50;
@@ -323,7 +325,7 @@ export default function MessageList() {
       try {
         const data = await api.search(searchQuery, selectedAccountId || undefined, { offset: 0 });
         if (searchSeq.current !== seq) return;
-        setSearchResults(data.messages);
+        setSearchResults(applyReadGuards(data.messages));
         setSearchHasMore(data.messages.length === SEARCH_PAGE);
       } catch (err) {
         if (searchSeq.current === seq) console.error('Search failed:', err);
@@ -332,7 +334,7 @@ export default function MessageList() {
       }
     }, 300);
     return () => clearTimeout(searchTimer.current);
-  }, [searchQuery, selectedAccountId]);
+  }, [searchQuery, selectedAccountId, applyReadGuards]);
 
   const loadMoreSearch = useCallback(async () => {
     if (searchLoadingMore) return;
@@ -344,14 +346,14 @@ export default function MessageList() {
       // Discard results if the query changed while we were fetching
       if (useStore.getState().searchQuery !== qSnapshot) return;
       const current = useStore.getState().searchResults;
-      useStore.setState({ searchResults: [...current, ...applyReadGuard(data.messages)] });
+      useStore.setState({ searchResults: [...current, ...applyReadGuards(data.messages)] });
       setSearchHasMore(data.messages.length === SEARCH_PAGE);
     } catch (err) {
       console.error('Search load more failed:', err);
     } finally {
       setSearchLoadingMore(false);
     }
-  }, [searchQuery, selectedAccountId, searchLoadingMore]);
+  }, [searchQuery, selectedAccountId, searchLoadingMore, applyReadGuards]);
 
   // Infinite scroll + scroll-to-top visibility
   const handleScroll = useCallback(() => {
@@ -381,7 +383,7 @@ export default function MessageList() {
       if (threadedView) params.threaded = 'true';
       const data = await api.getMessages(params);
       setMessagesTotal(data.total);
-      setMessages(applyReadGuard(data.messages));
+      setMessages(applyReadGuards(data.messages));
       setMessagesOffset((pageNum - 1) * pageSize + data.messages.length);
       setHasMoreMessages(false);
       setExpandedThreadId(null);
@@ -391,7 +393,7 @@ export default function MessageList() {
     } finally {
       setLoadingMessages(false);
     }
-  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages]);
+  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages, threadedView, applyReadGuards]);
 
   const handleSync = async () => {
     if (syncing) return;
@@ -611,6 +613,7 @@ export default function MessageList() {
 
     const ids = [...new Set(deleteMessages.map(msg => msg.id).filter(Boolean))];
     const visibleMessage = message;
+    ids.forEach((id) => setPendingDelete(id));
     removeMessage(visibleMessage.id);
     if (expandedThreadId === tid) setExpandedThreadId(null);
 
@@ -625,10 +628,13 @@ export default function MessageList() {
       try {
         if (ids.length > 1) {
           await api.bulkDelete(ids);
+          ids.forEach((id) => setCompletedDelete(id));
         } else {
           await api.deleteMessage(ids[0] || visibleMessage.id);
+          ids.forEach((id) => setCompletedDelete(id));
         }
       } catch {
+        ids.forEach((id) => clearDeleteGuard(id));
         addNotification({
           type: 'error',
           title: ids.length > 1 ? t('messageList.bulkDeleted.failTitle') : t('messageList.deleted.failTitle'),
@@ -645,6 +651,7 @@ export default function MessageList() {
         if (!pending) return;
         clearTimeout(pending.timer);
         pendingDeleteTimers.current.delete(key);
+        ids.forEach((id) => clearPendingDelete(id));
         const state = useStore.getState();
         state.setMessages([...state.messages, visibleMessage].sort((a, b) => new Date(b.date) - new Date(a.date)));
         if (unreadDelta > 0) incrementUnread(message.account_id, unreadDelta);
@@ -662,8 +669,14 @@ export default function MessageList() {
   useEffect(() => () => {
     pendingDeleteTimers.current.forEach(({ timer, message, ids }) => {
       clearTimeout(timer);
-      if (ids?.length > 1) api.bulkDelete(ids).catch(() => {});
-      else api.deleteMessage(ids?.[0] || message.id).catch(() => {});
+      const deleteIds = ids?.length ? ids : [message.id];
+      const deletePromise =
+        deleteIds.length > 1
+          ? api.bulkDelete(deleteIds)
+          : api.deleteMessage(deleteIds[0]);
+      deletePromise
+        .then(() => { deleteIds.forEach((id) => setCompletedDelete(id)); })
+        .catch(() => { deleteIds.forEach((id) => clearDeleteGuard(id)); });
     });
   }, []);
 
@@ -752,6 +765,7 @@ export default function MessageList() {
   }, []);
 
   const handleBulkDelete = useCallback((ids, msgs) => {
+    ids.forEach(id => setPendingDelete(id));
     ids.forEach(id => removeMessage(id));
     msgs.forEach(msg => { if (!msg.is_read) decrementUnread(msg.account_id); });
     setSelectedIds(new Set());
@@ -761,8 +775,10 @@ export default function MessageList() {
       if (undone) return;
       try {
         await api.bulkDelete(ids);
+        ids.forEach(id => setCompletedDelete(id));
       } catch (err) {
         console.error('Bulk delete failed:', err);
+        ids.forEach(id => clearDeleteGuard(id));
         addNotification({ title: t('messageList.bulkDeleted.failTitle'), body: t('messageList.bulkDeleted.failBody', { count: ids.length }) });
       }
     }, 4500);
@@ -772,6 +788,7 @@ export default function MessageList() {
       onUndo: () => {
         undone = true;
         clearTimeout(timer);
+        ids.forEach(id => clearPendingDelete(id));
         const state = useStore.getState();
         state.setMessages([...state.messages, ...msgs].sort((a, b) => new Date(b.date) - new Date(a.date)));
         msgs.forEach(msg => { if (!msg.is_read) incrementUnread(msg.account_id); });

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -100,7 +100,7 @@ export default function MessageList() {
   // Apply optimistic read guard to a batch of messages from the server.
   // Prevents a concurrent sync refresh from reverting a pending or recently-completed
   // mark-read before the IMAP flag has propagated back to the DB.
-  const applyReadGuards = useCallback((msgs) => {
+  const applyReadGuard = useCallback((msgs) => {
     msgs = applyDeleteGuard(msgs);
     if (pendingMarkReadMap.size === 0 && completedMarkReadMap.size === 0) return msgs;
     return msgs.map(m => {
@@ -211,7 +211,7 @@ export default function MessageList() {
         const data = await api.getMessages(params);
         if (cancelled) return;
         setMessagesTotal(data.total);
-        setMessages(applyReadGuards(data.messages));
+        setMessages(applyReadGuard(data.messages));
         setMessagesOffset(data.messages.length);
         setHasMoreMessages(data.messages.length < data.total);
 
@@ -251,7 +251,7 @@ export default function MessageList() {
       if (unreadOnly) params.unreadOnly = 'true';
       if (useStore.getState().threadedView) params.threaded = 'true';
       const data = await api.getMessages(params);
-      appendMessages(applyReadGuards(data.messages));
+      appendMessages(applyReadGuard(data.messages));
       setMessagesOffset(currentOffset + data.messages.length);
       setHasMoreMessages(currentOffset + data.messages.length < data.total);
     } catch (err) {
@@ -259,7 +259,7 @@ export default function MessageList() {
     } finally {
       setLoadingMessages(false);
     }
-  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages, hasMoreMessages, applyReadGuards]);
+  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages, hasMoreMessages, applyReadGuard]);
 
   // Listen for backfill refresh events from WebSocket
   useEffect(() => {
@@ -286,7 +286,7 @@ export default function MessageList() {
             setMessagesTotal(data.total);
             // If the unread filter is on and the currently open message was just marked
             // read, the server won't return it — preserve it so the user can keep reading.
-            let msgs = applyReadGuards(data.messages);
+            let msgs = applyReadGuard(data.messages);
             const activeId = useStore.getState().selectedMessageId;
             if (unreadOnly && activeId && !msgs.some(m => m.id === activeId)) {
               const kept = useStore.getState().messages.find(m => m.id === activeId);
@@ -306,7 +306,7 @@ export default function MessageList() {
     };
     window.addEventListener('mailflow:refresh', handler);
     return () => window.removeEventListener('mailflow:refresh', handler);
-  }, [selectedAccountId, selectedFolder, unreadOnly, searchQuery, applyReadGuards]);
+  }, [selectedAccountId, selectedFolder, unreadOnly, searchQuery, applyReadGuard]);
 
   // Search
   const SEARCH_PAGE = 50;
@@ -325,7 +325,7 @@ export default function MessageList() {
       try {
         const data = await api.search(searchQuery, selectedAccountId || undefined, { offset: 0 });
         if (searchSeq.current !== seq) return;
-        setSearchResults(applyReadGuards(data.messages));
+        setSearchResults(applyReadGuard(data.messages));
         setSearchHasMore(data.messages.length === SEARCH_PAGE);
       } catch (err) {
         if (searchSeq.current === seq) console.error('Search failed:', err);
@@ -334,7 +334,7 @@ export default function MessageList() {
       }
     }, 300);
     return () => clearTimeout(searchTimer.current);
-  }, [searchQuery, selectedAccountId, applyReadGuards]);
+  }, [searchQuery, selectedAccountId, applyReadGuard]);
 
   const loadMoreSearch = useCallback(async () => {
     if (searchLoadingMore) return;
@@ -346,14 +346,14 @@ export default function MessageList() {
       // Discard results if the query changed while we were fetching
       if (useStore.getState().searchQuery !== qSnapshot) return;
       const current = useStore.getState().searchResults;
-      useStore.setState({ searchResults: [...current, ...applyReadGuards(data.messages)] });
+      useStore.setState({ searchResults: [...current, ...applyReadGuard(data.messages)] });
       setSearchHasMore(data.messages.length === SEARCH_PAGE);
     } catch (err) {
       console.error('Search load more failed:', err);
     } finally {
       setSearchLoadingMore(false);
     }
-  }, [searchQuery, selectedAccountId, searchLoadingMore, applyReadGuards]);
+  }, [searchQuery, selectedAccountId, searchLoadingMore, applyReadGuard]);
 
   // Infinite scroll + scroll-to-top visibility
   const handleScroll = useCallback(() => {
@@ -383,7 +383,7 @@ export default function MessageList() {
       if (threadedView) params.threaded = 'true';
       const data = await api.getMessages(params);
       setMessagesTotal(data.total);
-      setMessages(applyReadGuards(data.messages));
+      setMessages(applyReadGuard(data.messages));
       setMessagesOffset((pageNum - 1) * pageSize + data.messages.length);
       setHasMoreMessages(false);
       setExpandedThreadId(null);
@@ -393,7 +393,7 @@ export default function MessageList() {
     } finally {
       setLoadingMessages(false);
     }
-  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages, threadedView, applyReadGuards]);
+  }, [selectedAccountId, selectedFolder, unreadOnly, pageSize, loadingMessages, threadedView, applyReadGuard]);
 
   const handleSync = async () => {
     if (syncing) return;

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -5,6 +5,7 @@ import { api } from '../utils/api.js';
 import { format } from 'date-fns';
 import { shortcutBus } from '../utils/shortcutBus.js';
 import { useMobile } from '../hooks/useMobile.js';
+import { clearDeleteGuard, setCompletedDelete, setPendingDelete } from '../utils/pendingDeletes.js';
 
 function parseAddressField(raw) {
   try {
@@ -614,10 +615,15 @@ export default function MessagePane() {
   }
 
   const handleDelete = async () => {
+    setPendingDelete(message.id);
     try {
       await api.deleteMessage(message.id);
+      setCompletedDelete(message.id);
       removeMessage(message.id);
-    } catch (err) { console.error(err); }
+    } catch (err) {
+      clearDeleteGuard(message.id);
+      console.error(err);
+    }
   };
 
   const handleArchive = () => {

--- a/frontend/src/utils/pendingDeletes.js
+++ b/frontend/src/utils/pendingDeletes.js
@@ -1,0 +1,43 @@
+// pendingDeleteMap: messageId -> timeout metadata for deletes hidden optimistically
+// but not yet committed to the server because the Undo toast is still active.
+export const pendingDeleteMap = new Map();
+export const completedDeleteMap = new Map();
+
+function setExpiring(map, messageId, ttlMs) {
+  const existing = map.get(messageId);
+  if (existing?.timer) clearTimeout(existing.timer);
+  const timer = setTimeout(() => map.delete(messageId), ttlMs);
+  map.set(messageId, { timer });
+}
+
+export function setPendingDelete(messageId) {
+  clearCompletedDelete(messageId);
+  setExpiring(pendingDeleteMap, messageId, 30000);
+}
+
+export function clearPendingDelete(messageId) {
+  const existing = pendingDeleteMap.get(messageId);
+  if (existing?.timer) clearTimeout(existing.timer);
+  pendingDeleteMap.delete(messageId);
+}
+
+export function setCompletedDelete(messageId) {
+  clearPendingDelete(messageId);
+  setExpiring(completedDeleteMap, messageId, 10000);
+}
+
+export function clearCompletedDelete(messageId) {
+  const existing = completedDeleteMap.get(messageId);
+  if (existing?.timer) clearTimeout(existing.timer);
+  completedDeleteMap.delete(messageId);
+}
+
+export function clearDeleteGuard(messageId) {
+  clearPendingDelete(messageId);
+  clearCompletedDelete(messageId);
+}
+
+export function applyDeleteGuard(messages) {
+  if (pendingDeleteMap.size === 0 && completedDeleteMap.size === 0) return messages;
+  return messages.filter(m => !pendingDeleteMap.has(m.id) && !completedDeleteMap.has(m.id));
+}


### PR DESCRIPTION
## Summary

Fixes an issue where messages could briefly reappear in the message list after being deleted while the optimistic delete/undo flow was still pending.

This happened because background refreshes or sync events could reinsert messages before the delete operation fully completed.

## Changes

- Apply delete guards during message refreshes
- Preserve pending delete state across sync/list reloads
- Add completed delete handling for optimistic delete cleanup
- Ensure bulk delete flows correctly update delete guard state
- Fix pending delete cleanup during component unmount

## Testing

- Deleted single messages and verified they do not reappear during undo window
- Deleted threaded/bulk messages and verified consistent behavior
- Triggered sync/refresh events during pending deletes
- Verified undo restore behavior still works correctly
- Verified delete failure paths correctly clear guards and restore messages

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
