### PR TITLE
fix: show sent replies in conversation threads and live-update on send

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -142,12 +142,16 @@ router.get('/thread/:threadId', async (req, res) => {
     const userAccountIds = accountsResult.rows.map(r => r.id);
     if (!userAccountIds.length) return res.json({ messages: [] });
 
-    // Only restrict expansion to INBOX when viewing the INBOX — ensures the expansion
-    // matches what the list shows. For All Mail and any other folder show all messages
-    // regardless of which folder they were synced under (All Mail backfill is skipped so
-    // not every message has a [Gmail]/All Mail row in the DB).
-    const folderFilter = (folder === 'INBOX') ? `AND m.folder = $3` : '';
-    const params = (folder === 'INBOX') ? [userAccountIds, threadId, folder] : [userAccountIds, threadId];
+    const accountsWithMappings = await query(
+      'SELECT id, folder_mappings FROM email_accounts WHERE id = ANY($1)',
+      [userAccountIds]
+    );
+    const excludedPaths = (await Promise.all(
+      accountsWithMappings.rows.flatMap(a => [
+        resolveTrashFolder(a.id, a.folder_mappings),
+        resolveArchiveFolder(a.id, a.folder_mappings),
+      ])
+    )).filter(Boolean);
 
     const result = await query(`
       WITH deduped AS (
@@ -163,13 +167,13 @@ router.get('/thread/:threadId', async (req, res) => {
         WHERE m.is_deleted = false
           AND m.account_id = ANY($1)
           AND m.thread_key = $2
-          ${folderFilter}
+          AND m.folder != ALL($3::text[])
         ORDER BY m.message_id,
                  CASE WHEN m.folder = 'INBOX' THEN 0 ELSE 1 END,
                  m.date ASC
       )
       SELECT * FROM deduped ORDER BY date ASC
-    `, params);
+    `, [userAccountIds, threadId, excludedPaths]);
 
     res.json({ messages: result.rows });
   } catch (err) {

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -1116,6 +1116,7 @@ export class ImapManager {
         const maxKnownUid = Number(max_uid);
 
         let newMessages = [];
+        const allNewlyInserted = [];
 
         // Insert/update a single fetched message and track it as new if appropriate.
         // Called from both Phase 1 and Phase 2; ON CONFLICT handles deduplication so
@@ -1200,8 +1201,10 @@ export class ImapManager {
               sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(atts || []),
               refs, threadId,
             ]);
-            if (result.rows[0]?.is_new && !parsed.isRead) {
-              newMessages.push({ ...parsed, id: result.rows[0].id, accountId: account.id, folder });
+            if (result.rows[0]?.is_new) {
+              const entry = { ...parsed, id: result.rows[0].id, accountId: account.id, folder };
+              allNewlyInserted.push(entry);
+              if (!parsed.isRead) newMessages.push(entry);
             }
             // Propagate resolved thread_id to any earlier messages that used this
             // message as a provisional thread root (out-of-order delivery / sync).
@@ -1293,16 +1296,18 @@ export class ImapManager {
                 .catch(err => console.warn('Push notification error:', err.message));
             });
           }
-          // Pre-warm the body cache for newly arrived messages so clicking one
-          // immediately after receipt doesn't require a live IMAP fetch.
-          // Only do this for small batches (periodic new mail, not initial bulk sync).
-          if (newMessages.length <= 5) {
-            const msgsToCache = newMessages.slice();
-            setImmediate(() => {
-              this.prefetchNewMessageBodies(account, msgsToCache)
-                .catch(err => console.warn(`Body prefetch error for ${logAccount(account)}:`, err.message));
-            });
-          }
+        }
+        // Pre-warm the body cache for newly arrived messages so clicking one
+        // immediately after receipt doesn't require a live IMAP fetch.
+        // Covers read messages too (e.g. user's own sent mail), so their snippets
+        // populate for thread previews. Only fires for small batches to avoid
+        // hammering IMAP during initial bulk sync.
+        if (allNewlyInserted.length > 0 && allNewlyInserted.length <= 5) {
+          const msgsToCache = allNewlyInserted.slice();
+          setImmediate(() => {
+            this.prefetchNewMessageBodies(account, msgsToCache)
+              .catch(err => console.warn(`Body prefetch error for ${logAccount(account)}:`, err.message));
+          });
         }
         await query('UPDATE email_accounts SET last_sync = NOW() WHERE id = $1', [account.id]);
       } finally {
@@ -1911,6 +1916,7 @@ export class ImapManager {
   // By the time the user clicks the email (typically 2–10s later), the body is already
   // in the DB and the click returns instantly without a live IMAP round-trip.
   async prefetchNewMessageBodies(account, messages) {
+    let anySnippetUpdated = false;
     for (const msg of messages) {
       try {
         // Skip if body already cached (concurrent click may have triggered this too)
@@ -1941,10 +1947,16 @@ export class ImapManager {
              WHERE id = $4`,
             [sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(attachments || []), msg.id, sanitizeStr(snip)]
           );
+          if (snip) anySnippetUpdated = true;
         }
       } catch (err) {
         console.warn(`Body prefetch failed for uid ${msg.uid}:`, err.message);
       }
