### PR TITLE
chore: resolve all ESLint warnings and enforce zero-warning lint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "dev": "node --watch src/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "eslint src"
+    "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
     "archiver": "^7.0.1",

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -249,7 +249,7 @@ router.post('/invites', async (req, res) => {
           });
           fromHeader = `${cfg.fromName || 'MailFlow'} <${cfg.fromEmail || cfg.user}>`;
         }
-      } catch {}
+      } catch { /* fall through to personal account */ }
     }
 
     // 2. Fall back to admin's first SMTP-enabled personal account
@@ -368,7 +368,7 @@ router.post('/system-email', async (req, res) => {
     "SELECT value FROM system_settings WHERE key = 'system_email_config'"
   );
   if (existing.rows.length) {
-    try { existingPass = JSON.parse(existing.rows[0].value).pass; } catch {}
+    try { existingPass = JSON.parse(existing.rows[0].value).pass; } catch { /* keep existingPass null */ }
   }
 
   const encryptedPass = pass && pass !== '••••••••'

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -56,6 +56,7 @@ router.post('/register', authLimiter, async (req, res) => {
   if (trimmedUsername.length < 1 || trimmedUsername.length > 120) {
     return res.status(400).json({ error: 'Username must be between 1 and 120 characters' });
   }
+  // eslint-disable-next-line no-control-regex -- intentionally rejecting control characters
   if (/[\x00-\x1f\x7f]/.test(trimmedUsername)) {
     return res.status(400).json({ error: 'Username contains invalid characters' });
   }
@@ -209,7 +210,7 @@ router.post('/login', authLimiter, async (req, res) => {
     logAuthEvent('login_success', { username: user.username, userId: user.id, ip: req.ip, success: true });
     res.locals.resetRateLimit?.();
     res.json({ user: { id: user.id, username: user.username, displayName: user.display_name, avatar: user.avatar, isAdmin: user.is_admin, totpEnabled: user.totp_enabled } });
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Login failed' });
   }
 });

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -21,6 +21,7 @@ function safeFilename(name) {
   // spoof displayed file extensions (e.g. U+202E reverses the filename visually).
   const cleaned = String(name)
     .replace(/[/\\]/g, '_')
+    // eslint-disable-next-line no-control-regex -- intentionally stripping control characters
     .replace(/[\x00-\x1f\x7f]/g, '')
     .replace(/[‪-‮⁦-⁩‏؜]/g, '')
     .trim()
@@ -30,6 +31,7 @@ function safeFilename(name) {
 
 // Validate a folder name / path component: no control chars, max 255 chars.
 function isValidFolderName(name) {
+  // eslint-disable-next-line no-control-regex -- intentionally rejecting control characters
   return typeof name === 'string' && name.length > 0 && name.length <= 255 && !/[\x00-\x1f\x7f]/.test(name);
 }
 
@@ -449,7 +451,7 @@ router.get('/messages/:id/attachments/:part', async (req, res) => {
   let partNum;
   try {
     partNum = decodeURIComponent(part);
-  } catch (_) {
+  } catch {
     return res.status(400).json({ error: 'Invalid attachment part identifier' });
   }
 
@@ -1267,7 +1269,7 @@ router.post('/messages/:id/snooze', async (req, res) => {
   const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [msg.account_id]);
   const account = accountResult.rows[0];
 
-  let snoozedUid = null;
+  let snoozedUid;
   imapManager._guardMoveUid(msg.account_id, msg.folder, msg.uid);
   try {
     try {
@@ -1344,7 +1346,7 @@ router.delete('/messages/:id', async (req, res) => {
     // Guard the source UID before the IMAP move so reconcileDeletes cannot delete
     // the DB row if an EXPUNGE arrives while the move is in flight.
     imapManager._guardMoveUid(message.account_id, message.folder, message.uid);
-    let newUid = null;
+    let newUid;
     try {
       try {
         newUid = await imapManager.moveMessage(account, message.uid, message.folder, trashPath);

--- a/backend/src/routes/oauth.js
+++ b/backend/src/routes/oauth.js
@@ -141,7 +141,7 @@ async function processMicrosoftTokens(userId, tokens, { tenantId, clientId }) {
       displayName = payload.name || null;
     } catch (jwtErr) {
       console.error('Microsoft id_token validation failed:', jwtErr.message);
-      throw new Error('Could not validate Microsoft identity token — please try again');
+      throw new Error('Could not validate Microsoft identity token — please try again', { cause: jwtErr });
     }
   }
 

--- a/backend/src/routes/oidc.js
+++ b/backend/src/routes/oidc.js
@@ -7,7 +7,7 @@ import { query, pool } from '../services/db.js';
 import { requireAuth } from '../middleware/auth.js';
 import { decrypt, isEncrypted } from '../services/encryption.js';
 import { imapManager } from '../index.js';
-import { validateHostLiteral, validateHost } from '../services/hostValidation.js';
+import { validateHost } from '../services/hostValidation.js';
 import { logAuthEvent } from '../services/authEvents.js';
 
 // In-memory OIDC discovery cache keyed by issuerUrl
@@ -118,7 +118,7 @@ oidcApiRouter.get('/providers', async (req, res) => {
       'SELECT id, name, slug FROM oidc_providers WHERE enabled = true ORDER BY name ASC'
     );
     res.json({ providers: result.rows });
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Failed to load providers' });
   }
 });
@@ -136,7 +136,7 @@ oidcApiRouter.get('/identities', requireAuth, async (req, res) => {
       [req.session.userId]
     );
     res.json({ identities: result.rows });
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Failed to load identities' });
   }
 });
@@ -161,7 +161,7 @@ oidcApiRouter.delete('/identities/:id', requireAuth, async (req, res) => {
       [req.params.id, req.session.userId]
     );
     res.json({ ok: true });
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Failed to unlink identity' });
   }
 });

--- a/backend/src/routes/rules.js
+++ b/backend/src/routes/rules.js
@@ -119,7 +119,7 @@ router.post('/run', async (req, res) => {
           if (Array.isArray(raw)) {
             toArr = raw.map(a => ({ email: a.address || a.email || '', name: a.name || '' }));
           }
-        } catch {}
+        } catch { /* malformed to_addresses — leave toArr empty */ }
         return {
           id: row.id,
           uid: row.uid,

--- a/backend/src/services/emailSanitizer.js
+++ b/backend/src/services/emailSanitizer.js
@@ -77,7 +77,7 @@ function unwrapEbayImgUrl(url) {
       const direct = u.searchParams.get('imageUrl');
       if (direct && direct.startsWith('https://')) return direct;
     }
-  } catch (_) {}
+  } catch { /* invalid URL — return as-is */ }
   return url;
 }
 
@@ -97,7 +97,7 @@ export function rewriteEbayImageserUrls(html) {
           const direct = u.searchParams.get('imageUrl');
           if (direct && direct.startsWith('https://')) return `${pre}src=${q}${direct}${q}`;
         }
-      } catch (_) {}
+      } catch { /* invalid URL — leave src unchanged */ }
       return match;
     }
   );

