### PR TITLE
Fix touch swipe and pulldown competing

### DIFF
--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -139,7 +139,9 @@ export default function MessageList() {
   const [fabVisible, setFabVisible] = useState(true);
   const lastScrollTopRef = useRef(0);
   const [pullDistance, setPullDistance] = useState(0);
+  const pullStartXRef = useRef(null);
   const pullStartYRef = useRef(null);
+  const pullDirectionRef = useRef(null);
   const pullDistRef = useRef(0);
   const handleSyncRef = useRef(null);
   const [contextMenu, setContextMenu] = useState(null); // { x, y, message }
@@ -449,12 +451,21 @@ export default function MessageList() {
     const MAX_PULL = 80;
 
     const onTouchStart = (e) => {
-      if (el.scrollTop === 0) pullStartYRef.current = e.touches[0].clientY;
+      if (el.scrollTop !== 0) return;
+      pullStartXRef.current = e.touches[0].clientX;
+      pullStartYRef.current = e.touches[0].clientY;
+      pullDirectionRef.current = null;
     };
 
     const onTouchMove = (e) => {
       if (pullStartYRef.current === null) return;
+      const dx = e.touches[0].clientX - pullStartXRef.current;
       const delta = e.touches[0].clientY - pullStartYRef.current;
+      if (!pullDirectionRef.current) {
+        if (Math.abs(dx) < 6 && Math.abs(delta) < 6) return;
+        pullDirectionRef.current = Math.abs(dx) > Math.abs(delta) ? 'h' : 'v';
+      }
+      if (pullDirectionRef.current === 'h') return;
       if (delta > 0 && el.scrollTop === 0) {
         e.preventDefault();
         const d = Math.min(delta * 0.5, MAX_PULL);
@@ -467,22 +478,30 @@ export default function MessageList() {
       }
     };
 
+    const resetPull = () => {
+      pullStartXRef.current = null;
+      pullStartYRef.current = null;
+      pullDirectionRef.current = null;
+      pullDistRef.current = 0;
+      setPullDistance(0);
+    };
+
     const onTouchEnd = () => {
       if (pullStartYRef.current === null) return;
       const dist = pullDistRef.current;
-      pullStartYRef.current = null;
-      pullDistRef.current = 0;
-      setPullDistance(0);
+      resetPull();
       if (dist >= THRESHOLD) handleSyncRef.current?.();
     };
 
     el.addEventListener('touchstart', onTouchStart, { passive: true });
     el.addEventListener('touchmove', onTouchMove, { passive: false });
     el.addEventListener('touchend', onTouchEnd, { passive: true });
+    el.addEventListener('touchcancel', resetPull, { passive: true });
     return () => {
       el.removeEventListener('touchstart', onTouchStart);
       el.removeEventListener('touchmove', onTouchMove);
       el.removeEventListener('touchend', onTouchEnd);
+      el.removeEventListener('touchcancel', resetPull);
     };
   }, [isMobile]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/frontend/src/hooks/useSwipeRow.js
+++ b/frontend/src/hooks/useSwipeRow.js
@@ -8,14 +8,19 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
   const swipeBgRightRef = useRef(null);
   const swipeRef = useRef({ active: false, startX: 0, startY: 0, dir: null, x: 0 });
   const longPressTimerRef = useRef(null);
+  const springBackTimerRef = useRef(null);
+  const latestRef = useRef({});
+  latestRef.current = { message, onSwipeLeft, onSwipeRight, onLongPress };
 
   const springBack = useCallback(() => {
     const el = contentRef.current;
     if (!el) return;
+    if (springBackTimerRef.current) clearTimeout(springBackTimerRef.current);
     el.style.transition = 'transform 0.25s cubic-bezier(0.25,0.46,0.45,0.94)';
     el.style.transform = 'translateX(0)';
     el.style.boxShadow = '';
-    setTimeout(() => {
+    springBackTimerRef.current = setTimeout(() => {
+      springBackTimerRef.current = null;
       if (swipeBgLeftRef.current)  { swipeBgLeftRef.current.style.display = 'none'; swipeBgLeftRef.current.style.opacity = '1'; }
       if (swipeBgRightRef.current) { swipeBgRightRef.current.style.display = 'none'; swipeBgRightRef.current.style.opacity = '1'; }
     }, 260);
@@ -43,13 +48,17 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
 
     const onStart = (e) => {
       const t = e.touches[0];
+      if (springBackTimerRef.current) {
+        clearTimeout(springBackTimerRef.current);
+        springBackTimerRef.current = null;
+      }
       swipeRef.current = { active: false, startX: t.clientX, startY: t.clientY, dir: null, x: 0 };
       showBgs();
-      if (onLongPress) {
+      if (latestRef.current.onLongPress) {
         longPressTimerRef.current = setTimeout(() => {
           longPressTimerRef.current = null;
           springBack();
-          onLongPress(message.id);
+          latestRef.current.onLongPress?.(latestRef.current.message.id);
         }, 500);
       }
     };
@@ -65,7 +74,7 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
         s.dir = Math.abs(dx) > Math.abs(dy) ? 'h' : 'v';
       }
       if (s.dir === 'v') return;
-      if ((dx < 0 && !onSwipeLeft) || (dx > 0 && !onSwipeRight)) return;
+      if ((dx < 0 && !latestRef.current.onSwipeLeft) || (dx > 0 && !latestRef.current.onSwipeRight)) return;
       e.preventDefault();
       s.active = true;
       s.x = Math.max(-160, Math.min(160, dx));
@@ -93,9 +102,9 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
       s.active = false; s.dir = null; s.x = 0;
       springBack();
       if (x < -SWIPE_THRESHOLD) {
-        onSwipeLeft && onSwipeLeft(message);
+        latestRef.current.onSwipeLeft?.(latestRef.current.message);
       } else if (x > SWIPE_THRESHOLD) {
-        onSwipeRight && onSwipeRight(message);
+        latestRef.current.onSwipeRight?.(latestRef.current.message);
       }
     };
 
@@ -111,6 +120,10 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
     el.addEventListener('touchcancel', onCancel, { passive: true });
     return () => {
       cancelLongPress();
+      if (springBackTimerRef.current) {
+        clearTimeout(springBackTimerRef.current);
+        springBackTimerRef.current = null;
+      }
       el.removeEventListener('touchstart', onStart);
       el.removeEventListener('touchmove', onMove);
       el.removeEventListener('touchend', onEnd);
@@ -122,7 +135,7 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
       if (swipeBgLeftRef.current)  swipeBgLeftRef.current.style.display = 'none';
       if (swipeBgRightRef.current) swipeBgRightRef.current.style.display = 'none';
     };
-  }, [isMobile, message, onSwipeLeft, onSwipeRight, onLongPress, springBack]);
+  }, [isMobile, springBack]);
 
   return { contentRef, swipeBgLeftRef, swipeBgRightRef, springBack };
 }


### PR DESCRIPTION
## Summary

Fix touch swipe and pull-down interactions competing with each other.

## Changes

- Improved touch gesture handling (swipes were flashing and flickering)
- Prevent swipe and pull-down conflicts

## Testing

- Tested locally on touch devices
- Verified swipe and pull-down behaviour

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