+    }
+    // Tell the frontend to re-pull snippets so newly synced messages no longer
+    // appear blank in thread previews.
+    if (anySnippetUpdated) {
+      this.broadcast({ type: 'sync_complete', accountId: account.id }, account.user_id);
     }
   }
 

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -1,4 +1,5 @@
 import { query } from './db.js';
+import { resolveTrashFolder, resolveArchiveFolder } from '../utils/mailUtils.js';
 
 export async function listMessages({ userId, accountId, folder = 'INBOX', limit = 50, offset = 0, unreadOnly, threaded }) {
   const accountsResult = await query(
@@ -62,12 +63,17 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
   if (threaded === 'true' || threaded === true) {
     const filterValues = [...values];
     const threadAccountParam = isSpecificAccount ? [accountId] : userAccountIds;
-    // For INBOX-specific views the thread badge must match the expansion, so scope
-    // thread_totals to that folder. For other folders (All Mail, Sent, etc.) count
-    // across all folders so the badge reflects the true thread size.
-    const threadFolderFilter = isSpecificAccount
-      ? (folder === 'INBOX' ? `AND folder = $2` : '')
-      : `AND folder = 'INBOX'`;
+
+    const accountsWithMappings = await query(
+      'SELECT id, folder_mappings FROM email_accounts WHERE id = ANY($1)',
+      [threadAccountParam]
+    );
+    const excludedPaths = (await Promise.all(
+      accountsWithMappings.rows.flatMap(a => [
+        resolveTrashFolder(a.id, a.folder_mappings),
+        resolveArchiveFolder(a.id, a.folder_mappings),
+      ])
+    )).filter(Boolean);
 
     const threadResult = await query(`
       WITH paged_threads AS (
@@ -106,7 +112,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
         WHERE m.account_id = ANY($${p})
           AND m.is_deleted = false
           AND m.message_id IS NOT NULL
-          ${threadFolderFilter}
+          AND m.folder != ALL($${p + 3}::text[])
           AND m.thread_key IN (SELECT thread_id FROM paged_threads)
         GROUP BY m.thread_key
       ),
@@ -130,7 +136,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
       FROM ranked
       WHERE rn = 1
       ORDER BY date DESC
-    `, [...filterValues, threadAccountParam, safeLimit, safeOffset]);
+    `, [...filterValues, threadAccountParam, safeLimit, safeOffset, excludedPaths]);
 
     const threadCountResult = await query(`
       SELECT COUNT(DISTINCT m.thread_key)::int AS total

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -97,7 +97,9 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
                a.color AS account_color
         FROM messages m
         JOIN email_accounts a ON m.account_id = a.id
-        WHERE ${where}
+        WHERE m.is_deleted = false
+          AND m.account_id = ANY($${p})
+          AND m.folder != ALL($${p + 3}::text[])
           AND m.thread_key IN (SELECT thread_id FROM paged_threads)
         ORDER BY m.account_id,
                  m.thread_key,

--- a/backend/src/services/messageService.test.js
+++ b/backend/src/services/messageService.test.js
@@ -1,13 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./db.js', () => ({ query: vi.fn() }));
+vi.mock('../utils/mailUtils.js', () => ({
+  resolveTrashFolder: vi.fn(),
+  resolveArchiveFolder: vi.fn(),
+}));
 
 const { query } = await import('./db.js');
+const { resolveTrashFolder, resolveArchiveFolder } = await import('../utils/mailUtils.js');
 import { listMessages } from './messageService.js';
 
 beforeEach(() => {
   query.mockClear();
+  resolveTrashFolder.mockClear();
+  resolveArchiveFolder.mockClear();
+  resolveTrashFolder.mockResolvedValue(null);
+  resolveArchiveFolder.mockResolvedValue(null);
 });
+
+// Threaded mode query call order:
+//   0: accounts
+//   1: folder cache
+//   2: accountsWithMappings
+//   3+: resolveTrashFolder / resolveArchiveFolder (via Promise.all, not query calls)
+//   next: thread CTE
+//   last: thread count
+
+function mockThreadedQueries({ accounts = [{ id: 'acc-1' }], folderCache = { total_count: 10, unread_count: 0 }, threadRows = [], threadTotal = 0 } = {}) {
+  query
+    .mockResolvedValueOnce({ rows: accounts })
+    .mockResolvedValueOnce({ rows: [folderCache] })
+    .mockResolvedValueOnce({ rows: accounts.map(a => ({ id: a.id, folder_mappings: {} })) })
+    .mockResolvedValueOnce({ rows: threadRows })
+    .mockResolvedValueOnce({ rows: [{ total: threadTotal }] });
+}
 
 describe('listMessages — account scope', () => {
   it('returns empty result immediately when user has no enabled accounts', async () => {
@@ -27,11 +53,9 @@ describe('listMessages — account scope', () => {
 
     const result = await listMessages({ userId: 'user-1', accountId: 'acc-other' });
 
-    // Unified inbox returns the cached total from the folder sum query
     expect(result.total).toBe(5);
     expect(result.resolvedAccountId).toBeNull();
 
-    // The folder count query should have used total_count (not unread_count)
     const countSql = query.mock.calls[1][0];
     expect(countSql).toContain('total_count');
     expect(countSql).not.toContain('unread_count');
@@ -93,14 +117,9 @@ describe('listMessages — total count selection', () => {
   });
 });
 
-// Threaded mode: 4 query calls — accounts, folder cache, thread CTE, thread count
 describe('listMessages — threaded mode', () => {
   it('returns thread count as total, ignoring the cached folder count', async () => {
-    query
-      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })                       // accounts
-      .mockResolvedValueOnce({ rows: [{ total_count: 99, unread_count: 2 }] })  // folder cache (not used)
-      .mockResolvedValueOnce({ rows: [{ id: 'msg-1' }] })                       // thread CTE
-      .mockResolvedValueOnce({ rows: [{ total: 5 }] });                          // thread count
+    mockThreadedQueries({ threadRows: [{ id: 'msg-1' }], threadTotal: 5 });
 
     const result = await listMessages({ userId: 'user-1', accountId: 'acc-1', threaded: 'true' });
 
@@ -109,44 +128,74 @@ describe('listMessages — threaded mode', () => {
     expect(result.messages).toHaveLength(1);
   });
 
-  it('scopes thread_totals to INBOX when viewing a specific account INBOX', async () => {
-    query
-      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })
-      .mockResolvedValueOnce({ rows: [{ total_count: 10, unread_count: 0 }] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+  it('excludes trash and archive paths from thread_totals', async () => {
+    resolveTrashFolder.mockResolvedValue('[Gmail]/Bin');
+    resolveArchiveFolder.mockResolvedValue(null);
+    mockThreadedQueries();
 
     await listMessages({ userId: 'user-1', accountId: 'acc-1', folder: 'INBOX', threaded: 'true' });
 
-    const cteSql = query.mock.calls[2][0];
-    expect(cteSql).toContain('AND folder = $2');
+    const cteSql = query.mock.calls[3][0];
+    expect(cteSql).toContain('folder != ALL(');
+    // excluded paths are passed as the last param
+    const cteParams = query.mock.calls[3][1];
+    expect(cteParams.at(-1)).toContain('[Gmail]/Bin');
   });
 
-  it('counts thread messages across all folders when viewing a non-INBOX folder', async () => {
-    query
-      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })
-      .mockResolvedValueOnce({ rows: [{ total_count: 10, unread_count: 0 }] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+  it('passes empty excluded paths when no trash or archive folder exists', async () => {
+    resolveTrashFolder.mockResolvedValue(null);
+    resolveArchiveFolder.mockResolvedValue(null);
+    mockThreadedQueries();
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1', folder: 'INBOX', threaded: 'true' });
+
+    const cteParams = query.mock.calls[3][1];
+    expect(cteParams.at(-1)).toEqual([]);
+  });
+
+  it('excludes both trash and archive when both exist', async () => {
+    resolveTrashFolder.mockResolvedValue('Trash');
+    resolveArchiveFolder.mockResolvedValue('Archive');
+    mockThreadedQueries();
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1', folder: 'INBOX', threaded: 'true' });
+
+    const cteParams = query.mock.calls[3][1];
+    expect(cteParams.at(-1)).toEqual(expect.arrayContaining(['Trash', 'Archive']));
+  });
+
+  it('counts thread messages across all non-excluded folders', async () => {
+    mockThreadedQueries();
 
     await listMessages({ userId: 'user-1', accountId: 'acc-1', folder: 'Sent', threaded: 'true' });
 
-    // thread_totals must not be scoped to a specific folder so the badge reflects true thread size
-    const cteSql = query.mock.calls[2][0];
-    expect(cteSql).not.toContain('AND folder = $2');
+    const cteSql = query.mock.calls[3][0];
+    expect(cteSql).toContain('folder != ALL(');
     expect(cteSql).not.toContain("AND folder = 'INBOX'");
   });
 
-  it('scopes thread_totals to INBOX for unified inbox threaded view', async () => {
+  it('does not scope thread_totals to INBOX when viewing a specific account INBOX', async () => {
+    mockThreadedQueries();
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1', folder: 'INBOX', threaded: 'true' });
+
+    const cteSql = query.mock.calls[3][0];
+    expect(cteSql).not.toContain('AND folder = $2');
+    expect(cteSql).toContain('folder != ALL(');
+  });
+
+  it('does not scope thread_totals to INBOX for unified inbox', async () => {
     query
       .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }, { id: 'acc-2' }] })
       .mockResolvedValueOnce({ rows: [{ n: 20 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1', folder_mappings: {} }, { id: 'acc-2', folder_mappings: {} }] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ total: 0 }] });
 
     await listMessages({ userId: 'user-1', threaded: 'true' });
 
-    const cteSql = query.mock.calls[2][0];
-    expect(cteSql).toContain("AND folder = 'INBOX'");
+    const cteSql = query.mock.calls[3][0];
+    expect(cteSql).not.toContain("AND folder = 'INBOX'");
+    expect(cteSql).toContain('folder != ALL(');
   });
 });

--- a/frontend/src/components/ComposeModal.jsx
+++ b/frontend/src/components/ComposeModal.jsx
@@ -596,6 +596,9 @@ export default function ComposeModal() {
       if (draftUid != null && draftFolder != null && draftAccountId) {
         api.deleteDraft(draftAccountId, draftUid, draftFolder).catch(() => {});
       }
+      if (composeData?.threadKey) {
+        window.dispatchEvent(new CustomEvent('mailflow:reply-sent', { detail: { threadKey: composeData.threadKey } }));
+      }
       const sentFolder = accounts.find(a => a.id === accountId)?.folder_mappings?.sent || 'Sent';
       addNotification({
         title: t('compose.sent.title'),

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -130,6 +130,42 @@ export default function MessageList() {
     });
   }, []);
 
+  const pendingRepliedThreadRef = useRef(null);
+
+  // Fetch a thread from the server and merge it into threadMessages without
+  // disturbing existing message references — preserves the open message body
+  // and only fills in new messages and previously-empty snippets.
+  const mergeServerThread = useCallback(async (threadKey, folder, isReplied) => {
+    try {
+      const d = await api.getThread(threadKey, folder);
+      if (!d.messages) return;
+      const existing = useStore.getState().threadMessages[threadKey] || [];
+      const existingMap = new Map(existing.map(m => [m.id, m]));
+      const newOnly = d.messages.filter(x => !existingMap.has(x.id));
+      // Backfill snippets that were empty on first fetch (body prefetch lags sync_complete)
+      let snippetFilled = false;
+      const merged = d.messages.map(fresh => {
+        const prev = existingMap.get(fresh.id);
+        if (!prev) return fresh;
+        if (!prev.snippet && fresh.snippet) {
+          snippetFilled = true;
+          return { ...prev, snippet: fresh.snippet };
+        }
+        return prev;
+      });
+      if (newOnly.length === 0 && !snippetFilled) return;
+      // Clear the reply ref only once the new message AND its snippet are both present
+      if (isReplied && newOnly.length > 0 && merged.every(m => m.snippet)) {
+        pendingRepliedThreadRef.current = null;
+      }
+      setThreadMessages(threadKey, merged);
+      // Auto-expand the replied thread if it was collapsed
+      if (isReplied && newOnly.length > 0 && useStore.getState().expandedThreadId !== threadKey) {
+        setExpandedThreadId(threadKey);
+      }
+    } catch { /* intentional */ }
+  }, [setThreadMessages, setExpandedThreadId]);
+
   const [unreadOnly, setUnreadOnly] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const currentPageRef = useRef(1);
@@ -323,12 +359,38 @@ export default function MessageList() {
               const kept = useStore.getState().messages.find(m => m.id === activeId);
               if (kept) msgs = [kept, ...msgs];
             }
+
+            // If a reply just promoted a new message to be the thread's "latest" in
+            // the list, the user's currently open message would drop out and the
+            // panel would empty. Stash it under threadMessages so MessagePane's
+            // fallback lookup keeps finding it.
+            const oldMessages = useStore.getState().messages;
+            if (activeId && !msgs.some(m => m.id === activeId)) {
+              const kept = oldMessages.find(m => m.id === activeId);
+              if (kept && kept.thread_id) {
+                const tm = useStore.getState().threadMessages[kept.thread_id] || [];
+                if (!tm.some(m => m.id === activeId)) {
+                  setThreadMessages(kept.thread_id, [...tm, kept]);
+                }
+              }
+            }
+
             setMessages(msgs);
             if (sm === 'paginated') {
               setHasMoreMessages(false);
             } else {
               setMessagesOffset(data.messages.length);
               setHasMoreMessages(data.messages.length < data.total);
+            }
+
+            // Refresh threads that need an update — the just-replied thread and the
+            // currently-expanded thread (in case a new message arrived in it).
+            if (state.threadedView) {
+              const repliedThreadKey = pendingRepliedThreadRef.current;
+              const expandedTid = useStore.getState().expandedThreadId;
+              const effectiveFolder = selectedAccountId ? selectedFolder : 'INBOX';
+              new Set([repliedThreadKey, expandedTid].filter(Boolean))
+                .forEach(tk => mergeServerThread(tk, effectiveFolder, tk === repliedThreadKey));
             }
           } catch { /* intentional */ }
         };
@@ -337,7 +399,17 @@ export default function MessageList() {
     };
     window.addEventListener('mailflow:refresh', handler);
     return () => window.removeEventListener('mailflow:refresh', handler);
-  }, [selectedAccountId, selectedFolder, unreadOnly, searchQuery, applyReadGuard, setHasMoreMessages, setMessages, setMessagesOffset, setMessagesTotal]);
+  }, [selectedAccountId, selectedFolder, unreadOnly, searchQuery, applyReadGuard, setHasMoreMessages, setMessages, setMessagesOffset, setMessagesTotal, setThreadMessages, mergeServerThread]);
+
+  // Store the replied thread key so the next mailflow:refresh (from sync_complete) can refresh it
+  useEffect(() => {
+    const handler = (e) => {
+      const { threadKey } = e.detail || {};
+      if (threadKey) pendingRepliedThreadRef.current = threadKey;
+    };
+    window.addEventListener('mailflow:reply-sent', handler);
+    return () => window.removeEventListener('mailflow:reply-sent', handler);
+  }, []);
 
   // Search
   const SEARCH_PAGE = 50;
@@ -901,6 +973,7 @@ export default function MessageList() {
       isReplyAll: replyAll,
       originalFrom: sender,
       allRecipients,
+      threadKey: message.thread_id,
     });
   }, [accounts, openCompose]);
   
@@ -1482,6 +1555,7 @@ export default function MessageList() {
           isReplyAll: replyAll,
           originalFrom: sender,
           allRecipients,
+          threadKey: message.thread_id,
         });
         break;
       }

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -586,6 +586,7 @@ export default function MessagePane() {
       isReplyAll: replyAll,
       originalFrom: sender,
       allRecipients,
+      threadKey: message.thread_id,
     });
   };
 