--- a/backend/src/services/encryption.js
+++ b/backend/src/services/encryption.js
@@ -2,7 +2,6 @@ import crypto from 'crypto';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_BYTES = 12;
-const TAG_BYTES = 16;
 const PREFIX = 'enc:v1:';
 
 // Cache the parsed key buffer so we don't re-allocate on every encrypt/decrypt call.

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -89,7 +89,7 @@ function decodeBody(buf, encoding, charset) {
   if (enc === 'base64') {
     // base64 payload is 7-bit ASCII so toString('ascii') is safe here
     const b64 = (Buffer.isBuffer(buf) ? buf : Buffer.from(buf)).toString('ascii').replace(/\s/g, '');
-    try { rawBytes = Buffer.from(b64, 'base64'); } catch (_) { rawBytes = buf; }
+    try { rawBytes = Buffer.from(b64, 'base64'); } catch { rawBytes = buf; }
   } else if (enc === 'quoted-printable') {
     const qpStr = (Buffer.isBuffer(buf) ? buf : Buffer.from(buf)).toString('ascii');
     const cleaned = qpStr.replace(/=\r\n/g, '').replace(/=\n/g, '');
@@ -117,7 +117,7 @@ function decodeBody(buf, encoding, charset) {
   // fatal:false replaces unrecognised bytes with U+FFFD rather than throwing.
   try {
     return new TextDecoder(cs, { fatal: false }).decode(rawBytes);
-  } catch (_) {
+  } catch {
     return rawBytes.toString('utf8'); // unknown charset — best effort
   }
 }
@@ -773,7 +773,7 @@ export class ImapManager {
     if (timer) { clearTimeout(timer); this.syncIntervals.delete(accountId); }
     const client = this.connections.get(accountId);
     if (client) {
-      try { await client.logout(); } catch (_) {}
+      try { await client.logout(); } catch { /* already disconnected */ }
       this.connections.delete(accountId);
     }
     this.syncThrottleSkips.delete(accountId);
@@ -1338,7 +1338,7 @@ export class ImapManager {
 
     const openBfClient = async () => {
       // Always clean up any existing client before creating a new one
-      if (bfClient) { try { await bfClient.logout(); } catch (_) {} bfClient = null; }
+      if (bfClient) { try { await bfClient.logout(); } catch { /* already disconnected */ } bfClient = null; }
       const row = (await query('SELECT * FROM email_accounts WHERE id = $1', [account.id])).rows[0];
       if (!row) throw new Error('Account deleted');
       const fresh = await ensureFreshToken(row);
@@ -1643,7 +1643,7 @@ export class ImapManager {
           consecutiveErrors++;
           const detail = extractImapError(err);
           // Discard the broken connection — openBfClient will reconnect next iteration
-          if (bfClient) { try { await bfClient.logout(); } catch (_) {} bfClient = null; }
+          if (bfClient) { try { await bfClient.logout(); } catch { /* already disconnected */ } bfClient = null; }
           batchesOnConn = cfg.batchesPerConn; // force reconnect
 
           if (consecutiveErrors >= 3) {
@@ -1677,7 +1677,7 @@ export class ImapManager {
     } catch (err) {
       console.error(`Backfill failed for ${logAccount(account)}/${folder}:`, err.message);
     } finally {
-      if (bfClient) { try { await bfClient.logout(); } catch (_) {} }
+      if (bfClient) { try { await bfClient.logout(); } catch { /* already disconnected */ } }
       this.backfillRunning.delete(backfillKey);
     }
   }
@@ -1756,7 +1756,7 @@ export class ImapManager {
       logger.debug(`Snippet indexer: ${logAccount(account)} has ${totalMissing} messages without snippets`);
 
       const openClient = async () => {
-        if (siClient) { try { await siClient.logout(); } catch (_) {} siClient = null; }
+        if (siClient) { try { await siClient.logout(); } catch { /* already disconnected */ } siClient = null; }
         const row = (await query('SELECT * FROM email_accounts WHERE id = $1', [account.id])).rows[0];
         if (!row) throw new Error('Account deleted');
         const fresh = await ensureFreshToken(row);
@@ -1831,7 +1831,7 @@ export class ImapManager {
                       [sanitizeStr(parsed.snippet), account.id, msg.uid, folder]
                     );
                   }
-                } catch (_) {}
+                } catch { /* skip snippet on parse/update failure */ }
               }
             } finally {
               lock.release();
@@ -1861,7 +1861,7 @@ export class ImapManager {
     } catch (err) {
       console.error(`Snippet indexer error ${logAccount(account)}:`, err.message);
     } finally {
-      if (siClient) { try { await siClient.logout(); } catch (_) {} }
+      if (siClient) { try { await siClient.logout(); } catch { /* already disconnected */ } }
       this.snippetIndexerRunning.delete(account.id);
     }
   }
@@ -2012,7 +2012,7 @@ export class ImapManager {
     const doFetch = () => withFreshClient(account, async (client) => {
       let html = null;
       let text = null;
-      let attachments = [];
+      let attachments;
       // Always address by UID string with uid:true option — direct UID FETCH avoids
       // the two-step SEARCH+FETCH path that object-range syntax triggers, which can
       // silently return nothing on stale connections or when a server-side search
@@ -2047,7 +2047,7 @@ export class ImapManager {
                 }
               }
             }
-          } catch (_) {
+          } catch {
             structure = null;
             prefetched.clear();
             for await (const msg of client.fetch(uidStr, { uid: true, bodyStructure: true }, { uid: true })) {
@@ -2112,7 +2112,7 @@ export class ImapManager {
                 const v = msg.bodyParts?.get(part.part);
                 if (v && v.length > 0) prefetched.set(part.part, v);
               }
-            } catch (_) {} // don't let a single part failure block others
+            } catch { /* don't let a single part failure block others */ }
           }
         }
 

--- a/backend/src/services/messageParser.js
+++ b/backend/src/services/messageParser.js
@@ -114,7 +114,7 @@ function decodeBodyPart(buf, encoding, charset) {
   let rawBytes;
   if (enc === 'base64') {
     const b64 = buf.toString('ascii').replace(/\s/g, '');
-    try { rawBytes = Buffer.from(b64, 'base64'); } catch (_) { rawBytes = buf; }
+    try { rawBytes = Buffer.from(b64, 'base64'); } catch { rawBytes = buf; }
   } else if (enc === 'quoted-printable') {
     const cleaned = buf.toString('ascii').replace(/=\r\n/g, '').replace(/=\n/g, '');
     const bytes = [];
@@ -138,7 +138,7 @@ function decodeBodyPart(buf, encoding, charset) {
 
   try {
     return new TextDecoder(cs, { fatal: false }).decode(rawBytes);
-  } catch (_) {
+  } catch {
     return rawBytes.toString('utf8');
   }
 }
@@ -222,7 +222,7 @@ export async function parseMessage(msg) {
         }
 
         snippet = text.replace(/\s+/g, ' ').trim().substring(0, 200);
-      } catch (_) {}
+      } catch { /* leave snippet empty on parse failure */ }
     }
   }
 

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -55,7 +55,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
           );
       total = r.rows[0]?.n ?? 0;
     }
