### PR TITLE
fix: preserve editor inline images as CID attachments on send (#237)

### DIFF
--- a/backend/src/routes/draft.js
+++ b/backend/src/routes/draft.js
@@ -3,7 +3,8 @@ import { Router } from 'express';
 import { query } from '../services/db.js';
 import { requireAuth } from '../middleware/auth.js';
 import sanitizeHtml from 'sanitize-html';
-import { sanitizeSignature } from '../services/emailSanitizer.js';
+import { sanitizeSignature, sanitizeComposeBody } from '../services/emailSanitizer.js';
+import { embedInlineDataImages } from '../utils/inlineImages.js';
 import { imapManager } from '../index.js';
 
 const router = Router();
@@ -57,11 +58,13 @@ async function buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, b
     : (body || '');
 
   const bodyHtml = bodyIsHtml
-    ? sanitizeHtml(body || '', {
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['u', 's']),
-        allowedAttributes: { '*': ['style'], 'a': ['href', 'target', 'rel'] },
-      })
+    ? sanitizeComposeBody(body || '')
     : textToHtml(body || '');
+
+  const rawHtml = bodyHtml +
+    (effectiveSignature ? `<div style="margin-top:16px;color:#555;font-size:13px">${effectiveSignature}</div>` : '') +
+    (quotedBodyHtml || (quotedBody ? textToHtml(quotedBody) : ''));
+  const { html: draftHtml, attachments: inlineImageAttachments } = embedInlineDataImages(rawHtml);
 
   const mailOptions = {
     from: `${fromName} <${fromEmail}>`,
@@ -70,9 +73,8 @@ async function buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, b
     bcc: (Array.isArray(bcc) ? bcc : []).filter(Boolean).join(', ') || undefined,
     subject: sanitizeHeaderValue(subject || ''),
     text: sigText ? `${bodyText}\n\n-- \n${sigText}${quotedBody || ''}` : `${bodyText}${quotedBody || ''}`,
-    html: bodyHtml +
-      (effectiveSignature ? `<div style="margin-top:16px;color:#555;font-size:13px">${effectiveSignature}</div>` : '') +
-      (quotedBodyHtml || (quotedBody ? textToHtml(quotedBody) : '')),
+    html: draftHtml,
+    ...(inlineImageAttachments.length ? { attachments: inlineImageAttachments } : {}),
   };
 
   const streamTransport = nodemailer.createTransport({ streamTransport: true, newline: 'unix' });

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -6,7 +6,7 @@ import { query } from '../services/db.js';
 import { requireAuth } from '../middleware/auth.js';
 import { imapManager } from '../index.js';
 import { sanitizeEmail, stripEmailHead, hasRemoteImages, blockRemoteImages, rewriteEbayImageserUrls, rewriteAnchorHrefs } from '../services/emailSanitizer.js';
-import { snippetFromBody, decodeMimeWords } from '../services/messageParser.js';
+import { snippetFromBody, decodeMimeWords, parseRawHeaders, buildHeadersFromMessage } from '../services/messageParser.js';
 import { resolveTrashFolder, resolveAllTrashPaths, resolveAllDraftsPaths, resolveArchiveFolder, resolveSpamFolder, resolveAllSpamPaths, getDeleteStrategy, adjustFolderCounts } from '../utils/mailUtils.js';
 import { listMessages } from '../services/messageService.js';
 import { validateHost } from '../services/hostValidation.js';
@@ -395,8 +395,30 @@ router.get('/messages/:id/headers', async (req, res) => {
     const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]);
     const account = accountResult.rows[0];
 