### PR DESCRIPTION
## Summary

Fixes #157.

This PR addresses two related gaps in the conversation view:

1. **Sent replies missing from the conversation** — thread expansion was filtering messages to the current folder, so a reply in the Sent folder never appeared alongside the inbox messages it was part of.

2. **Reply doesn't appear in the open thread until manual refresh** — after sending a reply, the count badge incremented but the new message wasn't added to the open expansion, and an open message body would close as the list refreshed.

### How the fix works

- Thread expansion now shows every message in the conversation except those in trash or archive folders, regardless of which folder the user is viewing from — same logic for the badge count.
- After a reply is sent, the frontend tracks the affected thread key and on each `sync_complete` re-fetches that thread, appending only newly seen messages without disturbing existing references. The currently expanded thread is also refreshed in case incoming mail arrived in it.
- The user's own sent mail now goes through body prefetch, so its snippet shows up in the conversation preview without waiting for a manual click.

## Changes

### Backend

- `routes/mail.js` — thread expansion excludes trash/archive instead of filtering to the current folder
- `services/messageService.js` — `thread_totals` and `deduped` CTEs apply the same trash/archive exclusion
- `services/imapManager.js` — `prefetchNewMessageBodies` now also runs on already-read newly inserted messages (e.g. user's own sent mail), and broadcasts `sync_complete` once a fresh snippet is generated so previews can refresh
- `services/messageService.test.js` — updated/extended threaded mode tests

### Frontend

- `components/ComposeModal.jsx` — dispatches `mailflow:reply-sent` with the thread key after a reply is sent
- `components/MessagePane.jsx`, `components/MessageList.jsx` — pass `message.thread_id` as `threadKey` when opening compose for a reply
- `components/MessageList.jsx` — tracks the just-replied thread via a ref, extracts a `mergeServerThread` helper that on every `mailflow:refresh` re-fetches the replied and currently expanded threads and merges in new messages (and previously empty snippets) without disturbing existing message references; preserves the open message in `threadMessages` when the refresh would otherwise drop it from the list

## Testing

1. Add an email account and exchange a few messages in a thread
2. Enable conversation view
3. Open the thread from inbox — sent replies appear alongside received messages and the thread count badge reflects the full thread size
4. With the thread open, send a reply — the new message appears in the sub-list automatically, the open message body stays put, and the thread auto-expands if it wasn't already
5. While the thread is expanded, simulate an incoming reply (e.g. from another device) — the new message appears without a manual refresh

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.