### PR TITLE
Fix: auto version number in about

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+**/node_modules
+**/dist
+**/.env
+**/.env.*
+!**/.env.example
+certs
+*.local

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,7 @@ jobs:
           push: true
           tags: ${{ steps.meta-backend.outputs.tags }}
           labels: ${{ steps.meta-backend.outputs.labels }}
+          provenance: false
           build-args: |
             BUILD_SHA=${{ github.sha }}
             APP_VERSION=${{ github.ref_name }}
@@ -78,6 +79,7 @@ jobs:
           push: true
           tags: ${{ steps.meta-frontend.outputs.tags }}
           labels: ${{ steps.meta-frontend.outputs.labels }}
+          provenance: false
           build-args: |
             VITE_BUILD_SHA=${{ github.sha }}
           cache-from: type=gha

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,13 +45,15 @@ jobs:
       - name: Build and push backend
         uses: docker/build-push-action@v6
         with:
-          context: ./backend
+          context: .
+          file: ./backend/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-backend.outputs.tags }}
           labels: ${{ steps.meta-backend.outputs.labels }}
           build-args: |
             BUILD_SHA=${{ github.sha }}
+            APP_VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -70,7 +72,8 @@ jobs:
       - name: Build and push frontend
         uses: docker/build-push-action@v6
         with:
-          context: ./frontend
+          context: .
+          file: ./frontend/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-frontend.outputs.tags }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,20 +2,35 @@ FROM --platform=$BUILDPLATFORM node:22-alpine AS deps
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+COPY backend/package.json backend/package-lock.json ./
 RUN npm ci --omit=dev
 
-FROM node:22-alpine
+FROM node:22-alpine AS runtime
 
 WORKDIR /app
 
 ARG BUILD_SHA
+ARG APP_VERSION
 ENV BUILD_SHA=${BUILD_SHA:-dev}
 
 COPY --from=deps /app/node_modules ./node_modules
-COPY --chown=node:node package.json ./package.json
-COPY --chown=node:node src/ ./src/
-COPY --chown=node:node migrations/ ./migrations/
+COPY . /repo
+RUN apk add --no-cache --virtual .build-deps git && \
+    cp /repo/backend/package.json ./package.json && \
+    cp -R /repo/backend/src ./src && \
+    cp -R /repo/backend/migrations ./migrations && \
+    APP_VERSION_VALUE="$APP_VERSION"; \
+    if [ -z "$APP_VERSION_VALUE" ]; then \
+      APP_VERSION_VALUE="$(git -C /repo describe --tags --abbrev=0 2>/dev/null | sed 's/^v[.]//' | sed 's/^v//' || true)"; \
+    fi; \
+    if [ -z "$APP_VERSION_VALUE" ]; then \
+      APP_VERSION_VALUE="$(node -p "require('./package.json').version")"; \
+    fi; \
+    APP_VERSION_VALUE="$(printf '%s' "$APP_VERSION_VALUE" | sed 's/^v[.]//' | sed 's/^v//')"; \
+    printf '{"version":"%s"}\n' "$APP_VERSION_VALUE" > ./build-meta.json && \
+    chown -R node:node /app && \
+    rm -rf /repo && \
+    apk del .build-deps
 
 USER node
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -24,7 +24,14 @@ import { reloadAuthSettings } from './services/authLimiter.js';
 import { setupWebSocket } from './services/websocket.js';
 import { ImapManager } from './services/imapManager.js';
 
-const { version: APP_VERSION } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+const packageMeta = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
+let buildMeta = {};
+try {
+  buildMeta = JSON.parse(readFileSync(new URL('../build-meta.json', import.meta.url), 'utf-8'));
+} catch {
+  // Local dev runs may not have build metadata yet.
+}
+const APP_VERSION = (process.env.APP_VERSION || buildMeta.version || packageMeta.version).replace(/^v[.]?/, '');
 
 const app = express();
 // Trust the nginx reverse proxy so req.secure reflects HTTPS correctly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
   # Production mode (--profile https): Caddy handles TLS instead (see below)
   frontend:
     build:
-      context: ./frontend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: frontend/Dockerfile
       args:
         VITE_BUILD_SHA: ${GIT_SHA:-dev}
     container_name: mailflow-frontend
@@ -32,8 +32,8 @@ services:
   # ── Backend API ──────────────────────────────────────────────────────────────
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
       args:
         BUILD_SHA: ${GIT_SHA:-dev}
     container_name: mailflow-backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,10 +2,11 @@ FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY frontend/package*.json ./
 RUN npm ci
 
-COPY . .
+COPY . /repo
+RUN cp -R /repo/frontend/. /app/
 
 ARG VITE_BUILD_SHA
 ENV VITE_BUILD_SHA=${VITE_BUILD_SHA:-dev}
@@ -17,8 +18,8 @@ FROM nginx:alpine
 RUN apk add --no-cache openssl
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY generate-cert.sh /docker-entrypoint.d/10-generate-cert.sh
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/generate-cert.sh /docker-entrypoint.d/10-generate-cert.sh
 RUN chmod +x /docker-entrypoint.d/10-generate-cert.sh
 
 EXPOSE 80 443


### PR DESCRIPTION
## Summary

Fixes version information shown on the About page, so packaged builds use the correct github release version instead of falling back to 1.0.0.

## Changes

- Add backend build metadata generation from APP_VERSION, git tags, or package.json
- Update backend startup to read build-meta.json with a fallback to package.json
- Adjust Docker build contexts for frontend and backend so version/git metadata is available during image builds.
- Add .dockerignore to keep build clean.
- Disable Docker provenance in publish workflow to avoid unknown/unknown package.

## Testing

- Verified Docker build for frontend and backend.
- Confirmed version fallback order works for packaged builds and local development.
- Ran and tested publish workflow changes for backend and frontend image builds.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
