### PR TITLE
fix: warn when shortcut key assignments collide

### DIFF
--- a/frontend/src/utils/defaultShortcuts.js
+++ b/frontend/src/utils/defaultShortcuts.js
@@ -74,23 +74,34 @@ export function parseModKey(key) {
 }
 
 // Returns the reverse lookup map: key → action, for fast dispatch (plain keys only).
+// Collisions (two actions resolving to the same key, e.g. via user overrides)
+// keep last-writer-wins behavior but are logged so they're not silently lost.
 export function buildKeyMap(userOverrides = {}) {
   const effective = getEffectiveShortcuts(userOverrides);
   const map = {};
   for (const [action, key] of Object.entries(effective)) {
-    if (key && !parseModKey(key)) map[key] = action;
+    if (!key || parseModKey(key)) continue;
+    if (map[key]) {
+      console.warn(`[shortcuts] key "${key}" is bound to both "${map[key]}" and "${action}"; "${action}" wins`);
+    }
+    map[key] = action;
   }
   return map;
 }
 
 // Returns a reverse lookup for modifier+key shortcuts: bare key → action.
 // e.g. { p: 'printMessage' } when printMessage is bound to 'ctrl+p'.
+// Collisions are logged the same way as buildKeyMap (see above).
 export function buildModKeyMap(userOverrides = {}) {
   const effective = getEffectiveShortcuts(userOverrides);
   const map = {};
   for (const [action, key] of Object.entries(effective)) {
     const parsed = parseModKey(key);
-    if (parsed) map[parsed.bare] = action;
+    if (!parsed) continue;
+    if (map[parsed.bare]) {
+      console.warn(`[shortcuts] key "${parsed.bare}" is bound to both "${map[parsed.bare]}" and "${action}"; "${action}" wins`);
+    }
+    map[parsed.bare] = action;
   }
   return map;
 }

--- a/frontend/src/utils/defaultShortcuts.test.js
+++ b/frontend/src/utils/defaultShortcuts.test.js
@@ -1,0 +1,44 @@
+// Run with: node --test src/utils/defaultShortcuts.test.js
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildKeyMap, buildModKeyMap } from './defaultShortcuts.js';
+
+describe('buildKeyMap', () => {
+  it('does not warn when no overrides are given (defaults have no collisions)', (t) => {
+    const warn = t.mock.method(console, 'warn', () => {});
+    buildKeyMap();
+    assert.equal(warn.mock.callCount(), 0);
+  });
+
+  it('warns and keeps last-writer-wins when an override collides with a default key', (t) => {
+    const warn = t.mock.method(console, 'warn', () => {});
+    // 'archive' defaults to 'e'; override 'delete' (default '#') to the same key.
+    const map = buildKeyMap({ delete: 'e' });
+    assert.equal(warn.mock.callCount(), 1);
+    const [message] = warn.mock.calls[0].arguments;
+    assert.match(message, /"e"/);
+    assert.match(message, /"archive"/);
+    assert.match(message, /"delete"/);
+    assert.equal(map.e, 'delete', 'later action (delete) should win');
+  });
+});
+
+describe('buildModKeyMap', () => {
+  it('does not warn when no overrides are given (defaults have no collisions)', (t) => {
+    const warn = t.mock.method(console, 'warn', () => {});
+    buildModKeyMap();
+    assert.equal(warn.mock.callCount(), 0);
+  });
+
+  it('warns and keeps last-writer-wins when an override collides on a modifier+key', (t) => {
+    const warn = t.mock.method(console, 'warn', () => {});
+    // 'printMessage' defaults to 'ctrl+p'; override 'toggleStar' (default 's') to the same combo.
+    const map = buildModKeyMap({ toggleStar: 'ctrl+p' });
+    assert.equal(warn.mock.callCount(), 1);
+    const [message] = warn.mock.calls[0].arguments;
+    assert.match(message, /"p"/);
+    assert.match(message, /"toggleStar"/);
+    assert.match(message, /"printMessage"/);
+    assert.equal(map.p, 'printMessage', 'later action (printMessage) should win');
+  });
+});


### PR DESCRIPTION
## Summary

`buildKeyMap` and `buildModKeyMap` let a later action silently take a key already bound to an earlier one, so a customized shortcut could disable a default with no trace.

## Changes

Both builders now `console.warn`, naming the two colliding actions and the winner.

## Testing

New `defaultShortcuts.test.js` covers both builders and the collision paths. The full frontend suite passes.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