-    const headers = await imapManager.fetchHeaders(account, message.uid, message.folder);
-    res.json({ headers });
+    let headers = '';
+    try {
+      headers = await imapManager.fetchHeaders(account, message.uid, message.folder);
+    } catch (fetchErr) {
+      console.warn('Headers IMAP fetch failed:', fetchErr.message);
+    }
+
+    if (!headers?.trim()) {
+      headers = buildHeadersFromMessage(message);
+    }
+
+    let resolvedSubject = message.subject;
+    if (headers?.trim()) {
+      const parsed = parseRawHeaders(headers);
+      const imapSubject = decodeMimeWords(parsed.subject || '').trim();
+      if (imapSubject && imapSubject !== '(no subject)') {
+        resolvedSubject = imapSubject;
+        if (!message.subject || message.subject === '(no subject)') {
+          await query('UPDATE messages SET subject = $1 WHERE id = $2', [imapSubject, id]);
+        }
+      }
+    }
+
+    res.json({ headers, subject: resolvedSubject });
   } catch (err) {
     console.error('Headers fetch error:', err);
     res.status(500).json({ error: 'Failed to fetch message headers' });

--- a/backend/src/routes/send.js
+++ b/backend/src/routes/send.js
@@ -6,7 +6,8 @@ import { requireAuth } from '../middleware/auth.js';
 import { refreshMicrosoftToken } from './oauth.js';
 import { decrypt } from '../services/encryption.js';
 import sanitizeHtml from 'sanitize-html';
-import { sanitizeSignature } from '../services/emailSanitizer.js';
+import { sanitizeSignature, sanitizeComposeBody } from '../services/emailSanitizer.js';
+import { embedInlineDataImages } from '../utils/inlineImages.js';
 import { redisClient } from '../services/redis.js';
 import { redactEmail } from '../utils/redact.js';
 import { generateVCard } from '../utils/vcard.js';
@@ -49,6 +50,32 @@ function parseAddress(str) {
   const bare = str.match(/^\s*<([^>]+)>\s*$/);
   if (bare) return { name: '', email: bare[1].trim().toLowerCase() };
   return { name: '', email: str.trim().toLowerCase() };
+}
+
+function mapRecipientList(list) {
+  return (list || []).map(addr => parseAddress(addr));
+}
+
+function buildSentSnippet(body, bodyIsHtml) {
+  return bodyToPlain(body, bodyIsHtml).replace(/\s+/g, ' ').trim().substring(0, 200);
+}
+
+function scheduleSentMetadataUpsert(account, sentFolder, mailOptions, meta) {
+  if (!sentFolder || !mailOptions.messageId) return;
+  setImmediate(async () => {
+    for (const delay of [3000, 10000, 20000]) {
+      await new Promise(r => setTimeout(r, delay));
+      try {
+        const uid = await imapManager.findUidByMessageId(account, sentFolder, mailOptions.messageId);
+        if (uid) {
+          await imapManager.upsertSentMessageRecord(account, sentFolder, uid, meta);
+          return;
+        }
+      } catch (err) {
+        console.warn('Post-send sent metadata upsert failed:', err.message);
+      }
+    }
+  });
 }
 
 // Reject any recipient address that contains newlines, null bytes, or looks
@@ -94,10 +121,7 @@ function bodyToPlain(body, isHtml) {
 
 function bodyToHtml(body, isHtml) {
   if (!isHtml) return textToHtml(body);
-  return sanitizeHtml(body, {
-    allowedTags: sanitizeHtml.defaults.allowedTags.concat(['u', 's']),
-    allowedAttributes: { '*': ['style'], 'a': ['href', 'target', 'rel'] },
-  });
+  return sanitizeComposeBody(body);
 }
 
 const router = Router();
@@ -302,20 +326,27 @@ router.post('/send', async (req, res) => {
       text: effectiveSignature
         ? bodyToPlain(body, bodyIsHtml) + '\n\n-- \n' + sigToPlainText(effectiveSignature) + (quotedBody || '')
         : bodyToPlain(body, bodyIsHtml) + (quotedBody || ''),
-      ...(plaintextEmail ? {} : {
-        html: bodyToHtml(body, bodyIsHtml) +
-          (effectiveSignature
-            ? '<div style="margin-top:16px;color:#555;font-size:13px">' + effectiveSignature + '</div>'
-            : '') +
-          (quotedBodyHtml || (quotedBody ? textToHtml(quotedBody) : '')),
-      }),
     };
+
+    let inlineImageAttachments = [];
+    if (!plaintextEmail) {
+      const rawHtml = bodyToHtml(body, bodyIsHtml) +
+        (effectiveSignature
+          ? '<div style="margin-top:16px;color:#555;font-size:13px">' + effectiveSignature + '</div>'
+          : '') +
+        (quotedBodyHtml || (quotedBody ? textToHtml(quotedBody) : ''));
+      const embedded = embedInlineDataImages(rawHtml);
+      mailOptions.html = embedded.html;
+      inlineImageAttachments = embedded.attachments;
+    }
+
     if (inReplyTo) {
       mailOptions.inReplyTo = sanitizeHeaderValue(inReplyTo);
       // Use the full prior references chain if available; fall back to just inReplyTo.
       mailOptions.references = sanitizeHeaderValue(references || inReplyTo);
     }
     const allAttachments = [
+      ...inlineImageAttachments,
       ...(attachments?.length ? attachments.map(a => ({
         filename: sanitizeHeaderValue(a.filename),
         content: Buffer.from(a.content, 'base64'),
@@ -442,6 +473,17 @@ router.post('/send', async (req, res) => {
     // true/false = whether OUR IMAP APPEND landed the Sent copy. Surfaced to the client so
     // it can warn when a delivered message could not be saved to Sent. Fixes audit finding [2].
     let sentCopySaved = null;
+    const sentMeta = sentFolder ? {
+      messageId: mailOptions.messageId,
+      subject: normalizedSubject,
+      fromName,
+      fromEmail,
+      to: mapRecipientList(normalizedTo),
+      cc: mapRecipientList(normalizedCc),
+      snippet: buildSentSnippet(body, bodyIsHtml),
+      date: new Date(),
+    } : null;
+
     if (sentFolder) {
       if (rawMessage) {
         // Non-auto-saving account: APPEND the Sent copy ourselves — exactly ONCE. IMAP
@@ -452,11 +494,15 @@ router.post('/send', async (req, res) => {
         // the user and schedule a fallback sync in case the append landed late. Audit [2].
         sentCopySaved = false;
         try {
-          await Promise.race([
+          const { uid } = await Promise.race([
             imapManager.appendToSent(account, sentFolder, rawMessage),
             new Promise((_, rej) => setTimeout(() => rej(new Error('Sent APPEND timed out')), 20000)),
           ]);
           sentCopySaved = true;
+          if (uid && sentMeta) {
+            await imapManager.upsertSentMessageRecord(account, sentFolder, uid, sentMeta)
+              .catch(err => console.warn('Sent metadata upsert failed:', err.message));
+          }
           setTimeout(() => {
             imapManager.syncFolderOnDemand(account, sentFolder)
               .catch(e => console.error(`Post-append sync failed: ${e.message}`));
@@ -471,6 +517,8 @@ router.post('/send', async (req, res) => {
           }, 8000);
         }
       } else {
+        // Server auto-saves via SMTP; seed metadata once the Sent copy is searchable.
+        if (sentMeta) scheduleSentMetadataUpsert(account, sentFolder, mailOptions, sentMeta);
         // Server auto-saves via SMTP; just sync after a delay.
         const syncAttempt = (label) => imapManager.syncFolderOnDemand(account, sentFolder)
           .then(() => console.log(`Post-send ${label} sync done: ${redactEmail(account.email_address)}/${sentFolder}`))

--- a/backend/src/services/emailSanitizer.js
+++ b/backend/src/services/emailSanitizer.js
@@ -252,6 +252,42 @@ export function sanitizeEmail(html) {
   return stripDarkModeStyleBlocks(upgradeStyleBlocks(stripExternalStyleBlockUrls(sanitized)));
 }
 
+// Sanitize user-authored compose body HTML — allows rich formatting and inline
+// images (data: or https:) but strips scripts and event handlers.
+export function sanitizeComposeBody(html) {
+  if (!html) return html;
+  return sanitizeHtml(html, {
+    allowedTags: [
+      'a', 'b', 'strong', 'i', 'em', 'u', 's', 'del',
+      'p', 'br', 'div', 'span', 'img',
+      'ul', 'ol', 'li',
+      'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr',
+      'blockquote', 'pre', 'code',
+      'table', 'thead', 'tbody', 'tr', 'th', 'td',
+      'font', 'center',
+    ],
+    allowedAttributes: {
+      '*': ['style', 'class'],
+      'a': ['href', 'target', 'rel'],
+      'img': ['src', 'alt', 'width', 'height', 'title'],
+      'font': ['color', 'size', 'face'],
+      'td': ['colspan', 'rowspan', 'align', 'valign', 'width', 'height', 'bgcolor'],
+      'th': ['colspan', 'rowspan', 'align', 'valign'],
+      'table': ['width', 'cellpadding', 'cellspacing', 'border', 'align', 'bgcolor'],
+      'code': ['class'],
+    },
+    allowedSchemes: ['https', 'mailto'],
+    allowedSchemesByTag: { img: ['https', 'data'] },
+    transformTags: {
+      'a': (tagName, attribs) => ({
+        tagName,
+        attribs: { ...attribs, rel: 'noopener noreferrer', target: '_blank' },
+      }),
+    },
+    disallowedTagsMode: 'discard',
+  });
+}
+
 // Sanitize user-authored signature HTML — allows common formatting and images
 // but strips all event handlers and scripts. Stricter than sanitizeEmail().
 export function sanitizeSignature(html) {

--- a/backend/src/services/emailSanitizer.test.js
+++ b/backend/src/services/emailSanitizer.test.js
@@ -3,6 +3,7 @@ import {
   stripEmailHead,
   sanitizeEmail,
   sanitizeSignature,
+  sanitizeComposeBody,
   hasRemoteImages,
   blockRemoteImages,
   rewriteEbayImageserUrls,
@@ -353,6 +354,40 @@ describe('rewriteEbayImageserUrls', () => {
   it('returns HTML without imageser unchanged (fast path)', () => {
     const html = '<p>No images here</p>';
     expect(rewriteEbayImageserUrls(html)).toBe(html);
+  });
+});
+
+// ── sanitizeComposeBody ────────────────────────────────────────────────────
+
+describe('sanitizeComposeBody', () => {
+  it('preserves inline data: images from the compose editor', () => {
+    const html = '<p><span style="font-size:14px"><img src="data:image/png;base64,abc123" width="200">test</span></p>';
+    const out = sanitizeComposeBody(html);
+    expect(out).toContain('src="data:image/png;base64,abc123"');
+    expect(out).toContain('test');
+  });
+
+  it('preserves https:// images', () => {
+    const html = '<img src="https://example.com/photo.jpg" alt="photo">';
+    const out = sanitizeComposeBody(html);
+    expect(out).toContain('src="https://example.com/photo.jpg"');
+    expect(out).toContain('alt="photo"');
+  });
+
+  it('strips http:// images (only https and data allowed)', () => {
+    const out = sanitizeComposeBody('<img src="http://example.com/tracker.png">');
+    expect(out).not.toContain('src="http://');
+  });
+
+  it('strips <script> tags', () => {
+    const out = sanitizeComposeBody('<p>Hi</p><script>alert(1)</script>');
+    expect(out).not.toContain('<script');
+    expect(out).toContain('Hi');
+  });
+
+  it('returns falsy input unchanged', () => {
+    expect(sanitizeComposeBody(null)).toBeNull();
+    expect(sanitizeComposeBody('')).toBe('');
   });
 });
 

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -1,6 +1,6 @@
 import { ImapFlow } from 'imapflow';
 import { query } from './db.js';
-import { parseMessage, snippetFromBody, detectBulkFromParsedHeaders, parseRawHeaders, decodeMimeWords } from './messageParser.js';
+import { parseMessage, snippetFromBody, detectBulkFromParsedHeaders, parseRawHeaders, parseHeadersInput, headersToRawString, decodeMimeWords, enrichParsedMetadata } from './messageParser.js';
 import { classifyMessage, loadSocialDomains, getGlobalCategorizationEnabled } from './categorizer.js';
 import { refreshMicrosoftToken } from '../routes/oauth.js';
 import { sanitizeEmail } from './emailSanitizer.js';
@@ -386,6 +386,46 @@ export function providerProfile(account) {
 // Per-account connection pool for body fetches — avoids TLS handshake on every click
 const connectionPools = new Map(); // accountId -> { clients: [], waiting: [] }
 const POOL_SIZE = 2;
+
+// When a message moves folders (same Message-ID, new UID), refresh metadata too —
+// otherwise a draft→sent relocate can leave subject/addresses stale forever.
+const RELOCATE_MESSAGE_SQL = `
+  UPDATE messages SET
+    folder = $1::text,
+    uid = $2::bigint,
+    is_deleted = false,
+    subject = CASE
+      WHEN $5::text IS NOT NULL AND $5::text <> '' AND $5::text <> '(no subject)'
+      THEN $5::text ELSE messages.subject END,
+    from_name = COALESCE(NULLIF($6::text, ''), messages.from_name),
+    from_email = COALESCE(NULLIF($7::text, ''), messages.from_email),
+    to_addresses = CASE
+      WHEN $8::jsonb::text IS NOT NULL AND $8::jsonb::text <> '[]'
+      THEN $8::jsonb ELSE messages.to_addresses END,
+    cc_addresses = CASE
+      WHEN $9::jsonb::text IS NOT NULL AND $9::jsonb::text <> '[]'
+      THEN $9::jsonb ELSE messages.cc_addresses END,
+    reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), $10::text)::jsonb,
+    date = $11::timestamptz
+  WHERE account_id = $3::uuid
+    AND message_id = $4::text
+    AND (folder != $1::text OR uid != $2::bigint)
+    AND 1 = (SELECT COUNT(*) FROM messages WHERE account_id = $3::uuid AND message_id = $4::text)
+    AND COALESCE((SELECT special_use FROM folders WHERE account_id = $3::uuid AND path = $1::text), '') NOT IN ('\\All', '\\Important')
+  RETURNING id`;
+
+function relocateMessageParams(folder, parsed, accountId, msgId) {
+  return [
+    folder, parsed.uid, accountId, msgId,
+    sanitizeStr(parsed.subject),
+    sanitizeStr(parsed.fromName),
+    sanitizeStr(parsed.fromEmail),
+    JSON.stringify(parsed.to),
+    JSON.stringify(parsed.cc),
+    JSON.stringify(parsed.replyTo || []),
+    safeDate(parsed.date),
+  ];
+}
 
 // Strip null bytes that PostgreSQL's UTF-8 encoding rejects (some emails contain them)
 function sanitizeStr(str) {
@@ -1625,6 +1665,13 @@ export class ImapManager {
         const processMsg = async (msg) => {
           try {
             const parsed = await parseMessage(msg);
+            enrichParsedMetadata(parsed, {
+              accountEmail: account.email_address,
+              accountName: account.name,
+              senderName: account.sender_name,
+              folderPath: folder,
+              sentFolderPath: account.folder_mappings?.sent,
+            });
             if (!parsed.uid) {
               console.warn(`Message sync skipped: IMAP FETCH returned no UID for ${account.email}/${folder}`);
               return;
@@ -1647,15 +1694,7 @@ export class ImapManager {
             // merging Gmail's virtual-folder copies (same message_id in INBOX and
             // [Gmail]/All Mail simultaneously).
             if (msgId) {
-              const relocated = await query(`
-                UPDATE messages SET folder = $1, uid = $2, is_deleted = false
-                WHERE account_id = $3
-                  AND message_id = $4
-                  AND (folder != $1 OR uid != $2)
-                  AND 1 = (SELECT COUNT(*) FROM messages WHERE account_id = $3 AND message_id = $4)
-                  AND COALESCE((SELECT special_use FROM folders WHERE account_id = $3 AND path = $1), '') NOT IN ('\\All', '\\Important')
-                RETURNING id
-              `, [folder, parsed.uid, account.id, msgId]);
+              const relocated = await query(RELOCATE_MESSAGE_SQL, relocateMessageParams(folder, parsed, account.id, msgId));
               if (relocated.rows.length > 0) return;
             }
 
@@ -1679,8 +1718,25 @@ export class ImapManager {
                 list_unsubscribe, list_unsubscribe_post
               ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)
               ON CONFLICT (account_id, uid, folder) DO UPDATE
-              SET from_name = $6, from_email = $7,
-                  to_addresses = $8, cc_addresses = $9,
+              SET subject = CASE
+                    WHEN EXCLUDED.subject IS NOT NULL
+                         AND EXCLUDED.subject != ''
+                         AND EXCLUDED.subject != '(no subject)'
+                    THEN EXCLUDED.subject
+                    ELSE messages.subject
+                  END,
+                  from_name = COALESCE(NULLIF(EXCLUDED.from_name, ''), messages.from_name),
+                  from_email = COALESCE(NULLIF(EXCLUDED.from_email, ''), messages.from_email),
+                  to_addresses = CASE
+                    WHEN EXCLUDED.to_addresses::text IS NOT NULL AND EXCLUDED.to_addresses::text <> '[]'
+                    THEN EXCLUDED.to_addresses
+                    ELSE messages.to_addresses
+                  END,
+                  cc_addresses = CASE
+                    WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
+                    THEN EXCLUDED.cc_addresses
+                    ELSE messages.cc_addresses
+                  END,
                   reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), EXCLUDED.reply_to::text)::jsonb,
                   in_reply_to = COALESCE(messages.in_reply_to, EXCLUDED.in_reply_to),
                   snippet = CASE WHEN EXCLUDED.snippet != '' THEN EXCLUDED.snippet
@@ -2099,6 +2155,13 @@ export class ImapManager {
             for await (const msg of bfClient.fetch(uidSet, bfQuery, { uid: true })) {
               try {
                 const parsed = await parseMessage(msg);
+                enrichParsedMetadata(parsed, {
+                  accountEmail: account.email_address,
+                  accountName: account.name,
+                  senderName: account.sender_name,
+                  folderPath: folder,
+                  sentFolderPath: account.folder_mappings?.sent,
+                });
                 if (!parsed.uid) {
                   console.warn(`Backfill skipped: IMAP FETCH returned no UID for ${account.email}/${folder}`);
                   continue;
@@ -2118,15 +2181,7 @@ export class ImapManager {
                 const bfThreadId = await computeThreadId(account.id, bfMsgId, bfReplyTo, bfRefs, sanitizeStr(parsed.subject));
 
                 if (bfMsgId) {
-                  const relocated = await query(`
-                    UPDATE messages SET folder = $1, uid = $2, is_deleted = false
-                    WHERE account_id = $3
-                      AND message_id = $4
-                      AND (folder != $1 OR uid != $2)
-                      AND 1 = (SELECT COUNT(*) FROM messages WHERE account_id = $3 AND message_id = $4)
-                      AND COALESCE((SELECT special_use FROM folders WHERE account_id = $3 AND path = $1), '') NOT IN ('\\All', '\\Important')
-                    RETURNING id
-                  `, [folder, parsed.uid, account.id, bfMsgId]);
+                  const relocated = await query(RELOCATE_MESSAGE_SQL, relocateMessageParams(folder, parsed, account.id, bfMsgId));
                   if (relocated.rows.length > 0) continue;
                 }
 
@@ -2150,8 +2205,25 @@ export class ImapManager {
                     list_unsubscribe, list_unsubscribe_post
                   ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)
                   ON CONFLICT (account_id, uid, folder) DO UPDATE
-                  SET from_name = $6, from_email = $7,
-                      to_addresses = $8, cc_addresses = $9,
+                  SET subject = CASE
+                        WHEN EXCLUDED.subject IS NOT NULL
+                             AND EXCLUDED.subject != ''
+                             AND EXCLUDED.subject != '(no subject)'
+                        THEN EXCLUDED.subject
+                        ELSE messages.subject
+                      END,
+                      from_name = COALESCE(NULLIF(EXCLUDED.from_name, ''), messages.from_name),
+                      from_email = COALESCE(NULLIF(EXCLUDED.from_email, ''), messages.from_email),
+                      to_addresses = CASE
+                        WHEN EXCLUDED.to_addresses::text IS NOT NULL AND EXCLUDED.to_addresses::text <> '[]'
+                        THEN EXCLUDED.to_addresses
+                        ELSE messages.to_addresses
+                      END,
+                      cc_addresses = CASE
+                        WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
+                        THEN EXCLUDED.cc_addresses
+                        ELSE messages.cc_addresses
+                      END,
                       reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), EXCLUDED.reply_to::text)::jsonb,
                       in_reply_to = COALESCE(messages.in_reply_to, EXCLUDED.in_reply_to),
                       snippet = CASE WHEN EXCLUDED.snippet != '' THEN EXCLUDED.snippet
@@ -2358,7 +2430,7 @@ export class ImapManager {
           }, { uid: true })) {
             const dbId = uidToId.get(msg.uid);
             if (dbId == null) continue;
-            const h = parseRawHeaders(msg.headers);
+            const h = parseHeadersInput(msg.headers);
             updates.push({ id: dbId, isBulk: detectBulkFromParsedHeaders(h) });
           }
         } finally {
@@ -2604,7 +2676,71 @@ export class ImapManager {
   }
 
   async appendToSent(account, folder, rawMessage) {
-    await this.appendToFolder(account, folder, rawMessage, ['\\Seen']);
+    return this.appendToFolder(account, folder, rawMessage, ['\\Seen']);
+  }
+
+  // Persist authoritative Sent metadata right after SMTP/APPEND so a later IMAP sync
+  // with an incomplete ENVELOPE (common for multipart/related inline-image mail) cannot
+  // wipe subject/from/to.
+  async upsertSentMessageRecord(account, folder, uid, {
+    messageId,
+    subject,
+    fromName,
+    fromEmail,
+    to = [],
+    cc = [],
+    snippet = '',
+    date = new Date(),
+  }) {
+    if (!uid || !folder) return;
+    const msgId = sanitizeStr(messageId);
+    const threadId = msgId || null;
+    await query(`
+      INSERT INTO messages (
+        account_id, uid, folder, message_id, subject,
+        from_name, from_email, to_addresses, cc_addresses,
+        date, snippet, is_read, is_starred, has_attachments, flags, thread_id
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11,true,false,false,'[]',$12)
+      ON CONFLICT (account_id, uid, folder) DO UPDATE SET
+        message_id = COALESCE(EXCLUDED.message_id, messages.message_id),
+        subject = CASE
+          WHEN EXCLUDED.subject IS NOT NULL AND EXCLUDED.subject <> '' AND EXCLUDED.subject <> '(no subject)'
+          THEN EXCLUDED.subject ELSE messages.subject END,
+        from_name = COALESCE(NULLIF(EXCLUDED.from_name, ''), messages.from_name),
+        from_email = COALESCE(NULLIF(EXCLUDED.from_email, ''), messages.from_email),
+        to_addresses = CASE
+          WHEN EXCLUDED.to_addresses::text IS NOT NULL AND EXCLUDED.to_addresses::text <> '[]'
+          THEN EXCLUDED.to_addresses ELSE messages.to_addresses END,
+        cc_addresses = CASE
+          WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
+          THEN EXCLUDED.cc_addresses ELSE messages.cc_addresses END,
+        date = EXCLUDED.date,
+        snippet = CASE WHEN EXCLUDED.snippet <> '' THEN EXCLUDED.snippet ELSE messages.snippet END,
+        is_read = true,
+        thread_id = COALESCE(messages.thread_id, EXCLUDED.thread_id)
+    `, [
+      account.id, uid, folder, msgId,
+      sanitizeStr(subject || '(no subject)'),
+      sanitizeStr(fromName || ''), sanitizeStr(fromEmail || ''),
+      JSON.stringify(to), JSON.stringify(cc),
+      safeDate(date), sanitizeStr(snippet || ''), threadId,
+    ]);
+  }
+
+  async findUidByMessageId(account, folder, messageId) {
+    if (!messageId || !folder) return null;
+    const mid = String(messageId).replace(/[<>]/g, '').trim();
+    if (!mid) return null;
+    return withFreshClient(account, async (client) => {
+      const lock = await client.getMailboxLock(folder);
+      try {
+        const uids = await client.search({ header: ['Message-ID', mid] }, { uid: true });
+        if (!uids?.length) return null;
+        return uids[uids.length - 1];
+      } finally {
+        lock.release();
+      }
+    });
   }
 
   // Syncs the most recent messages in a specific folder on demand.
@@ -2918,12 +3054,26 @@ export class ImapManager {
     return withFreshClient(account, async (client) => {
       const lock = await client.getMailboxLock(folder);
       try {
+        const uidStr = String(uid);
         let headers = '';
-        for await (const msg of client.fetch(String(uid), { uid: true, headers: true }, { uid: true })) {
-          if (msg.headers) {
-            headers = msg.headers.toString();
+
+        for await (const msg of client.fetch(uidStr, { uid: true, headers: true }, { uid: true })) {
+          if (msg.headers) headers = headersToRawString(msg.headers);
+        }
+
+        // Some providers return an empty HEADER.FIELDS response — fall back to the
+        // leading bytes of the raw message, which always include the header block.
+        if (!headers.trim()) {
+          for await (const msg of client.fetch(uidStr, { uid: true, source: { start: 0, maxLength: 65536 } }, { uid: true })) {
+            if (msg.source) {
+              const raw = Buffer.isBuffer(msg.source) ? msg.source.toString('utf8') : String(msg.source);
+              const sep = raw.search(/\r?\n\r?\n/);
+              headers = sep >= 0 ? raw.slice(0, sep) : raw;
+              break;
+            }
           }
         }
+
         return headers;
       } finally {
         lock.release();

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -1,6 +1,6 @@
 import { ImapFlow } from 'imapflow';
 import { query } from './db.js';
-import { parseMessage, snippetFromBody, detectBulkFromParsedHeaders, parseRawHeaders, parseHeadersInput, headersToRawString, decodeMimeWords, enrichParsedMetadata } from './messageParser.js';
+import { parseMessage, snippetFromBody, detectBulkFromParsedHeaders, parseHeadersInput, headersToRawString, decodeMimeWords, enrichParsedMetadata } from './messageParser.js';
 import { classifyMessage, loadSocialDomains, getGlobalCategorizationEnabled } from './categorizer.js';
 import { refreshMicrosoftToken } from '../routes/oauth.js';
 import { sanitizeEmail } from './emailSanitizer.js';

--- a/backend/src/services/messageParser.headers.test.js
+++ b/backend/src/services/messageParser.headers.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseHeadersInput,
+  headersToRawString,
+  buildHeadersFromMessage,
+  enrichParsedMetadata,
+  parseMailboxList,
+} from './messageParser.js';
+
+describe('parseHeadersInput', () => {
+  it('parses Buffer headers', () => {
+    const buf = Buffer.from('Subject: TEST\r\nFrom: a@b.com\r\n');
+    expect(parseHeadersInput(buf)).toEqual({
+      subject: 'TEST',
+      from: 'a@b.com',
+    });
+  });
+
+  it('parses plain objects', () => {
+    expect(parseHeadersInput({ Subject: 'Hello', From: 'x@y.com' })).toEqual({
+      subject: 'Hello',
+      from: 'x@y.com',
+    });
+  });
+});
+
+describe('headersToRawString', () => {
+  it('serializes parsed headers back to text', () => {
+    const raw = headersToRawString(Buffer.from('Subject: TEST\r\nTo: a@b.com\r\n'));
+    expect(raw).toContain('Subject: TEST');
+    expect(raw).toContain('To: a@b.com');
+  });
+});
+
+describe('enrichParsedMetadata', () => {
+  it('fills from account identity for Sent folder when envelope from is empty', () => {
+    const parsed = {
+      fromEmail: '',
+      fromName: '',
+      subject: '(no subject)',
+      to: [],
+      cc: [],
+      parsedHeaders: { subject: 'TEST', to: 'bob@example.com' },
+    };
+    enrichParsedMetadata(parsed, {
+      accountEmail: 'alice@example.com',
+      accountName: 'Alice',
+      senderName: 'Alice S',
+      folderPath: 'INBOX.Sent',
+      sentFolderPath: 'INBOX.Sent',
+    });
+    expect(parsed.fromEmail).toBe('alice@example.com');
+    expect(parsed.fromName).toBe('Alice S');
+    expect(parsed.subject).toBe('TEST');
+    expect(parsed.to).toEqual([{ name: '', email: 'bob@example.com' }]);
+  });
+});
+
+describe('parseMailboxList', () => {
+  it('parses named and bare addresses', () => {
+    expect(parseMailboxList('"Bob" <bob@example.com>, cc@example.com')).toEqual([
+      { name: 'Bob', email: 'bob@example.com' },
+      { name: '', email: 'cc@example.com' },
+    ]);
+  });
+});
+
+describe('buildHeadersFromMessage', () => {
+  it('builds headers from stored message fields', () => {
+    const raw = buildHeadersFromMessage({
+      from_name: 'Alice',
+      from_email: 'alice@example.com',
+      to_addresses: JSON.stringify([{ name: 'Bob', email: 'bob@example.com' }]),
+      subject: 'TEST',
+      message_id: '<abc@mail>',
+      date: '2026-07-11T12:00:00Z',
+    });
+    expect(raw).toContain('From: "Alice" <alice@example.com>');
+    expect(raw).toContain('To: "Bob" <bob@example.com>');
+    expect(raw).toContain('Subject: TEST');
+    expect(raw).toContain('Message-ID: <abc@mail>');
+  });
+});

--- a/backend/src/services/messageParser.js
+++ b/backend/src/services/messageParser.js
@@ -210,6 +210,160 @@ export function parseRawHeaders(buf) {
   return result;
 }
 
+// Normalize imapflow header payloads (Buffer, string, Map-like) into a key/value map.
+export function parseHeadersInput(headers) {
+  if (!headers) return {};
+  if (Buffer.isBuffer(headers) || typeof headers === 'string') return parseRawHeaders(headers);
+  if (typeof headers === 'object') {
+    const result = {};
+    if (typeof headers.forEach === 'function') {
+      headers.forEach((val, key) => {
+        const k = String(key).toLowerCase();
+        const v = Array.isArray(val) ? val.join('\n') : String(val);
+        result[k] = result[k] ? `${result[k]}\n${v}` : v;
+      });
+      if (Object.keys(result).length) return result;
+    }
+    for (const [key, val] of Object.entries(headers)) {
+      const k = String(key).toLowerCase();
+      const v = Array.isArray(val) ? val.join('\n') : String(val);
+      result[k] = result[k] ? `${result[k]}\n${v}` : v;
+    }
+    if (Object.keys(result).length) return result;
+  }
+  return parseRawHeaders(String(headers));
+}
+
+export function headersToRawString(headers) {
+  if (!headers) return '';
+  if (Buffer.isBuffer(headers)) return headers.toString('utf8');
+  const parsed = parseHeadersInput(headers);
+  if (Object.keys(parsed).length) {
+    return Object.entries(parsed)
+      .flatMap(([k, v]) => v.split('\n').map(line => `${k}: ${line}`))
+      .join('\r\n');
+  }
+  const s = String(headers);
+  return s === '[object Object]' ? '' : s;
+}
+
+function formatAddressEntry(entry) {
+  if (typeof entry === 'string') return decodeMimeWords(entry);
+  const email = entry?.email || '';
+  const name = entry?.name || '';
+  if (name && email) return `"${decodeMimeWords(name)}" <${email}>`;
+  return email || decodeMimeWords(name) || '';
+}
+
+function parseAddressJson(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  try {
+    const parsed = typeof value === 'string' ? JSON.parse(value) : value;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+// Build a best-effort RFC822 header block from stored message metadata.
+export function buildHeadersFromMessage(msg) {
+  const lines = [];
+  const fromEmail = msg.from_email || '';
+  const fromName = msg.from_name || '';
+  if (fromEmail || fromName) {
+    lines.push(`From: ${formatAddressEntry({ name: fromName, email: fromEmail })}`);
+  }
+  const to = parseAddressJson(msg.to_addresses);
+  if (to.length) lines.push(`To: ${to.map(formatAddressEntry).join(', ')}`);
+  const cc = parseAddressJson(msg.cc_addresses);
+  if (cc.length) lines.push(`Cc: ${cc.map(formatAddressEntry).join(', ')}`);
+  const replyTo = parseAddressJson(msg.reply_to);
+  if (replyTo.length) lines.push(`Reply-To: ${replyTo.map(formatAddressEntry).join(', ')}`);
+  const subject = msg.subject && msg.subject !== '(no subject)' ? decodeMimeWords(msg.subject) : '';
+  if (subject) lines.push(`Subject: ${subject}`);
+  if (msg.message_id) lines.push(`Message-ID: ${msg.message_id}`);
+  if (msg.date) {
+    try { lines.push(`Date: ${new Date(msg.date).toUTCString()}`); } catch { /* skip */ }
+  }
+  if (msg.in_reply_to) lines.push(`In-Reply-To: ${msg.in_reply_to}`);
+  if (msg.thread_references) lines.push(`References: ${msg.thread_references}`);
+  return lines.join('\r\n');
+}
+
+function resolveSubject(envelopeSubject, parsedHeaders) {
+  const fromEnvelope = envelopeSubject ? decodeMimeWords(envelopeSubject).trim() : '';
+  const fromHeader = parsedHeaders.subject ? decodeMimeWords(parsedHeaders.subject).trim() : '';
+  return fromEnvelope || fromHeader || '(no subject)';
+}
+
+function parseSingleMailbox(str) {
+  const trimmed = decodeMimeWords(str.trim());
+  const m = trimmed.match(/^(.+?)\s*<([^>]+)>\s*$/);
+  if (m) {
+    return {
+      name: m[1].replace(/^"|"$/g, '').trim(),
+      email: m[2].trim().toLowerCase(),
+    };
+  }
+  const bare = trimmed.match(/^\s*<([^>]+)>\s*$/);
+  if (bare) return { name: '', email: bare[1].trim().toLowerCase() };
+  if (trimmed.includes('@')) return { name: '', email: trimmed.toLowerCase() };
+  return { name: trimmed, email: '' };
+}
+
+// Parse a comma-separated RFC 5322 address list (To/Cc/Bcc headers).
+export function parseMailboxList(headerValue) {
+  if (!headerValue) return [];
+  const results = [];
+  let current = '';
+  let inQuote = false;
+  for (let i = 0; i < headerValue.length; i++) {
+    const c = headerValue[i];
+    if (c === '"') inQuote = !inQuote;
+    if (c === ',' && !inQuote) {
+      if (current.trim()) results.push(parseSingleMailbox(current));
+      current = '';
+      continue;
+    }
+    current += c;
+  }
+  if (current.trim()) results.push(parseSingleMailbox(current));
+  return results.filter(r => r.email);
+}
+
+// Fill gaps when IMAP ENVELOPE is incomplete — common for multipart/related Sent copies.
+export function enrichParsedMetadata(parsed, {
+  accountEmail,
+  accountName,
+  senderName,
+  folderPath,
+  sentFolderPath,
+} = {}) {
+  const isSentFolder = (sentFolderPath && folderPath === sentFolderPath)
+    || (typeof folderPath === 'string' && /\bsent\b/i.test(folderPath));
+
+  if (isSentFolder && !parsed.fromEmail && accountEmail) {
+    parsed.fromEmail = accountEmail;
+    parsed.fromName = parsed.fromName || senderName || accountName || '';
+  }
+
+  if ((!parsed.subject || parsed.subject === '(no subject)') && parsed.parsedHeaders?.subject) {
+    const subject = decodeMimeWords(parsed.parsedHeaders.subject).trim();
+    if (subject) parsed.subject = subject;
+  }
+
+  if ((!parsed.to || parsed.to.length === 0) && parsed.parsedHeaders?.to) {
+    parsed.to = parseMailboxList(parsed.parsedHeaders.to);
+  }
+
+  if ((!parsed.cc || parsed.cc.length === 0) && parsed.parsedHeaders?.cc) {
+    parsed.cc = parseMailboxList(parsed.parsedHeaders.cc);
+  }
+
+  return parsed;
+}
+
 export function detectBulkFromParsedHeaders(h) {
   if (!h) return false;
   if (h['list-unsubscribe'] || h['list-id'] || h['list-post']) return true;
@@ -341,16 +495,16 @@ export async function parseMessage(msg) {
     hasAttachments = detectAttachments(msg.bodyStructure);
   }
 
-  const parsedHeaders = msg.headers && Buffer.isBuffer(msg.headers) ? parseRawHeaders(msg.headers) : {};
+  const parsedHeaders = parseHeadersInput(msg.headers);
   const references = (() => {
     if (msg.headers && typeof msg.headers.get === 'function') return msg.headers.get('references') || null;
-    return parsedHeaders['references'] || null;
+    return parsedHeaders.references || null;
   })();
 
   return {
     uid: msg.uid,
     messageId: envelope.messageId || null,
-    subject: envelope.subject || '(no subject)',
+    subject: resolveSubject(envelope.subject, parsedHeaders),
     fromName,
     fromEmail,
     to: mapAddrs(envelope.to),

--- a/backend/src/utils/inlineImages.js
+++ b/backend/src/utils/inlineImages.js
@@ -24,7 +24,6 @@ export function embedInlineDataImages(html) {
 
     const [, , mimeSubtype, b64] = srcMatch;
     const cid = `img-${randomBytes(8).toString('hex')}-${index}@mailflow`;
-    index += 1;
 
     attachments.push({
       filename: `image-${index}.${mimeToExtension(mimeSubtype)}`,
@@ -33,6 +32,7 @@ export function embedInlineDataImages(html) {
       contentDisposition: 'inline',
       contentType: `image/${mimeSubtype}`,
     });
+    index += 1;
 
     const newAttrs = attrs.replace(DATA_SRC_RE, ` src="cid:${cid}"`);
     return `<img${newAttrs}>`;

--- a/backend/src/utils/inlineImages.js
+++ b/backend/src/utils/inlineImages.js
@@ -1,0 +1,42 @@
+import { randomBytes } from 'crypto';
+
+const IMG_TAG_RE = /<img\b([^>]*)>/gi;
+const DATA_SRC_RE = /\ssrc=["'](data:image\/([^;]+);base64,([^"']+))["']/i;
+
+function mimeToExtension(mimeSubtype) {
+  const sub = (mimeSubtype || 'png').toLowerCase();
+  if (sub === 'jpeg') return 'jpg';
+  if (sub === 'svg+xml') return 'svg';
+  return sub.replace(/[^a-z0-9+.-]/g, '') || 'png';
+}
+
+// Convert inline data: images to MIME CID attachments so recipients can display them.
+// Most email clients (Gmail, Outlook, Apple Mail) ignore or strip data: URIs in HTML.
+export function embedInlineDataImages(html) {
+  if (!html) return { html, attachments: [] };
+
+  const attachments = [];
+  let index = 0;
+
+  const rewritten = html.replace(IMG_TAG_RE, (match, attrs) => {
+    const srcMatch = attrs.match(DATA_SRC_RE);
+    if (!srcMatch) return match;
+
+    const [, , mimeSubtype, b64] = srcMatch;
+    const cid = `img-${randomBytes(8).toString('hex')}-${index}@mailflow`;
+    index += 1;
+
+    attachments.push({
+      filename: `image-${index}.${mimeToExtension(mimeSubtype)}`,
+      content: Buffer.from(b64, 'base64'),
+      cid,
+      contentDisposition: 'inline',
+      contentType: `image/${mimeSubtype}`,
+    });
+
+    const newAttrs = attrs.replace(DATA_SRC_RE, ` src="cid:${cid}"`);
+    return `<img${newAttrs}>`;
+  });
+
+  return { html: rewritten, attachments };
+}

--- a/backend/src/utils/inlineImages.test.js
+++ b/backend/src/utils/inlineImages.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { embedInlineDataImages } from './inlineImages.js';
+
+describe('embedInlineDataImages', () => {
+  it('converts data: images to CID inline attachments', () => {
+    const html = '<p><img src="data:image/png;base64,QUJD" width="200">test</p>';
+    const { html: out, attachments } = embedInlineDataImages(html);
+
+    expect(out).toContain('src="cid:img-');
+    expect(out).not.toContain('data:image/png');
+    expect(out).toContain('test');
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].cid).toMatch(/^img-[a-f0-9]+-0@mailflow$/);
+    expect(attachments[0].contentDisposition).toBe('inline');
+    expect(attachments[0].contentType).toBe('image/png');
+    expect(attachments[0].content.equals(Buffer.from('ABC'))).toBe(true);
+  });
+
+  it('leaves remote https images unchanged', () => {
+    const html = '<img src="https://example.com/a.jpg" alt="photo">';
+    const { html: out, attachments } = embedInlineDataImages(html);
+    expect(out).toBe(html);
+    expect(attachments).toHaveLength(0);
+  });
+
+  it('handles multiple inline images with unique CIDs', () => {
+    const html = [
+      '<img src="data:image/png;base64,AA">',
+      '<img src="data:image/jpeg;base64,BB">',
+    ].join('');
+    const { html: out, attachments } = embedInlineDataImages(html);
+    expect(attachments).toHaveLength(2);
+    expect(attachments[0].cid).not.toBe(attachments[1].cid);
+    expect(out.match(/src="cid:/g)).toHaveLength(2);
+  });
+
+  it('returns falsy html unchanged', () => {
+    expect(embedInlineDataImages(null)).toEqual({ html: null, attachments: [] });
+    expect(embedInlineDataImages('')).toEqual({ html: '', attachments: [] });
+  });
+});

--- a/backend/src/utils/inlineImages.test.js
+++ b/backend/src/utils/inlineImages.test.js
@@ -11,6 +11,7 @@ describe('embedInlineDataImages', () => {
     expect(out).toContain('test');
     expect(attachments).toHaveLength(1);
     expect(attachments[0].cid).toMatch(/^img-[a-f0-9]+-0@mailflow$/);
+    expect(attachments[0].filename).toBe('image-0.png');
     expect(attachments[0].contentDisposition).toBe('inline');
     expect(attachments[0].contentType).toBe('image/png');
     expect(attachments[0].content.equals(Buffer.from('ABC'))).toBe(true);
@@ -30,6 +31,10 @@ describe('embedInlineDataImages', () => {
     ].join('');
     const { html: out, attachments } = embedInlineDataImages(html);
     expect(attachments).toHaveLength(2);
+    expect(attachments[0].cid).toMatch(/^img-[a-f0-9]+-0@mailflow$/);
+    expect(attachments[0].filename).toBe('image-0.png');
+    expect(attachments[1].cid).toMatch(/^img-[a-f0-9]+-1@mailflow$/);
+    expect(attachments[1].filename).toBe('image-1.jpg');
     expect(attachments[0].cid).not.toBe(attachments[1].cid);
     expect(out.match(/src="cid:/g)).toHaveLength(2);
   });

--- a/frontend/src/components/MessageHeaderModal.jsx
+++ b/frontend/src/components/MessageHeaderModal.jsx
@@ -3,19 +3,26 @@ import { useTranslation } from 'react-i18next';
 import { api } from '../utils/api.js';
 import { useMobile } from '../hooks/useMobile.js';
 
-export default function MessageHeaderModal({ messageId, subject, onClose }) {
+export default function MessageHeaderModal({ messageId, subject, onClose, onSubjectResolved }) {
   const { t } = useTranslation();
   const isMobile = useMobile();
   const [headers, setHeaders] = useState(null);
+  const [resolvedSubject, setResolvedSubject] = useState(subject);
   const [loading, setLoading] = useState(true);
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     api.getMessageHeaders(messageId)
-      .then(data => setHeaders(data.headers))
+      .then(data => {
+        setHeaders(data.headers);
+        if (data.subject && data.subject !== '(no subject)') {
+          setResolvedSubject(data.subject);
+          onSubjectResolved?.(data.subject);
+        }
+      })
       .catch(err => setHeaders(`Error: ${err.message}`))
       .finally(() => setLoading(false));
-  }, [messageId]);
+  }, [messageId, onSubjectResolved]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(headers || '');
@@ -44,6 +51,10 @@ export default function MessageHeaderModal({ messageId, subject, onClose }) {
     'return-path','received','x-mailer','mime-version','content-type','dkim-signature',
     'authentication-results','x-spam-status','x-spam-score']);
 
+  const displaySubject = (resolvedSubject && resolvedSubject !== '(no subject)')
+    ? resolvedSubject
+    : (parsedHeaders.find(h => h.key.toLowerCase() === 'subject')?.value || t('common.noSubject'));
+
   if (isMobile) {
     return (
       <div style={{
@@ -62,7 +73,7 @@ export default function MessageHeaderModal({ messageId, subject, onClose }) {
               {t('contextMenu.headers.title')}
             </div>
             <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {subject}
+              {displaySubject}
             </div>
           </div>
           <button
@@ -170,7 +181,7 @@ export default function MessageHeaderModal({ messageId, subject, onClose }) {
               fontSize: 12, color: 'var(--text-tertiary)', marginTop: 2,
               maxWidth: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
             }}>
-              {subject}
+              {displaySubject}
             </div>
           </div>
           <div style={{ display: 'flex', gap: 8 }}>

--- a/frontend/src/components/MessageHeaderModal.jsx
+++ b/frontend/src/components/MessageHeaderModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { api } from '../utils/api.js';
 import { useMobile } from '../hooks/useMobile.js';
@@ -10,6 +10,8 @@ export default function MessageHeaderModal({ messageId, subject, onClose, onSubj
   const [resolvedSubject, setResolvedSubject] = useState(subject);
   const [loading, setLoading] = useState(true);
   const [copied, setCopied] = useState(false);
+  const onSubjectResolvedRef = useRef(onSubjectResolved);
+  onSubjectResolvedRef.current = onSubjectResolved;
 
   useEffect(() => {
     api.getMessageHeaders(messageId)
@@ -17,12 +19,12 @@ export default function MessageHeaderModal({ messageId, subject, onClose, onSubj
         setHeaders(data.headers);
         if (data.subject && data.subject !== '(no subject)') {
           setResolvedSubject(data.subject);
-          onSubjectResolved?.(data.subject);
+          onSubjectResolvedRef.current?.(data.subject);
         }
       })
       .catch(err => setHeaders(`Error: ${err.message}`))
       .finally(() => setLoading(false));
-  }, [messageId, onSubjectResolved]);
+  }, [messageId]);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(headers || '');

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -200,6 +200,10 @@ export default function MessagePane() {
   const message = allMessages.find(m => m.id === selectedMessageId)
     ?? Object.values(threadMessages).flat().find(m => m.id === selectedMessageId);
 
+  useEffect(() => {
+    setResolvedSubject(null);
+  }, [message?.id]);
+
   // Antispam (v0.1) — toolbar visibility for the spam / ham buttons.
   // Mirrors the heuristic in ContextMenu.jsx so the toolbar matches the menu.
   const account = accounts.find(a => a.id === message?.account_id);
@@ -263,6 +267,7 @@ export default function MessagePane() {
   const [savingAllow, setSavingAllow] = useState(false);
   const [paneScrolled, setPaneScrolled] = useState(false);
   const [showHeaderModal, setShowHeaderModal] = useState(false);
+  const [resolvedSubject, setResolvedSubject] = useState(null);
   const [showMovePicker, setShowMovePicker] = useState(false);
   const [movePickerFolders, setMovePickerFolders] = useState([]);
   const [movePickerLoading, setMovePickerLoading] = useState(false);
@@ -2085,7 +2090,12 @@ ${bodyContent}
             color: 'var(--text-primary)', lineHeight: 1.3,
             fontFamily: 'var(--font-display)',
           }}>
-            {message.subject || t('message.noSubject')}
+            {(() => {
+              const paneSubject = resolvedSubject || message.subject;
+              return (paneSubject && paneSubject !== '(no subject)')
+                ? paneSubject
+                : t('message.noSubject');
+            })()}
           </div>
 
           <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, padding: '12px 16px' }}>
@@ -2731,8 +2741,12 @@ ${bodyContent}
       {showHeaderModal && (
         <MessageHeaderModal
           messageId={message.id}
-          subject={message.subject}
+          subject={resolvedSubject || message.subject}
           onClose={() => setShowHeaderModal(false)}
+          onSubjectResolved={(s) => {
+            setResolvedSubject(s);
+            updateMessage(message.id, { subject: s });
+          }}
         />
       )}
 


### PR DESCRIPTION
## Summary

Fixes #237: images pasted or inserted in the rich-text compose editor were silently removed on send because the backend HTML sanitizer did not allow `img` `src` attributes, so `data:image/...` tags were stripped before Nodemailer ran.

This PR allows images in compose HTML, converts Base64 `data:` URIs into inline CID MIME attachments (the format email clients actually render), and hardens Sent-folder sync so `multipart/related` copies do not lose subject/header metadata when IMAP returns an incomplete envelope.

## Changes

- Add `sanitizeComposeBody()` so compose HTML keeps `img` tags with `data:` and `https:` sources
- Add `embedInlineDataImages()` to rewrite `data:` images as `cid:` references and attach them inline via Nodemailer
- Use both helpers in `/mail/send` and draft save paths
- Upsert authoritative Sent metadata immediately after IMAP APPEND (subject, from, to) so later sync cannot wipe it
- Stop IMAP `ON CONFLICT` updates from overwriting existing metadata with empty envelope values
- Enrich parsed message metadata from RFC822 headers and account identity for Sent-folder messages
- Improve full-headers fetch (IMAP fallback + DB reconstruction) and subject display in the message pane

## Testing

- [x] `npm test` in `backend/` — 289 tests pass, including new coverage for `sanitizeComposeBody`, `embedInlineDataImages`, and header/metadata helpers
- [x] Manual: compose email with pasted/inserted image → send → image visible in recipient inbox
- [x] Manual: sent copy in Sent folder shows correct subject, sender, and recipients (including multipart/related messages)
- [x] Manual: “View full headers” shows Subject/From/To instead of empty state

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.