### PR TITLE
feat: per-sender avatar colors

### DIFF
--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -4,6 +4,7 @@ import { useStore } from '../store/index.js';
 import { api } from '../utils/api.js';
 import { format, isToday, isYesterday, isThisYear } from 'date-fns';
 import { LAYOUTS } from '../layouts.js';
+import { senderColor } from '../themes.js';
 import { useMobile } from '../hooks/useMobile.js';
 import ContextMenu from './ContextMenu.jsx';
 import { shortcutBus } from '../utils/shortcutBus.js';
@@ -2493,7 +2494,7 @@ function ThreadRow({ message, isExpanded, threadMsgs, isLoadingThread, selectedM
         {!isNarrow && !isMobile && (
           <div style={{
             width: 30, height: 30, borderRadius: '50%', flexShrink: 0,
-            background: message.account_color || 'var(--accent)',
+            background: senderColor(message.from_email || message.from_name),
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             fontSize: 13, fontWeight: 600, color: 'white', marginTop: 1,
           }}>
@@ -2869,7 +2870,7 @@ function MessageRow({ message, selected, lastViewed, isChecked, selectionMode, s
         {!isNarrow && !isMobile && (
           <div style={{
             width: 30, height: 30, borderRadius: '50%', flexShrink: 0,
-            background: message.account_color || 'var(--accent)',
+            background: senderColor(message.from_email || message.from_name),
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             fontSize: 13, fontWeight: 600, color: 'white',
             marginTop: 1,

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -6,6 +6,7 @@ import { format } from 'date-fns';
 import { shortcutBus } from '../utils/shortcutBus.js';
 import { useMobile } from '../hooks/useMobile.js';
 import { clearDeleteGuard, setCompletedDelete, setPendingDelete } from '../utils/pendingDeletes.js';
+import { senderColor } from '../themes.js';
 
 function parseAddressField(raw) {
   try {
@@ -909,7 +910,7 @@ export default function MessagePane() {
             {/* Avatar */}
             <div style={{
               width: 40, height: 40, borderRadius: '50%', flexShrink: 0,
-              background: message.account_color || 'var(--accent)',
+              background: senderColor(message.from_email || message.from_name),
               display: 'flex', alignItems: 'center', justifyContent: 'center',
               fontSize: 16, fontWeight: 700, color: 'white',
             }}>

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -545,6 +545,69 @@ function buildFaviconSvg(accent, count = 0) {
 </svg>`;
 }
 
+// ── Sender avatar color ───────────────────────────────────────────────────────
+
+const SENDER_PALETTE = [
+  '#dc2626', // red
+  '#ea580c', // orange
+  '#d97706', // amber
+  '#65a30d', // lime
+  '#16a34a', // green
+  '#059669', // emerald
+  '#0d9488', // teal
+  '#0891b2', // cyan
+  '#0284c7', // sky
+  '#2563eb', // blue
+  '#4f46e5', // indigo
+  '#7c3aed', // violet
+  '#9333ea', // purple
+  '#c026d3', // fuchsia
+  '#db2777', // pink
+  '#e11d48', // rose
+];
+
+const SENDER_COLOR_STORE = 'mf_sender_colors';
+
+function hashIndex(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) >>> 0;
+  return h % SENDER_PALETTE.length;
+}
+
+export function senderColor(email) {
+  const key = (email || '').toLowerCase().trim();
+  if (!key) return SENDER_PALETTE[0];
+
+  let map;
+  try { map = JSON.parse(localStorage.getItem(SENDER_COLOR_STORE) || '{}'); }
+  catch { map = {}; }
+
+  if (map[key]) return map[key];
+
+  const usedColors = new Set(Object.values(map));
+  const unused = SENDER_PALETTE.filter(c => !usedColors.has(c));
+
+  let color;
+  if (unused.length > 0) {
+    const preferred = SENDER_PALETTE[hashIndex(key)];
+    color = unused.includes(preferred) ? preferred : unused[0];
+  } else {
+    // Palette exhausted — pick least-used slot
+    const usage = Object.fromEntries(SENDER_PALETTE.map(c => [c, 0]));
+    for (const c of Object.values(map)) if (c in usage) usage[c]++;
+    const min = Math.min(...Object.values(usage));
+    const candidates = SENDER_PALETTE.filter(c => usage[c] === min);
+    const preferred = SENDER_PALETTE[hashIndex(key)];
+    color = candidates.includes(preferred) ? preferred : candidates[0];
+  }
+
+  map[key] = color;
+  try { localStorage.setItem(SENDER_COLOR_STORE, JSON.stringify(map)); }
+  catch {}
+
+  return color;
+}
+
 // ── Theme application ─────────────────────────────────────────────────────────
 
 export function applyTheme(themeName) {

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -566,52 +566,15 @@ const SENDER_PALETTE = [
   '#e11d48', // rose
 ];
 
-const SENDER_COLOR_STORE = 'mf_sender_colors';
-
 function hashIndex(str) {
   let h = 0;
   for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i)) >>> 0;
   return h % SENDER_PALETTE.length;
 }
 
-let _senderCache = null;
-
-function _loadCache() {
-  if (_senderCache) return _senderCache;
-  try { _senderCache = new Map(Object.entries(JSON.parse(localStorage.getItem(SENDER_COLOR_STORE) || '{}'))); }
-  catch { _senderCache = new Map(); }
-  return _senderCache;
-}
-
 export function senderColor(email) {
   const key = (email || '').toLowerCase().trim();
-  if (!key) return SENDER_PALETTE[0];
-
-  const cache = _loadCache();
-  if (cache.has(key)) return cache.get(key);
-
-  const usedColors = new Set(cache.values());
-  const unused = SENDER_PALETTE.filter(c => !usedColors.has(c));
-
-  let color;
-  if (unused.length > 0) {
-    const preferred = SENDER_PALETTE[hashIndex(key)];
-    color = unused.includes(preferred) ? preferred : unused[0];
-  } else {
-    // Palette exhausted — pick least-used slot
-    const usage = Object.fromEntries(SENDER_PALETTE.map(c => [c, 0]));
-    for (const c of cache.values()) if (c in usage) usage[c]++;
-    const min = Math.min(...Object.values(usage));
-    const candidates = SENDER_PALETTE.filter(c => usage[c] === min);
-    const preferred = SENDER_PALETTE[hashIndex(key)];
-    color = candidates.includes(preferred) ? preferred : candidates[0];
-  }
-
-  cache.set(key, color);
-  try { localStorage.setItem(SENDER_COLOR_STORE, JSON.stringify(Object.fromEntries(cache))); }
-  catch {}
-
-  return color;
+  return SENDER_PALETTE[key ? hashIndex(key) : 0];
 }
 
 // ── Theme application ─────────────────────────────────────────────────────────

--- a/frontend/src/themes.js
+++ b/frontend/src/themes.js
@@ -574,17 +574,23 @@ function hashIndex(str) {
   return h % SENDER_PALETTE.length;
 }
 
+let _senderCache = null;
+
+function _loadCache() {
+  if (_senderCache) return _senderCache;
+  try { _senderCache = new Map(Object.entries(JSON.parse(localStorage.getItem(SENDER_COLOR_STORE) || '{}'))); }
+  catch { _senderCache = new Map(); }
+  return _senderCache;
+}
+
 export function senderColor(email) {
   const key = (email || '').toLowerCase().trim();
   if (!key) return SENDER_PALETTE[0];
 
-  let map;
-  try { map = JSON.parse(localStorage.getItem(SENDER_COLOR_STORE) || '{}'); }
-  catch { map = {}; }
+  const cache = _loadCache();
+  if (cache.has(key)) return cache.get(key);
 
-  if (map[key]) return map[key];
-
-  const usedColors = new Set(Object.values(map));
+  const usedColors = new Set(cache.values());
   const unused = SENDER_PALETTE.filter(c => !usedColors.has(c));
 
   let color;
@@ -594,15 +600,15 @@ export function senderColor(email) {
   } else {
     // Palette exhausted — pick least-used slot
     const usage = Object.fromEntries(SENDER_PALETTE.map(c => [c, 0]));
-    for (const c of Object.values(map)) if (c in usage) usage[c]++;
+    for (const c of cache.values()) if (c in usage) usage[c]++;
     const min = Math.min(...Object.values(usage));
     const candidates = SENDER_PALETTE.filter(c => usage[c] === min);
     const preferred = SENDER_PALETTE[hashIndex(key)];
     color = candidates.includes(preferred) ? preferred : candidates[0];
   }
 
-  map[key] = color;
-  try { localStorage.setItem(SENDER_COLOR_STORE, JSON.stringify(map)); }
+  cache.set(key, color);
+  try { localStorage.setItem(SENDER_COLOR_STORE, JSON.stringify(Object.fromEntries(cache))); }
   catch {}
 
   return color;


### PR DESCRIPTION
## Summary

Implements per-sender avatar colors as discussed in #81. Each sender gets a consistent color derived from their email address, so the message list shows visual variety and senders become recognisable at a glance without reading the name. The small account-color dot used for account identification in the unified inbox is unchanged.

## Changes

- Added a 16-color palette to `themes.js` covering the full hue wheel with sufficient contrast for white text
- Added `senderColor(email)` in `themes.js`: hashes the email address to a palette index — deterministic, no storage, consistent across devices and browsers
- Updated the two avatar sites in `MessageList.jsx` (compact threaded view and wide non-threaded view) and the one in `MessagePane.jsx` to use `senderColor` instead of `account_color`

## Testing

- Tested against a real inbox with multiple accounts
- Verified that the same sender always receives the same color across page reloads and devices
- Verified the account-color dot is unaffected

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.