### PR TITLE
Fix: message pane padding

### DIFF
--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -1174,6 +1174,7 @@ export default function MessagePane() {
           )}
           <div style={{
             position: 'relative',
+            padding: '14px 16px 12px',
             background: 'white',
             borderRadius: isMobile ? 0 : 10,
             border: isMobile ? 'none' : '1px solid var(--border-subtle)',


### PR DESCRIPTION
## Summary

Emails with 100% width were rendering flush against the container border.

## Changes

- Added padding around email body content so email content has same visual consistency as other panes.

## Testing

- Verified spacing renders correctly in desktop and mobile email clients

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
