### PR TITLE
fix: scope snooze-wakeup UPDATEs to the snoozed folder

### DIFF
--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -4040,16 +4040,16 @@ export class ImapManager {
           // Update DB: change folder, mark unread, and update UID if the move returned one.
           if (newUid != null) {
             await query(
-              'UPDATE messages SET folder = $1, is_read = false, read_changed_at = NOW(), uid = $4 WHERE account_id = $2 AND message_id = $3',
-              [row.original_folder, row.account_id, row.message_id_header, newUid]
+              'UPDATE messages SET folder = $1, is_read = false, read_changed_at = NOW(), uid = $4 WHERE account_id = $2 AND message_id = $3 AND folder = $5',
+              [row.original_folder, row.account_id, row.message_id_header, newUid, row.snoozed_folder]
             );
           } else {
             // Non-UIDPLUS: DB holds the stale source UID at the destination. Guard it so
             // reconcileDeletes does not treat it as an orphan before the next sync corrects it.
             this._guardMoveUid(row.account_id, row.original_folder, row.uid);
             await query(
-              'UPDATE messages SET folder = $1, is_read = false, read_changed_at = NOW() WHERE account_id = $2 AND message_id = $3',
-              [row.original_folder, row.account_id, row.message_id_header]
+              'UPDATE messages SET folder = $1, is_read = false, read_changed_at = NOW() WHERE account_id = $2 AND message_id = $3 AND folder = $4',
+              [row.original_folder, row.account_id, row.message_id_header, row.snoozed_folder]
             );
             setTimeout(() => this._unguardMoveUid(row.account_id, row.original_folder, row.uid), 10_000);
           }


### PR DESCRIPTION
## Summary

`_runSnoozeWakeup` re-homes a woken message with `UPDATE messages … WHERE account_id = $2 AND message_id = $3` and no folder filter. When the same RFC Message-ID exists in several folders (over IMAP, Gmail labels are folder copies), wakeup could move an unrelated copy.

## Changes

Add `AND folder = <snoozed_folder>` to both UPDATE variants in `imapManager.js`.

## Testing

The change narrows an existing UPDATE; the full backend suite passes.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
