### PR TITLE
feat: service layer extraction, resolveArchiveFolder, and bulk-read endpoint

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -5,6 +5,7 @@ import { imapManager } from '../index.js';
 import { sanitizeEmail, stripEmailHead, hasRemoteImages, blockRemoteImages, rewriteEbayImageserUrls } from '../services/emailSanitizer.js';
 import { buildSnippetFromHtml, decodeNamedEntity } from '../services/messageParser.js';
 import { resolveTrashFolder, getDeleteStrategy } from '../utils/mailUtils.js';
+import { listMessages } from '../services/messageService.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -110,183 +111,22 @@ function snippetFromBody(text, html) {
 router.get('/messages', async (req, res) => {
   const { accountId, folder = 'INBOX', limit = 50, offset = 0, unreadOnly, threaded } = req.query;
 
-  const accountsResult = await query(
-    'SELECT id FROM email_accounts WHERE user_id = $1 AND enabled = true',
-    [req.session.userId]
-  );
-  const userAccountIds = accountsResult.rows.map(r => r.id);
-  if (!userAccountIds.length) return res.json({ messages: [], total: 0 });
+  const { messages, total, threaded: isThreaded, resolvedAccountId } = await listMessages({
+    userId: req.session.userId,
+    accountId,
+    folder,
+    limit,
+    offset,
+    unreadOnly,
+    threaded,
+  });
 
-  let whereConditions = ['m.is_deleted = false'];
-  const values = [];
-  let p = 1;
-
-  if (accountId && userAccountIds.includes(accountId)) {
-    whereConditions.push(`m.account_id = $${p++}`);
-    values.push(accountId);
-    whereConditions.push(`m.folder = $${p++}`);
-    values.push(folder);
-  } else {
-    whereConditions.push(`m.account_id = ANY($${p++})`);
-    values.push(userAccountIds);
-    whereConditions.push(`m.folder = 'INBOX'`);
-  }
-
-  if (unreadOnly === 'true') whereConditions.push('m.is_read = false');
-
-  const where = whereConditions.join(' AND ');
-
-  // Use cached counts from the folders table instead of an expensive COUNT(*).
-  // These are kept current by the sync process and are accurate within one sync cycle.
-  let total = 0;
-  try {
-    if (accountId && userAccountIds.includes(accountId)) {
-      const r = await query(
-        'SELECT total_count, unread_count FROM folders WHERE account_id = $1 AND path = $2',
-        [accountId, folder]
-      );
-      if (r.rows.length) {
-        total = unreadOnly === 'true' ? (r.rows[0].unread_count ?? 0) : (r.rows[0].total_count ?? 0);
-      }
-    } else {
-      // Unified inbox: sum INBOX counts across all enabled accounts
-      const r = unreadOnly === 'true'
-        ? await query(
-            "SELECT COALESCE(SUM(unread_count), 0)::int AS n FROM folders WHERE account_id = ANY($1) AND path = 'INBOX'",
-            [userAccountIds]
-          )
-        : await query(
-            "SELECT COALESCE(SUM(total_count), 0)::int AS n FROM folders WHERE account_id = ANY($1) AND path = 'INBOX'",
-            [userAccountIds]
-          );
-      total = r.rows[0]?.n ?? 0;
-    }
-  } catch (_) {
-    total = 0;
-  }
-
-  const safeLimit  = Math.min(Math.max(parseInt(limit)  || 50, 1), 500);
-  const safeOffset = Math.max(parseInt(offset) || 0, 0);
-
-  // ── Threaded mode ────────────────────────────────────────────────────────────
-  if (threaded === 'true') {
-    // One row per thread (latest message per thread_id), ordered by latest date.
-    // thread_key is a stored generated column: COALESCE(thread_id, id::text), treating null-thread_id messages as singletons.
-    const filterValues = [...values]; // values before limit/offset were pushed
-    const threadAccountParam = accountId ? [accountId] : userAccountIds;
-    // Only scope thread_totals to a specific folder for INBOX views, where the badge
-    // must match the expansion (which also filters to INBOX). For any other folder
-    // (All Mail, Sent, etc.) count across all folders so the badge reflects the true
-    // thread size rather than how many copies happen to be synced to that folder.
-    const threadFolderFilter = (accountId && userAccountIds.includes(accountId))
-        ? (folder === 'INBOX' ? `AND folder = $2` : '')
-        : `AND folder = 'INBOX'`;
-    const threadResult = await query(`
-      WITH paged_threads AS (
-        -- Identify the thread_ids for this page before any expensive dedup work.
-        -- Full-scan is lightweight here (index-only on account+folder+thread_key+date);
-        -- deduped below then touches only the ~safeLimit threads on this page.
-        SELECT m.thread_key AS thread_id
-        FROM messages m
-        WHERE ${where}
-        GROUP BY m.thread_key
-        ORDER BY MAX(m.date) DESC
-        LIMIT $${p + 1} OFFSET $${p + 2}
-      ),
-      deduped AS MATERIALIZED (
-        SELECT DISTINCT ON (m.account_id, m.thread_key, m.message_id)
-               m.id, m.uid, m.folder, m.message_id,
-               m.thread_key AS thread_id,
-               m.subject, m.from_name, m.from_email,
-               m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
-               m.date, m.snippet, m.is_read, m.is_starred,
-               m.has_attachments, m.account_id,
-               a.name  AS account_name,
-               a.email_address AS account_email,
-               a.color AS account_color
-        FROM messages m
-        JOIN email_accounts a ON m.account_id = a.id
-        WHERE ${where}
-          AND m.thread_key IN (SELECT thread_id FROM paged_threads)
-        ORDER BY m.account_id,
-                 m.thread_key,
-                 m.message_id,
-                 CASE WHEN m.folder = 'INBOX' THEN 0 ELSE 1 END,
-                 m.date ASC
-      ),
-      thread_totals AS (
-        SELECT m.thread_key AS thread_id,
-               COUNT(DISTINCT m.message_id)::int AS message_count
-        FROM messages m
-        WHERE m.account_id = ANY($${p})
-          AND m.is_deleted = false
-          AND m.message_id IS NOT NULL
-          ${threadFolderFilter}
-          AND m.thread_key IN (SELECT thread_id FROM paged_threads)
-        GROUP BY m.thread_key
-      ),
-      ranked AS (
-        SELECT d.*,
-               COALESCE(tt.message_count, 1) AS message_count,
-               COUNT(*) FILTER (WHERE NOT d.is_read) OVER (PARTITION BY d.thread_id)::int AS unread_count,
-               FIRST_VALUE(d.subject)    OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_subject,
-               FIRST_VALUE(d.from_name)  OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_from_name,
-               FIRST_VALUE(d.from_email) OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_from_email,
-               ROW_NUMBER() OVER (PARTITION BY d.thread_id ORDER BY d.date DESC) AS rn
-        FROM deduped d
-        LEFT JOIN thread_totals tt ON tt.thread_id = d.thread_id
-      )
-      SELECT id, uid, folder, message_id, thread_id, thread_subject AS subject,
-             thread_from_name AS from_name, thread_from_email AS from_email,
-             to_addresses, cc_addresses, reply_to, in_reply_to,
-             date, snippet, is_starred, is_read, has_attachments, account_id,
-             account_name, account_email, account_color,
-             message_count, unread_count
-      FROM ranked
-      WHERE rn = 1
-      ORDER BY date DESC
-    `, [...filterValues, threadAccountParam, safeLimit, safeOffset]);
-
-    // Thread-level total: distinct thread groups matching the filter.
-    const threadCountResult = await query(`
-      SELECT COUNT(DISTINCT m.thread_key)::int AS total
-      FROM messages m
-      WHERE ${where}
-    `, filterValues);
-
-    if (accountId && userAccountIds.includes(accountId) && threadResult.rows.length) {
-      imapManager.prefetchFolderBodies(accountId, threadResult.rows.map(r => r.id))
-        .catch(err => console.warn('Folder body prefetch error:', err.message));
-    }
-    return res.json({
-      messages: threadResult.rows,
-      total: threadCountResult.rows[0]?.total ?? 0,
-      threaded: true,
-    });
-  }
-  // ── Non-threaded mode ────────────────────────────────────────────────────────
-
-  values.push(safeLimit);
-  values.push(safeOffset);
-
-  const result = await query(`
-    SELECT m.id, m.uid, m.folder, m.message_id, m.subject, m.from_name, m.from_email,
-           m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
-           m.date, m.snippet, m.is_read, m.is_starred,
-           m.has_attachments, m.account_id,
-           a.name as account_name, a.email_address as account_email, a.color as account_color
-    FROM messages m
-    JOIN email_accounts a ON m.account_id = a.id
-    WHERE ${where}
-    ORDER BY m.date DESC
-    LIMIT $${p++} OFFSET $${p++}
-  `, values);
-
-  if (accountId && userAccountIds.includes(accountId) && result.rows.length) {
-    imapManager.prefetchFolderBodies(accountId, result.rows.map(r => r.id))
+  if (resolvedAccountId && messages.length) {
+    imapManager.prefetchFolderBodies(resolvedAccountId, messages.map(r => r.id))
       .catch(err => console.warn('Folder body prefetch error:', err.message));
   }
-  res.json({ messages: result.rows, total });
+
+  res.json({ messages, total, ...(isThreaded ? { threaded: true } : {}) });
 });
 
 // Returns true if remote images should be blocked for this message given the user's preferences.

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -4,7 +4,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { imapManager } from '../index.js';
 import { sanitizeEmail, stripEmailHead, hasRemoteImages, blockRemoteImages, rewriteEbayImageserUrls } from '../services/emailSanitizer.js';
 import { buildSnippetFromHtml, decodeNamedEntity } from '../services/messageParser.js';
-import { resolveTrashFolder, getDeleteStrategy } from '../utils/mailUtils.js';
+import { resolveTrashFolder, resolveArchiveFolder, getDeleteStrategy } from '../utils/mailUtils.js';
 import { listMessages } from '../services/messageService.js';
 
 const router = Router();
@@ -948,16 +948,7 @@ router.post('/messages/bulk-archive', async (req, res) => {
     const noArchiveFolder = [];
 
     for (const [accountId, msgs] of Object.entries(byAccount)) {
-      // Resolve archive folder: explicit mapping > special_use > name heuristic
-      let archiveFolder = msgs[0].folder_mappings?.archive || null;
-      if (!archiveFolder) {
-        const folderResult = await query(
-          `SELECT path FROM folders WHERE account_id = $1
-           AND (special_use = '\\Archive' OR lower(name) LIKE '%archive%') LIMIT 1`,
-          [accountId]
-        );
-        archiveFolder = folderResult.rows[0]?.path || null;
-      }
+      const archiveFolder = await resolveArchiveFolder(accountId, msgs[0].folder_mappings);
       if (!archiveFolder) {
         noArchiveFolder.push(accountId);
         continue;
@@ -965,14 +956,17 @@ router.post('/messages/bulk-archive', async (req, res) => {
 
       const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [accountId]);
       const account = accountResult.rows[0];
-      for (const msg of msgs) {
-        try {
-          const newUid = await imapManager.moveMessage(account, msg.uid, msg.folder, archiveFolder);
-          archivedIds.push({ id: msg.id, folder: archiveFolder, newUid: newUid || null });
-        } catch (err) {
-          console.error(`bulk-archive IMAP ${msg.id}:`, err.message);
+      const results = await runInBatches(
+        msgs, 3,
+        msg => imapManager.moveMessage(account, msg.uid, msg.folder, archiveFolder)
+      );
+      results.forEach((r, i) => {
+        if (r.status === 'fulfilled') {
+          archivedIds.push({ id: msgs[i].id, folder: archiveFolder, newUid: r.value || null });
+        } else {
+          console.error(`bulk-archive IMAP ${msgs[i].id}:`, r.reason.message);
         }
-      }
+      });
     }
 
     // Update DB folder for successfully archived messages, grouped by destination

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -641,6 +641,79 @@ router.post('/folders/empty', async (req, res) => {
   imapManager.broadcast({ type: 'sync_complete', accountId }, check.rows[0].user_id);
 });
 
+// Bulk mark read/unread
+router.post('/messages/bulk-read', async (req, res) => {
+  const { ids, read } = req.body;
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return res.status(400).json({ error: 'ids array required' });
+  }
+  if (ids.length > 500) {
+    return res.status(400).json({ error: 'Too many ids — maximum 500 per request' });
+  }
+  if (!areValidUUIDs(ids)) {
+    return res.status(400).json({ error: 'Invalid message IDs' });
+  }
+  if (typeof read !== 'boolean') {
+    return res.status(400).json({ error: 'read must be a boolean' });
+  }
+
+  try {
+    const result = await query(
+      `SELECT m.id, m.uid, m.folder, m.is_read, m.account_id FROM messages m
+       JOIN email_accounts a ON m.account_id = a.id
+       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1`,
+      [req.session.userId, ids]
+    );
+
+    const owned = result.rows;
+    if (!owned.length) return res.json({ ok: true, updated: [] });
+
+    // Skip messages whose state already matches — avoid spurious DB writes and IMAP round-trips.
+    const toUpdate = owned.filter(m => !!m.is_read !== !!read);
+    if (!toUpdate.length) return res.json({ ok: true, updated: [] });
+
+    await query(
+      'UPDATE messages SET is_read = $1, read_changed_at = NOW() WHERE id = ANY($2::uuid[])',
+      [read, toUpdate.map(m => m.id)]
+    );
+
+    // Adjust cached unread counts per account+folder.
+    const folderDeltas = {};
+    for (const msg of toUpdate) {
+      const key = `${msg.account_id}:${msg.folder}`;
+      if (!folderDeltas[key]) folderDeltas[key] = { accountId: msg.account_id, folder: msg.folder, delta: 0 };
+      folderDeltas[key].delta += read ? -1 : 1;
+    }
+    for (const { accountId, folder, delta } of Object.values(folderDeltas)) {
+      adjustFolderCounts(accountId, folder, 0, delta);
+    }
+
+    // IMAP flag updates — group by account to fetch each account row once.
+    const byAccount = {};
+    for (const msg of toUpdate) {
+      (byAccount[msg.account_id] = byAccount[msg.account_id] || []).push(msg);
+    }
+    for (const [accountId, msgs] of Object.entries(byAccount)) {
+      const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [accountId]);
+      const account = accountResult.rows[0];
+      const results = await runInBatches(
+        msgs, 3,
+        msg => imapManager.setFlag(account, msg.uid, msg.folder, '\\Seen', read)
+      );
+      results.forEach((r, i) => {
+        if (r.status === 'rejected') {
+          console.error(`bulk-read IMAP ${msgs[i].id}:`, r.reason.message);
+        }
+      });
+    }
+
+    res.json({ ok: true, updated: toUpdate.map(m => m.id) });
+  } catch (err) {
+    console.error('bulk-read error:', err);
+    res.status(500).json({ error: 'Failed to update messages' });
+  }
+});
+
 // Bulk delete (move to trash)
 router.post('/messages/bulk-delete', async (req, res) => {
   const { ids } = req.body;

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -1,0 +1,171 @@
+import { query } from './db.js';
+
+export async function listMessages({ userId, accountId, folder = 'INBOX', limit = 50, offset = 0, unreadOnly, threaded }) {
+  const accountsResult = await query(
+    'SELECT id FROM email_accounts WHERE user_id = $1 AND enabled = true',
+    [userId]
+  );
+  const userAccountIds = accountsResult.rows.map(r => r.id);
+  if (!userAccountIds.length) return { messages: [], total: 0 };
+
+  let whereConditions = ['m.is_deleted = false'];
+  const values = [];
+  let p = 1;
+
+  const isSpecificAccount = accountId && userAccountIds.includes(accountId);
+
+  if (isSpecificAccount) {
+    whereConditions.push(`m.account_id = $${p++}`);
+    values.push(accountId);
+    whereConditions.push(`m.folder = $${p++}`);
+    values.push(folder);
+  } else {
+    whereConditions.push(`m.account_id = ANY($${p++})`);
+    values.push(userAccountIds);
+    whereConditions.push(`m.folder = 'INBOX'`);
+  }
+
+  const isUnreadOnly = unreadOnly === 'true' || unreadOnly === true;
+  if (isUnreadOnly) whereConditions.push('m.is_read = false');
+
+  const where = whereConditions.join(' AND ');
+
+  const safeLimit  = Math.min(Math.max(parseInt(limit)  || 50, 1), 500);
+  const safeOffset = Math.max(parseInt(offset) || 0, 0);
+
+  let total = 0;
+  try {
+    if (isSpecificAccount) {
+      const r = await query(
+        'SELECT total_count, unread_count FROM folders WHERE account_id = $1 AND path = $2',
+        [accountId, folder]
+      );
+      if (r.rows.length) {
+        total = isUnreadOnly ? (r.rows[0].unread_count ?? 0) : (r.rows[0].total_count ?? 0);
+      }
+    } else {
+      const r = isUnreadOnly
+        ? await query(
+            "SELECT COALESCE(SUM(unread_count), 0)::int AS n FROM folders WHERE account_id = ANY($1) AND path = 'INBOX'",
+            [userAccountIds]
+          )
+        : await query(
+            "SELECT COALESCE(SUM(total_count), 0)::int AS n FROM folders WHERE account_id = ANY($1) AND path = 'INBOX'",
+            [userAccountIds]
+          );
+      total = r.rows[0]?.n ?? 0;
+    }
+  } catch (_) {
+    total = 0;
+  }
+
+  if (threaded === 'true' || threaded === true) {
+    const filterValues = [...values];
+    const threadAccountParam = isSpecificAccount ? [accountId] : userAccountIds;
+    // For INBOX-specific views the thread badge must match the expansion, so scope
+    // thread_totals to that folder. For other folders (All Mail, Sent, etc.) count
+    // across all folders so the badge reflects the true thread size.
+    const threadFolderFilter = isSpecificAccount
+      ? (folder === 'INBOX' ? `AND folder = $2` : '')
+      : `AND folder = 'INBOX'`;
+
+    const threadResult = await query(`
+      WITH paged_threads AS (
+        SELECT m.thread_key AS thread_id
+        FROM messages m
+        WHERE ${where}
+        GROUP BY m.thread_key
+        ORDER BY MAX(m.date) DESC
+        LIMIT $${p + 1} OFFSET $${p + 2}
+      ),
+      deduped AS MATERIALIZED (
+        SELECT DISTINCT ON (m.account_id, m.thread_key, m.message_id)
+               m.id, m.uid, m.folder, m.message_id,
+               m.thread_key AS thread_id,
+               m.subject, m.from_name, m.from_email,
+               m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
+               m.date, m.snippet, m.is_read, m.is_starred,
+               m.has_attachments, m.account_id,
+               a.name  AS account_name,
+               a.email_address AS account_email,
+               a.color AS account_color
+        FROM messages m
+        JOIN email_accounts a ON m.account_id = a.id
+        WHERE ${where}
+          AND m.thread_key IN (SELECT thread_id FROM paged_threads)
+        ORDER BY m.account_id,
+                 m.thread_key,
+                 m.message_id,
+                 CASE WHEN m.folder = 'INBOX' THEN 0 ELSE 1 END,
+                 m.date ASC
+      ),
+      thread_totals AS (
+        SELECT m.thread_key AS thread_id,
+               COUNT(DISTINCT m.message_id)::int AS message_count
+        FROM messages m
+        WHERE m.account_id = ANY($${p})
+          AND m.is_deleted = false
+          AND m.message_id IS NOT NULL
+          ${threadFolderFilter}
+          AND m.thread_key IN (SELECT thread_id FROM paged_threads)
+        GROUP BY m.thread_key
+      ),
+      ranked AS (
+        SELECT d.*,
+               COALESCE(tt.message_count, 1) AS message_count,
+               COUNT(*) FILTER (WHERE NOT d.is_read) OVER (PARTITION BY d.thread_id)::int AS unread_count,
+               FIRST_VALUE(d.subject)    OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_subject,
+               FIRST_VALUE(d.from_name)  OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_from_name,
+               FIRST_VALUE(d.from_email) OVER (PARTITION BY d.thread_id ORDER BY d.date ASC) AS thread_from_email,
+               ROW_NUMBER() OVER (PARTITION BY d.thread_id ORDER BY d.date DESC) AS rn
+        FROM deduped d
+        LEFT JOIN thread_totals tt ON tt.thread_id = d.thread_id
+      )
+      SELECT id, uid, folder, message_id, thread_id, thread_subject AS subject,
+             thread_from_name AS from_name, thread_from_email AS from_email,
+             to_addresses, cc_addresses, reply_to, in_reply_to,
+             date, snippet, is_starred, is_read, has_attachments, account_id,
+             account_name, account_email, account_color,
+             message_count, unread_count
+      FROM ranked
+      WHERE rn = 1
+      ORDER BY date DESC
+    `, [...filterValues, threadAccountParam, safeLimit, safeOffset]);
+
+    const threadCountResult = await query(`
+      SELECT COUNT(DISTINCT m.thread_key)::int AS total
+      FROM messages m
+      WHERE ${where}
+    `, filterValues);
+
+    return {
+      messages: threadResult.rows,
+      total: threadCountResult.rows[0]?.total ?? 0,
+      threaded: true,
+      resolvedAccountId: isSpecificAccount ? accountId : null,
+    };
+  }
+
+  const limitParam  = p;
+  const offsetParam = p + 1;
+  values.push(safeLimit, safeOffset);
+
+  const result = await query(`
+    SELECT m.id, m.uid, m.folder, m.message_id, m.subject, m.from_name, m.from_email,
+           m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
+           m.date, m.snippet, m.is_read, m.is_starred,
+           m.has_attachments, m.account_id,
+           a.name as account_name, a.email_address as account_email, a.color as account_color
+    FROM messages m
+    JOIN email_accounts a ON m.account_id = a.id
+    WHERE ${where}
+    ORDER BY m.date DESC
+    LIMIT $${limitParam} OFFSET $${offsetParam}
+  `, values);
+
+  return {
+    messages: result.rows,
+    total,
+    resolvedAccountId: isSpecificAccount ? accountId : null,
+  };
+}

--- a/backend/src/services/messageService.test.js
+++ b/backend/src/services/messageService.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./db.js', () => ({ query: vi.fn() }));
+
+const { query } = await import('./db.js');
+import { listMessages } from './messageService.js';
+
+beforeEach(() => {
+  query.mockClear();
+});
+
+describe('listMessages — account scope', () => {
+  it('returns empty result immediately when user has no enabled accounts', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await listMessages({ userId: 'user-1' });
+
+    expect(result).toEqual({ messages: [], total: 0 });
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to unified inbox when accountId is not owned by the user', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })           // accounts
+      .mockResolvedValueOnce({ rows: [{ n: 5 }] })                  // folder count
+      .mockResolvedValueOnce({ rows: [{ id: 'msg-1', folder: 'INBOX' }] }); // messages
+
+    const result = await listMessages({ userId: 'user-1', accountId: 'acc-other' });
+
+    // Unified inbox returns the cached total from the folder sum query
+    expect(result.total).toBe(5);
+    expect(result.resolvedAccountId).toBeNull();
+
+    // The folder count query should have used total_count (not unread_count)
+    const countSql = query.mock.calls[1][0];
+    expect(countSql).toContain('total_count');
+    expect(countSql).not.toContain('unread_count');
+  });
+});
+
+describe('listMessages — total count selection', () => {
+  it('sums unread_count across accounts for unified inbox when unreadOnly=true', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }, { id: 'acc-2' }] }) // accounts
+      .mockResolvedValueOnce({ rows: [{ n: 7 }] })                          // folder count
+      .mockResolvedValueOnce({ rows: [] });                                  // messages
+
+    const result = await listMessages({ userId: 'user-1', unreadOnly: 'true' });
+
+    expect(result.total).toBe(7);
+
+    const countSql = query.mock.calls[1][0];
+    expect(countSql).toContain('unread_count');
+    expect(countSql).not.toContain('total_count');
+  });
+
+  it('sums total_count across accounts for unified inbox when unreadOnly is not set', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }, { id: 'acc-2' }] }) // accounts
+      .mockResolvedValueOnce({ rows: [{ n: 42 }] })                         // folder count
+      .mockResolvedValueOnce({ rows: [] });                                  // messages
+
+    const result = await listMessages({ userId: 'user-1' });
+
+    expect(result.total).toBe(42);
+
+    const countSql = query.mock.calls[1][0];
+    expect(countSql).toContain('total_count');
+    expect(countSql).not.toContain('unread_count');
+  });
+
+  it('reads unread_count from folder row for specific account when unreadOnly=true', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })                       // accounts
+      .mockResolvedValueOnce({ rows: [{ total_count: 100, unread_count: 3 }] })  // folder row
+      .mockResolvedValueOnce({ rows: [] });                                        // messages
+
+    const result = await listMessages({ userId: 'user-1', accountId: 'acc-1', unreadOnly: 'true' });
+
+    expect(result.total).toBe(3);
+    expect(result.resolvedAccountId).toBe('acc-1');
+  });
+
+  it('reads total_count from folder row for specific account when unreadOnly is not set', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })                       // accounts
+      .mockResolvedValueOnce({ rows: [{ total_count: 100, unread_count: 3 }] })  // folder row
+      .mockResolvedValueOnce({ rows: [] });                                        // messages
+
+    const result = await listMessages({ userId: 'user-1', accountId: 'acc-1' });
+
+    expect(result.total).toBe(100);
+  });
+});