-  } catch (_) {
+  } catch {
     total = 0;
   }
 

--- a/backend/src/services/websocket.js
+++ b/backend/src/services/websocket.js
@@ -1,7 +1,7 @@
 // Derive the expected origin from APP_URL once at startup.
 // If APP_URL is not set, origin validation is skipped — log a warning so operators know.
 const ALLOWED_ORIGIN = (() => {
-  try { return process.env.APP_URL ? new URL(process.env.APP_URL).origin : null; } catch (_) { return null; }
+  try { return process.env.APP_URL ? new URL(process.env.APP_URL).origin : null; } catch { return null; }
 })();
 if (!ALLOWED_ORIGIN) {
   if (process.env.NODE_ENV === 'production') {
@@ -50,7 +50,7 @@ export function setupWebSocket(wss, sessionMiddleware, imapManager) {
       try {
         const msg = JSON.parse(data);
         if (msg.type === 'ping') ws.send(JSON.stringify({ type: 'pong' }));
-      } catch (_) {}
+      } catch { /* ignore malformed client message */ }
     });
 
     ws.on('close', () => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "node --test",
-    "lint": "eslint src"
+    "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
     "@emoji-mart/data": "^1.2.1",

--- a/frontend/src/components/ComposeModal.jsx
+++ b/frontend/src/components/ComposeModal.jsx
@@ -455,7 +455,7 @@ export default function ComposeModal() {
       dragCleanupRef.current = null;
       if (commit) {
         setCustomSize({ width: curW, height: curH });
-        try { localStorage.setItem('mailflow_compose_size', JSON.stringify({ width: curW, height: curH })); } catch {}
+        try { localStorage.setItem('mailflow_compose_size', JSON.stringify({ width: curW, height: curH })); } catch { /* localStorage unavailable */ }
       }
     };
     const cleanupNoCommit = () => cleanup({ commit: false });


### PR DESCRIPTION
## Summary

The backend and frontend ESLint configs were in place, but the lint step never actually enforced anything: `eslint src` exits 0 when only warnings are present, so warnings accumulated unnoticed (48 in the backend, 1 in the frontend). This PR clears every existing warning and then changes the lint command to fail on any warning, so the zero-warning state can't regress.

## Changes

- **Cleared all 49 ESLint warnings** across backend and frontend:
  - Dropped unused `catch` bindings to optional catch binding (`catch {}`).
  - Documented intentionally-empty `catch` blocks (required to satisfy `no-empty`; comment explains why the error is swallowed).
  - Removed dead variable initializers flagged by `no-useless-assignment` (`let x = null` → `let x`, where every read path reassigns first; the only reads use `!= null`, so `null` vs `undefined` is indistinguishable).
  - Removed the unused `TAG_BYTES` constant and the unused `validateHostLiteral` import.
  - Attached `{ cause }` to the re-thrown Microsoft token-validation error (`preserve-caught-error`), preserving the original error for diagnostics.
  - Added `// eslint-disable-next-line no-control-regex` only on the three regexes that intentionally match control characters (username / folder-name / filename sanitization).
- **Enforced a zero-warning ceiling**: both `lint` scripts are now `eslint src --max-warnings 0`, so CI fails on any warning. Rule severities in `eslint.config.js` are unchanged, keeping the warn/error gradient for editor feedback.

No runtime behavior changes.

## Testing

- `npm run lint` passes (exit 0) in both `backend/` and `frontend/`.
- `node --check src/index.js` passes (backend).
- Backend test suite: 224 passed.
- Frontend test suite: 814 passed.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.