### PR TITLE
Fix: plain text email message pane treatment

### DIFF
--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -1231,14 +1231,21 @@ export default function MessagePane() {
 
       {/* Plain-text email — no internal scroll, outer container handles it */}
       {!loadingBody && !bodyError && body?.text && !body?.html && (
-        <pre style={{
-          margin: 0, padding: isMobile ? '0 12px 16px' : '0 28px 24px',
-          whiteSpace: 'pre-wrap', wordBreak: 'break-word',
-          fontSize: 14, color: 'var(--text-primary)', lineHeight: 1.7,
-          fontFamily: 'DM Sans, sans-serif',
-        }}
-          dangerouslySetInnerHTML={{ __html: linkifyText(body.text) }}
-        />
+        <div style={{
+          padding: isMobile ? '0 12px 16px' : '0 28px 24px',
+        }}>
+          <div style={{
+            margin: 0, padding: '14px 16px 12px',
+            whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+            fontSize: 14, color: 'var(--text-primary)', lineHeight: 1.7,
+            fontFamily: 'DM Sans, sans-serif', background: 'white',
+            borderRadius: isMobile ? 0 : 10,
+            border: isMobile ? 'none' : '1px solid var(--border-subtle)',
+            overflow: 'hidden',
+          }}
+            dangerouslySetInnerHTML={{ __html: linkifyText(body.text) }}
+          />
+        </div>
       )}
       </div>{/* end single scroll container */}
     </div>

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -1232,7 +1232,7 @@ export default function MessagePane() {
       {/* Plain-text email — no internal scroll, outer container handles it */}
       {!loadingBody && !bodyError && body?.text && !body?.html && (
         <div style={{
-          padding: isMobile ? '0 12px 16px' : '0 28px 24px',
+          padding: isMobile ? '0 0px 16px' : '0 28px 24px',
         }}>
           <div style={{
             margin: 0, padding: '14px 16px 12px',


### PR DESCRIPTION
## Summary

Fixes the styling of plain-text email message panes so they visually match HTML email panes. Plain-text emails rendered without a background treatment, making the reading experience feel inconsistent and harder to distinguish from the surroundings.

## Changes

- Add background styling for plain-text email message panes
- Apply consistent padding and container treatment to match HTML email rendering
- Improve visual consistency between plain-text and HTML email views
- Preserved existing plain-text formatting and readability

## Testing

- Opened plain-text emails and verified background styling is applied correctly
- Compared plain-text and HTML email panes for visual consistency
- Confirmed text formatting and spacing remain intact

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