--- a/backend/src/services/messageService.test.js
+++ b/backend/src/services/messageService.test.js
@@ -92,3 +92,61 @@ describe('listMessages — total count selection', () => {
     expect(result.total).toBe(100);
   });
 });
+
+// Threaded mode: 4 query calls — accounts, folder cache, thread CTE, thread count
+describe('listMessages — threaded mode', () => {
+  it('returns thread count as total, ignoring the cached folder count', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })                       // accounts
+      .mockResolvedValueOnce({ rows: [{ total_count: 99, unread_count: 2 }] })  // folder cache (not used)
+      .mockResolvedValueOnce({ rows: [{ id: 'msg-1' }] })                       // thread CTE
+      .mockResolvedValueOnce({ rows: [{ total: 5 }] });                          // thread count
+
+    const result = await listMessages({ userId: 'user-1', accountId: 'acc-1', threaded: 'true' });
+
+    expect(result.total).toBe(5);
+    expect(result.threaded).toBe(true);
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it('scopes thread_totals to INBOX when viewing a specific account INBOX', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })
+      .mockResolvedValueOnce({ rows: [{ total_count: 10, unread_count: 0 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1', folder: 'INBOX', threaded: 'true' });
+
+    const cteSql = query.mock.calls[2][0];
+    expect(cteSql).toContain('AND folder = $2');
+  });
+
+  it('counts thread messages across all folders when viewing a non-INBOX folder', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })
+      .mockResolvedValueOnce({ rows: [{ total_count: 10, unread_count: 0 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1', folder: 'Sent', threaded: 'true' });
+
+    // thread_totals must not be scoped to a specific folder so the badge reflects true thread size
+    const cteSql = query.mock.calls[2][0];
+    expect(cteSql).not.toContain('AND folder = $2');
+    expect(cteSql).not.toContain("AND folder = 'INBOX'");
+  });
+
+  it('scopes thread_totals to INBOX for unified inbox threaded view', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }, { id: 'acc-2' }] })
+      .mockResolvedValueOnce({ rows: [{ n: 20 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+
+    await listMessages({ userId: 'user-1', threaded: 'true' });
+
+    const cteSql = query.mock.calls[2][0];
+    expect(cteSql).toContain("AND folder = 'INBOX'");
+  });
+});

