### PR TITLE
fix: strip <style> tags from quoted HTML to prevent CSS leaking into app UI

### DIFF
--- a/frontend/src/components/ComposeModal.jsx
+++ b/frontend/src/components/ComposeModal.jsx
@@ -335,7 +335,9 @@ export default function ComposeModal() {
   // Initialise quoted HTML contentEditable once on mount (ref-based to avoid React cursor conflicts)
   useEffect(() => {
     if (quotedHtmlRef.current && quotedBodyHtml) {
-      quotedHtmlRef.current.innerHTML = DOMPurify.sanitize(quotedBodyHtml);
+      // FORBID_TAGS: strip <style> blocks — marketing emails use global rules like
+      // "div { margin: 0 !important }" that leak out of contentEditable into the app UI.
+      quotedHtmlRef.current.innerHTML = DOMPurify.sanitize(quotedBodyHtml, { FORBID_TAGS: ['style'] });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
Closes #141

## Summary

When replying to or forwarding a marketing email that contains a `<style>` block with global rules (e.g. `div { margin: 0 !important }`), those styles bleed out of the quoted-body `contentEditable` and break the compose UI layout.

This PR strips `<style>` tags via `DOMPurify.sanitize(..., { FORBID_TAGS: ['style'] })` before injecting the quoted HTML into the `contentEditable`. It fixes the immediate problem.

That said, I'm not sure this is the ideal long-term solution. The root cause is that `contentEditable` doesn't scope styles — anything injected affects the whole document. A sandboxed `<iframe>` for the quoted body would be a more robust fix, but I wanted to get something in for the bug first and flag it for discussion.

## Changes

- `frontend/src/components/ComposeModal.jsx`: pass `{ FORBID_TAGS: ['style'] }` to `DOMPurify.sanitize()` on the quoted body HTML

## Testing

- Forwarded/replied to a marketing email with aggressive global `<style>` rules
- Confirmed compose modal layout is no longer broken
- Confirmed quoted content still renders correctly (only `<style>` blocks are stripped, not inline `style` attributes)

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.