### PR TITLE
fix: archive falls back to Gmail All Mail instead of silently no-oping

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -7,7 +7,7 @@ import { requireAuth } from '../middleware/auth.js';
 import { imapManager } from '../index.js';
 import { sanitizeEmail, stripEmailHead, hasRemoteImages, blockRemoteImages, rewriteEbayImageserUrls, rewriteAnchorHrefs } from '../services/emailSanitizer.js';
 import { snippetFromBody, decodeMimeWords, parseRawHeaders, buildHeadersFromMessage } from '../services/messageParser.js';
-import { resolveTrashFolder, resolveAllTrashPaths, resolveAllDraftsPaths, resolveArchiveFolder, resolveSpamFolder, resolveAllSpamPaths, getDeleteStrategy, adjustFolderCounts } from '../utils/mailUtils.js';
+import { resolveTrashFolder, resolveAllTrashPaths, resolveAllDraftsPaths, resolveArchiveFolder, isAllMailFolder, resolveSpamFolder, resolveAllSpamPaths, getDeleteStrategy, adjustFolderCounts } from '../utils/mailUtils.js';
 import { listMessages } from '../services/messageService.js';
 import { validateHost } from '../services/hostValidation.js';
 import { safeFetch } from '../services/safeFetch.js';
@@ -1278,12 +1278,19 @@ router.post('/messages/bulk-archive', async (req, res) => {
     const archivedIds = [];
     const noArchiveFolder = [];
     const accountsById = {};
+    // Archive-folder paths that resolved to Gmail's All Mail (special_use '\All').
+    // All Mail is excluded from sync/backfill and the relocate guard (imapManager.js),
+    // so messages archived there get their DB row deleted below instead of re-homed.
+    const allMailDestFolders = new Set();
 
     for (const [accountId, msgs] of Object.entries(byAccount)) {
       const archiveFolder = await resolveArchiveFolder(accountId, msgs[0].folder_mappings);
       if (!archiveFolder) {
         noArchiveFolder.push(accountId);
         continue;
+      }
+      if (await isAllMailFolder(accountId, archiveFolder)) {
+        allMailDestFolders.add(archiveFolder);
       }
 
       const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [accountId]);
@@ -1304,13 +1311,19 @@ router.post('/messages/bulk-archive', async (req, res) => {
       }
     }
 
-    // Update DB: same CTE DELETE+INSERT pattern as bulk-move.
+    // Update DB: same CTE DELETE+INSERT pattern as bulk-move — except when the
+    // destination is Gmail's All Mail, where the message just vanishes from our view
+    // (see allMailDestFolders above), so a plain DELETE with no reinsert is correct.
     const byFolder = {};
     for (const { id, folder, newUid } of archivedIds) {
       (byFolder[folder] = byFolder[folder] || []).push({ id, newUid });
     }
     for (const [archiveFolder, entries] of Object.entries(byFolder)) {
       const allIds  = entries.map(e => e.id);
+      if (allMailDestFolders.has(archiveFolder)) {
+        await query('DELETE FROM messages WHERE id = ANY($1::uuid[])', [allIds]);
+        continue;
+      }
       const withUid = entries.filter(e => e.newUid != null);
       await query(`
         WITH deleted AS (
@@ -1349,6 +1362,7 @@ router.post('/messages/bulk-archive', async (req, res) => {
     const needResync = new Map(); // accountId -> Set<archiveFolder>
     for (const e of archivedIds) {
       if (e.newUid) continue;
+      if (allMailDestFolders.has(e.folder)) continue; // no DB row there to keep fresh
       if (!needResync.has(e.accountId)) needResync.set(e.accountId, new Set());
       needResync.get(e.accountId).add(e.folder);
     }
@@ -1373,6 +1387,7 @@ router.post('/messages/bulk-archive', async (req, res) => {
         if (!folderDeltas[srcKey]) folderDeltas[srcKey] = { accountId: msg.account_id, path: msg.folder, totalDelta: 0, unreadDelta: 0 };
         folderDeltas[srcKey].totalDelta--;
         folderDeltas[srcKey].unreadDelta -= wasUnread;
+        if (allMailDestFolders.has(dest)) continue; // All Mail counts aren't tracked
         const dstKey = `${msg.account_id}:${dest}`;
         if (!folderDeltas[dstKey]) folderDeltas[dstKey] = { accountId: msg.account_id, path: dest, totalDelta: 0, unreadDelta: 0 };
         folderDeltas[dstKey].totalDelta++;
@@ -1382,7 +1397,7 @@ router.post('/messages/bulk-archive', async (req, res) => {
         adjustFolderCounts(accountId, path, totalDelta, unreadDelta);
       }
       // Notify clients viewing each destination folder to refresh silently.
-      const destFolders = [...new Set(archivedIds.map(a => a.folder))];
+      const destFolders = [...new Set(archivedIds.map(a => a.folder))].filter(f => !allMailDestFolders.has(f));
       for (const dest of destFolders) {
         const accountIds = [...new Set(archivedIds.filter(a => a.folder === dest).map(a => {
           const msg = owned.find(m => m.id === a.id);

--- a/backend/src/services/inboxRules.js
+++ b/backend/src/services/inboxRules.js
@@ -1,5 +1,5 @@
 import { query } from './db.js';
-import { resolveArchiveFolder, resolveTrashFolder, resolveAllTrashPaths, getDeleteStrategy, adjustFolderCounts } from '../utils/mailUtils.js';
+import { resolveArchiveFolder, isAllMailFolder, resolveTrashFolder, resolveAllTrashPaths, getDeleteStrategy, adjustFolderCounts } from '../utils/mailUtils.js';
 
 async function getRulesForAccount(userId, accountId) {
   const result = await query(
@@ -410,6 +410,11 @@ async function applyAction(action, msg, account, imapManager, resolverCache = {}
       if (!resolverCache._archiveResolved) {
         resolverCache._archiveResolved = true;
         resolverCache.archiveFolder = await resolveArchiveFolder(account.id, account.folder_mappings);
+        // Gmail's All Mail (special_use '\All') is excluded from sync/backfill and the
+        // relocate guard (imapManager.js) — see mailUtils.js resolveArchiveFolder/isAllMailFolder.
+        resolverCache.archiveIsAllMail = resolverCache.archiveFolder
+          ? await isAllMailFolder(account.id, resolverCache.archiveFolder)
+          : false;
       }
       const archiveFolder = resolverCache.archiveFolder;
       if (!archiveFolder) return false;
@@ -420,16 +425,20 @@ async function applyAction(action, msg, account, imapManager, resolverCache = {}
         const archiveResult = await imapManager.bulkMoveMessages(account, [srcUid], srcFolder, archiveFolder);
         if (archiveResult.failed?.length) throw new Error(`IMAP archive failed for uid ${srcUid}`);
         const newArchiveUid = archiveResult.uidMap?.get(Number(srcUid));
-        if (newArchiveUid) {
+        const wasUnread = !(msg.isRead ?? msg.is_read);
+        if (resolverCache.archiveIsAllMail) {
+          // No sync loop maintains a messages row filed under All Mail — the message
+          // vanishes from our view instead of getting re-homed there (see mail.js bulk-archive).
+          await query('DELETE FROM messages WHERE id = $1', [msg.id]);
+        } else if (newArchiveUid) {
           await query('UPDATE messages SET folder = $1, uid = $2 WHERE id = $3', [archiveFolder, newArchiveUid, msg.id]);
         } else {
           imapManager._guardMoveUid(account.id, archiveFolder, srcUid);
           await query('UPDATE messages SET folder = $1 WHERE id = $2', [archiveFolder, msg.id]);
           setTimeout(() => imapManager._unguardMoveUid(account.id, archiveFolder, srcUid), 10_000);
         }
-        const wasUnread = !(msg.isRead ?? msg.is_read);
         adjustFolderCounts(account.id, srcFolder, -1, wasUnread ? -1 : 0);
-        adjustFolderCounts(account.id, archiveFolder, 1, wasUnread ? 1 : 0);
+        if (!resolverCache.archiveIsAllMail) adjustFolderCounts(account.id, archiveFolder, 1, wasUnread ? 1 : 0);
         msg.folder = archiveFolder;
         msg.uid = newArchiveUid || srcUid;
       } finally {

--- a/backend/src/services/inboxRules.test.js
+++ b/backend/src/services/inboxRules.test.js
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('./db.js', () => ({ query: vi.fn() }));
 vi.mock('../utils/mailUtils.js', () => ({
   resolveArchiveFolder: vi.fn(),
+  isAllMailFolder: vi.fn(),
   resolveTrashFolder: vi.fn(),
   resolveAllTrashPaths: vi.fn(),
   getDeleteStrategy: vi.fn(),
@@ -10,7 +11,7 @@ vi.mock('../utils/mailUtils.js', () => ({
 }));
 
 const { query } = await import('./db.js');
-const { resolveArchiveFolder, adjustFolderCounts } = await import('../utils/mailUtils.js');
+const { resolveArchiveFolder, isAllMailFolder, adjustFolderCounts } = await import('../utils/mailUtils.js');
 import { applyInboxRules } from './inboxRules.js';
 
 const account = { id: 'acc-1', user_id: 'user-1', folder_mappings: {} };
@@ -158,6 +159,28 @@ describe('applyInboxRules — destination action no-ops do not remove message', 
 
     expect(result.remaining).toHaveLength(1);
     expect(mockImap.bulkMoveMessages).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyInboxRules — archive to Gmail All Mail', () => {
+  it('deletes the message row instead of re-homing it into the All Mail folder', async () => {
+    const rule = mkRule([{ type: 'archive', value: '' }]);
+    query
+      .mockResolvedValueOnce({ rows: [rule] })                  // getRulesForAccount
+      .mockResolvedValueOnce({ rows: [] });                      // DELETE FROM messages
+    resolveArchiveFolder.mockResolvedValue('[Gmail]/All Mail');
+    isAllMailFolder.mockResolvedValue(true);
+    mockImap.bulkMoveMessages.mockResolvedValue({ failed: [], uidMap: new Map([[100, 200]]) });
+
+    const result = await applyInboxRules([mkMsg({ is_read: false })], account, mockImap);
+
+    expect(result.remaining).toHaveLength(0); // message removed from inbox
+    const deleteCall = query.mock.calls[1];
+    expect(deleteCall[0]).toMatch(/DELETE FROM messages/);
+    expect(deleteCall[1]).toEqual(['msg-1']);
+    // Source folder count decrements; All Mail destination count is never touched.
+    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX', -1, -1);
+    expect(adjustFolderCounts).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/backend/src/utils/mailUtils.js
+++ b/backend/src/utils/mailUtils.js
@@ -39,16 +39,42 @@ export async function resolveAllDraftsPaths(accountId, folderMappings) {
   return new Set(result.rows.map(r => r.path));
 }
 
+// Resolve the canonical archive folder path for an account.
+// folder_mappings.archive (user-configured) takes priority over special_use and the
+// name heuristic. Falls back to special_use = '\All' (Gmail's "All Mail") last, since
+// stock Gmail over IMAP exposes no '\Archive' folder — archiving there means moving
+// the message to All Mail, which strips the INBOX label.
+// IMPORTANT: callers that persist the destination back to the messages table must
+// special-case an '\All' result — see isAllMailFolder below.
 export async function resolveArchiveFolder(accountId, folderMappings) {
   if (folderMappings?.archive) return folderMappings.archive;
   const result = await query(
     `SELECT path FROM folders WHERE account_id = $1
-     AND (special_use = '\\Archive' OR lower(name) LIKE '%archive%')
-     ORDER BY (CASE WHEN special_use = '\\Archive' THEN 0 ELSE 1 END)
+     AND (special_use = '\\Archive' OR lower(name) LIKE '%archive%' OR special_use = '\\All')
+     ORDER BY (CASE
+       WHEN special_use = '\\Archive' THEN 0
+       WHEN lower(name) LIKE '%archive%' THEN 1
+       ELSE 2
+     END)
      LIMIT 1`,
     [accountId]
   );
   return result.rows[0]?.path || null;
+}
+
+// True when `path` is this account's Gmail-style "All Mail" folder (special_use = '\All').
+// All Mail is excluded from sync/backfill (imapManager.js skipFolderPatterns) and from
+// the relocate guard, so no sync loop ever maintains a messages row filed under it.
+// Callers that move a message there (see resolveArchiveFolder) must delete the source
+// row instead of re-homing it into folder = <All Mail path> — the message should
+// simply vanish from our view, matching how the app treats All Mail everywhere else.
+export async function isAllMailFolder(accountId, path) {
+  if (!path) return false;
+  const result = await query(
+    `SELECT 1 FROM folders WHERE account_id = $1 AND path = $2 AND special_use = '\\All'`,
+    [accountId, path]
+  );
+  return result.rows.length > 0;
 }
 
 // Resolve the canonical spam/junk folder path for an account.

--- a/backend/src/utils/mailUtils.test.js
+++ b/backend/src/utils/mailUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { resolveTrashFolder, resolveArchiveFolder, resolveSpamFolder, getDeleteStrategy } from './mailUtils.js';
+import { resolveTrashFolder, resolveArchiveFolder, isAllMailFolder, resolveSpamFolder, getDeleteStrategy } from './mailUtils.js';
 
 vi.mock('../services/db.js', () => ({
   query: vi.fn(),
@@ -58,17 +58,45 @@ describe('resolveArchiveFolder', () => {
     expect(result).toBe('INBOX.archive-2024');
   });
 
+  it('falls back to special_use=\\All (Gmail All Mail) when nothing else matches', async () => {
+    query.mockResolvedValue({ rows: [{ path: '[Gmail]/All Mail' }] });
+    const result = await resolveArchiveFolder(4, {});
+    expect(result).toBe('[Gmail]/All Mail');
+  });
+
   it('returns null when no archive folder is found', async () => {
     query.mockResolvedValue({ rows: [] });
     const result = await resolveArchiveFolder(3, undefined);
     expect(result).toBeNull();
   });
 
-  it('uses ORDER BY to prefer special_use match over name heuristic', async () => {
+  it('uses ORDER BY to prefer special_use=\\Archive, then name match, then \\All last', async () => {
     query.mockResolvedValue({ rows: [] });
     await resolveArchiveFolder(1, null);
     const sql = query.mock.calls[0][0];
-    expect(sql).toContain("CASE WHEN special_use = '\\Archive' THEN 0 ELSE 1 END");
+    expect(sql).toContain("WHEN special_use = '\\Archive' THEN 0");
+    expect(sql).toContain("WHEN lower(name) LIKE '%archive%' THEN 1");
+  });
+});
+
+describe('isAllMailFolder', () => {
+  it('returns false without querying the DB when path is falsy', async () => {
+    const result = await isAllMailFolder(1, null);
+    expect(result).toBe(false);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('returns true when the folder row has special_use = \\All', async () => {
+    query.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    const result = await isAllMailFolder(1, '[Gmail]/All Mail');
+    expect(result).toBe(true);
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  it('returns false when no matching \\All row exists', async () => {
+    query.mockResolvedValue({ rows: [] });
+    const result = await isAllMailFolder(1, 'Archive');
+    expect(result).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Gmail-style accounts have no `\Archive` folder; archiving there means removing the message from INBOX while it stays in All Mail. `resolveArchiveFolder` returned null for these accounts, so the archive route and inbox rules silently skipped the message.

## Changes

- Add an `\All` fallback in `resolveArchiveFolder` and an `isAllMailFolder` helper.
- At the archive call sites, remove the INBOX copy instead of duplicating the message into All Mail.

## Testing

`mailUtils.test.js` covers the fallback and `isAllMailFolder`; `inboxRules.test.js` gains an All-Mail archive case. The full backend suite passes.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