--- a/backend/src/utils/mailUtils.js
+++ b/backend/src/utils/mailUtils.js
@@ -15,6 +15,18 @@ export async function resolveTrashFolder(accountId, folderMappings) {
   return result.rows[0]?.path || null;
 }
 
+export async function resolveArchiveFolder(accountId, folderMappings) {
+  if (folderMappings?.archive) return folderMappings.archive;
+  const result = await query(
+    `SELECT path FROM folders WHERE account_id = $1
+     AND (special_use = '\\Archive' OR lower(name) LIKE '%archive%')
+     ORDER BY (CASE WHEN special_use = '\\Archive' THEN 0 ELSE 1 END)
+     LIMIT 1`,
+    [accountId]
+  );
+  return result.rows[0]?.path || null;
+}
+
 // Determine what action to take when deleting a message.
 // Returns { action: 'move', destination } | { action: 'expunge' } | { action: 'no_trash' }.
 // 'no_trash' must be treated as a safe failure — never permanently delete when

--- a/backend/src/utils/mailUtils.test.js
+++ b/backend/src/utils/mailUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { resolveTrashFolder, getDeleteStrategy } from './mailUtils.js';
+import { resolveTrashFolder, resolveArchiveFolder, getDeleteStrategy } from './mailUtils.js';
 
 vi.mock('../services/db.js', () => ({
   query: vi.fn(),
@@ -35,6 +35,40 @@ describe('resolveTrashFolder', () => {
     query.mockResolvedValue({ rows: [] });
     const result = await resolveTrashFolder(3, undefined);
     expect(result).toBeNull();
+  });
+});
+
+describe('resolveArchiveFolder', () => {
+  it('returns folder_mappings.archive immediately without querying the DB', async () => {
+    const result = await resolveArchiveFolder(1, { archive: 'INBOX.Archive' });
+    expect(result).toBe('INBOX.Archive');
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('falls back to special_use=\\Archive folder when no mapping is set', async () => {
+    query.mockResolvedValue({ rows: [{ path: 'Archive' }] });
+    const result = await resolveArchiveFolder(1, null);
+    expect(result).toBe('Archive');
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to name heuristic when no special_use match exists', async () => {
+    query.mockResolvedValue({ rows: [{ path: 'INBOX.archive-2024' }] });
+    const result = await resolveArchiveFolder(2, {});
+    expect(result).toBe('INBOX.archive-2024');
+  });
+
+  it('returns null when no archive folder is found', async () => {
+    query.mockResolvedValue({ rows: [] });
+    const result = await resolveArchiveFolder(3, undefined);
+    expect(result).toBeNull();
+  });
+
+  it('uses ORDER BY to prefer special_use match over name heuristic', async () => {
+    query.mockResolvedValue({ rows: [] });
+    await resolveArchiveFolder(1, null);
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain("CASE WHEN special_use = '\\Archive' THEN 0 ELSE 1 END");
   });
 });
 

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -544,7 +544,7 @@ export default function MessageList() {
     }
 
     try {
-      await Promise.all(actionMessages.map(msg => api.markRead(msg.id, read)));
+      await api.bulkRead(actionMessages.map(msg => msg.id), read);
       if (read) {
         actionMessages.forEach(msg => {
           pendingMarkReadMap.delete(msg.id);
@@ -1079,7 +1079,7 @@ export default function MessageList() {
       if (newRead) {
         decrementUnread(msg.account_id);
         setPending(selectedMessageId, msg.account_id);
-        api.markRead(selectedMessageId, true)
+        api.bulkRead([selectedMessageId], true)
           .then(() => {
             pendingMarkReadMap.delete(selectedMessageId);
             completedMarkReadMap.set(selectedMessageId, msg.account_id);
@@ -1093,7 +1093,7 @@ export default function MessageList() {
         incrementUnread(msg.account_id);
         pendingMarkReadMap.delete(selectedMessageId);
         completedMarkReadMap.delete(selectedMessageId);
-        api.markRead(selectedMessageId, false).catch(console.error);
+        api.bulkRead([selectedMessageId], false).catch(console.error);
       }
     };
 
@@ -1328,7 +1328,7 @@ export default function MessageList() {
       updateMessage(message.id, { is_read: true });
       decrementUnread(message.account_id);
       setPending(message.id, message.account_id);
-      api.markRead(message.id, true)
+      api.bulkRead([message.id], true)
         .then(() => {
           pendingMarkReadMap.delete(message.id);
           completedMarkReadMap.set(message.id, message.account_id);

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -104,7 +104,7 @@ export const api = {
     const qs = folder ? `?folder=${encodeURIComponent(folder)}` : '';
     return request('GET', `/mail/thread/${encodeURIComponent(threadId)}${qs}`);
   },
-  markRead: (id, read) => request('PATCH', `/mail/messages/${id}/read`, { read }),
+  bulkRead: (ids, read) => request('POST', '/mail/messages/bulk-read', { ids, read }),
   markStarred: (id, starred) => request('PATCH', `/mail/messages/${id}/star`, { starred }),
   markAllRead: (accountId, folder) => request('POST', '/mail/mark-all-read', { accountId, folder }),
   deleteMessage: (id) => request('DELETE', `/mail/messages/${id}`),


### PR DESCRIPTION
## Summary

Implements the four items from issue #90.

Extracts the `GET /messages` query logic (threaded CTE + non-threaded) into `services/messageService.js` so it can be unit-tested in isolation. Adds `resolveArchiveFolder` to `mailUtils.js` — matching the shape of the existing `resolveTrashFolder` — and closes a correctness gap where a name-heuristic match could win over a `special_use = '\Archive'` folder due to missing `ORDER BY`. Fixes `bulk-archive` to use `runInBatches` with concurrency 3 for consistency with `bulk-delete` and `bulk-move`. Adds `POST /messages/bulk-read` and routes all mark-read calls through it, replacing N individual `PATCH` requests with a single round-trip.

## Changes

- `services/messageService.js` — new file, `listMessages()` extracted from route handler
- `services/messageService.test.js` — 11 tests covering non-threaded count branching, unowned-accountId fallback, and all four threaded-mode behaviours
- `utils/mailUtils.js` — `resolveArchiveFolder` added alongside `resolveTrashFolder`
- `utils/mailUtils.test.js` — 5 tests for `resolveArchiveFolder` including ORDER BY assertion
- `routes/mail.js` — `GET /messages` handler collapsed to ~15 lines; `bulk-archive` uses `resolveArchiveFolder` and `runInBatches`; new `POST /messages/bulk-read` endpoint
- `frontend/src/utils/api.js` — `api.markRead` replaced by `api.bulkRead`
- `frontend/src/components/MessageList.jsx` — all mark-read call sites use `api.bulkRead`

## Testing

Tested against a live instance. Message list, threaded view, and unread filter all behave identically to before. Mark-read on a single message and on a thread both fire a single `POST /mail/messages/bulk-read` confirmed in browser devtools. Archive correctly returns `noArchiveFolder` for accounts without a configured archive folder.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.