### PR TITLE
feat: add Fastmail identity and Masked Email alias sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,23 @@ Gmail requires an **App Password** (not your normal password):
 | SMTP Port | `587` |
 | Username | your full iCloud email (`you@icloud.com`) |
 
+### Fastmail
+
+Fastmail uses two credentials for different responsibilities:
+
+1. Create a Fastmail app password and enter it in the account's **Password** field for IMAP and SMTP access.
+2. Create a Fastmail API token with **Email submission** and **Masked Email** permissions, then enter it in the **Fastmail API token** field.
+
+| Setting | Value |
+|---|---|
+| IMAP Host | `imap.fastmail.com` |
+| IMAP Port | `993` |
+| SMTP Host | `smtp.fastmail.com` |
+| SMTP Port | `465` |
+| Username | your full Fastmail email (`you@fastmail.com`) |
+
+MailFlow uses the API token to synchronize the sending identities and masked addresses that Fastmail authorizes. Manage provider-owned addresses in Fastmail, then use **Refresh addresses** in MailFlow when you need an immediate synchronization.
+
 ### Microsoft 365 / Outlook (OAuth2)
 
 **Work / school accounts (Microsoft 365):** require modern auth via Azure App Registration:

--- a/backend/migrations/0030_fastmail_alias_sync.sql
+++ b/backend/migrations/0030_fastmail_alias_sync.sql
@@ -1,0 +1,62 @@
+-- Fastmail alias/identity sync (v0.1)
+--
+-- Mirrors a Fastmail account's sending identities and Masked Email addresses into
+-- MailFlow so the user can send from any of them. All added columns are nullable or
+-- defaulted so existing rows stay valid.
+
+ALTER TABLE email_accounts
+  ADD COLUMN IF NOT EXISTS fastmail_api_token TEXT,
+  ADD COLUMN IF NOT EXISTS fastmail_last_sync TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS fastmail_sync_error TEXT;
+
+ALTER TABLE account_aliases
+  ADD COLUMN IF NOT EXISTS provenance VARCHAR(20) NOT NULL DEFAULT 'manual',
+  ADD COLUMN IF NOT EXISTS fastmail_identity_id VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS fastmail_masked_email_id VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS fastmail_label TEXT,
+  ADD COLUMN IF NOT EXISTS fastmail_reply_to JSONB NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS fastmail_bcc JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- provenance separates user-created aliases ('manual', freely editable) from rows
+-- mirrored out of Fastmail ('fastmail', read-only in the UI and replaced on each sync).
+-- Guard the constraint so re-running the migration is a no-op.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'account_aliases_provenance_check'
+  ) THEN
+    ALTER TABLE account_aliases
+      ADD CONSTRAINT account_aliases_provenance_check
+      CHECK (provenance IN ('manual', 'fastmail'));
+  END IF;
+END $$;
+
+-- One row per Fastmail identity and per Masked Email, scoped to the account. Partial so
+-- only Fastmail-provenanced rows are constrained, and unique so reconciliation matches an
+-- existing row by its provider ID instead of inserting a duplicate.
+CREATE UNIQUE INDEX IF NOT EXISTS account_aliases_fastmail_identity_idx
+  ON account_aliases (account_id, fastmail_identity_id)
+  WHERE provenance = 'fastmail' AND fastmail_identity_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS account_aliases_fastmail_mask_idx
+  ON account_aliases (account_id, fastmail_masked_email_id)
+  WHERE provenance = 'fastmail' AND fastmail_masked_email_id IS NOT NULL;
+
+-- Claim table that dedupes masked-email -> identity promotion across concurrent syncs: a
+-- worker inserts a claim row before creating the Fastmail identity so a second worker
+-- (even in another process) sees the pending claim and backs off. Claims are reclaimable
+-- after a TTL so a crashed promotion can be retried; the TTL reasoning lives in
+-- fastmailAliasSync.js (FASTMAIL_PROMOTION_CLAIM_TTL).
+CREATE TABLE IF NOT EXISTS fastmail_identity_promotions (
+  account_id UUID NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  masked_email_id VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  claimed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (account_id, masked_email_id)
+);
+
+-- Addresses a message was delivered to, captured at ingest. Reply-sender resolution
+-- matches these (plus To/Cc) against the account's identities and Masked Email addresses
+-- to pick which alias a reply should come From (senderResolver.js).
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS delivery_addresses JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -35,6 +35,7 @@ import { parseVCard } from './utils/vcard.js';
 import { reloadAuthSettings } from './services/authLimiter.js';
 import { setupWebSocket } from './services/websocket.js';
 import { ImapManager } from './services/imapManager.js';
+import { startFastmailAliasScheduler } from './services/fastmailAliasSync.js';
 
 const packageMeta = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
 let buildMeta = {};
@@ -207,6 +208,9 @@ await reloadAuthSettings();
 
 // Encrypt any plaintext credentials left in the DB from before this feature was added
 await encryptExistingCredentials();
+
+// Start an immediate Fastmail identity refresh and continue on the background cadence.
+startFastmailAliasScheduler();
 
 // Load OAuth integration configs from DB into process.env
 await loadIntegrationConfigs();

--- a/backend/src/routes/accounts.fastmail.test.js
+++ b/backend/src/routes/accounts.fastmail.test.js
@@ -1,0 +1,267 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/db.js', () => ({
+  query: vi.fn(),
+  withTransaction: vi.fn(),
+}));
+vi.mock('../index.js', () => ({
+  imapManager: {
+    connectAccount: vi.fn().mockResolvedValue(undefined),
+    disconnectAccount: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => {
+    req.session = { userId: 'u1' };
+    next();
+  },
+}));
+vi.mock('../services/encryption.js', () => ({
+  encrypt: vi.fn(value => value ? `encrypted:${value}` : value),
+}));
+vi.mock('../services/fastmailClient.js', async importOriginal => {
+  const actual = await importOriginal();
+  return { ...actual, loadFastmailSession: vi.fn() };
+});
+vi.mock('../services/fastmailAliasSync.js', () => ({
+  syncFastmailAliases: vi.fn(),
+}));
+vi.mock('../services/connectionPolicy.js', () => ({
+  getConnectionPolicy: vi.fn().mockResolvedValue({
+    allowPrivateHosts: false,
+    allowNonstandardPorts: false,
+  }),
+}));
+
+import express from 'express';
+import { query, withTransaction } from '../services/db.js';
+import { fastmailConfigError, fastmailSyncError, loadFastmailSession } from '../services/fastmailClient.js';
+import { syncFastmailAliases } from '../services/fastmailAliasSync.js';
+import accountRoutes from './accounts.js';
+
+const aliasBody = {
+  name: 'Fastmail Alias',
+  email: 'alias@example.com',
+  reply_to: null,
+  signature: null,
+};
+
+const tx = { query: vi.fn() };
+let server;
+let base;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/accounts', accountRoutes);
+  return app;
+}
+
+const api = (path, { method = 'GET', body } = {}) => fetch(`${base}${path}`, {
+  method,
+  headers: body === undefined ? {} : { 'Content-Type': 'application/json' },
+  body: body === undefined ? undefined : JSON.stringify(body),
+});
+
+beforeAll(async () => {
+  await new Promise(resolve => { server = buildApp().listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+beforeEach(() => {
+  query.mockReset();
+  withTransaction.mockReset();
+  tx.query.mockReset();
+  tx.query.mockResolvedValue({ rows: [] });
+  withTransaction.mockImplementation(fn => fn(tx));
+  loadFastmailSession.mockResolvedValue({ apiUrl: 'https://api.fastmail.com/jmap/api/' });
+  syncFastmailAliases.mockResolvedValue([]);
+});
+
+describe('Fastmail account API boundary', () => {
+  it('never returns fastmail_api_token and reports only configuration state', async () => {
+    query.mockResolvedValueOnce({ rows: [{
+      id: 'a1', user_id: 'u1', email_address: 'owner@example.com',
+      fastmail_api_token: 'enc:v1:secret', fastmail_last_sync: null,
+      fastmail_sync_error: null,
+    }] });
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const res = await api('/accounts');
+    const body = await res.json();
+    expect(body[0].fastmail_configured).toBe(true);
+    expect(body[0]).not.toHaveProperty('fastmail_api_token');
+  });
+
+  it('rejects editing and deleting provider-managed aliases', async () => {
+    query.mockResolvedValue({ rows: [{ id: 'al1', provenance: 'fastmail' }] });
+    expect((await api('/accounts/a1/aliases/al1', { method: 'PUT', body: aliasBody })).status).toBe(409);
+    expect((await api('/accounts/a1/aliases/al1', { method: 'DELETE' })).status).toBe(409);
+  });
+
+  it('disconnects Fastmail atomically without deleting manual aliases', async () => {
+    query.mockResolvedValue({ rows: [{ id: 'a1' }] });
+    tx.query.mockResolvedValueOnce({ rows: [{ id: 'a1', user_id: 'u1', fastmail_api_token: null }] });
+
+    const res = await api('/accounts/a1', { method: 'PUT', body: { fastmail_api_token: null } });
+    const body = await res.json();
+
+    expect(withTransaction).toHaveBeenCalledTimes(1);
+    expect(tx.query).toHaveBeenCalledWith(
+      "DELETE FROM account_aliases WHERE account_id = $1 AND provenance = 'fastmail'",
+      ['a1'],
+    );
+    expect(tx.query.mock.calls.some(([sql]) => sql.includes('fastmail_identity_promotions'))).toBe(false);
+    expect(body.fastmail_configured).toBe(false);
+    expect(body).not.toHaveProperty('fastmail_api_token');
+  });
+
+  it('validates a token before inserting an account and maps configuration errors to 422', async () => {
+    loadFastmailSession.mockRejectedValue(fastmailConfigError('Fastmail API token is missing Masked Email permission'));
+
+    const res = await api('/accounts', { method: 'POST', body: {
+      name: 'Fastmail', email_address: 'owner@example.com',
+      fastmail_api_token: 'invalid-token',
+    } });
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: 'Fastmail API token is missing Masked Email permission' });
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('still creates the account when token validation hits a transient reach failure', async () => {
+    loadFastmailSession.mockRejectedValue(fastmailSyncError('Could not reach Fastmail'));
+    query
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', name: 'Fastmail', email_address: 'owner@example.com',
+        fastmail_api_token: 'encrypted:valid-token',
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', name: 'Fastmail', email_address: 'owner@example.com',
+        fastmail_api_token: 'encrypted:valid-token',
+        fastmail_sync_error: 'Could not reach Fastmail',
+      }] })
+      .mockResolvedValueOnce({ rows: [] });
+    syncFastmailAliases.mockRejectedValue(fastmailSyncError('Could not reach Fastmail'));
+
+    const res = await api('/accounts', { method: 'POST', body: {
+      name: 'Fastmail', email_address: 'owner@example.com',
+      fastmail_api_token: 'valid-token',
+    } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.fastmail_configured).toBe(true);
+    expect(body.fastmail_sync_error).toBe('Could not reach Fastmail');
+    expect(body).not.toHaveProperty('fastmail_api_token');
+    expect(syncFastmailAliases).toHaveBeenCalledWith('a1');
+  });
+
+  it('retains a newly saved account and returns its safe sync status when initial sync fails', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', name: 'Fastmail', email_address: 'owner@example.com',
+        fastmail_api_token: 'encrypted:valid-token',
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', name: 'Fastmail', email_address: 'owner@example.com',
+        fastmail_api_token: 'encrypted:valid-token',
+        fastmail_sync_error: 'Could not reach Fastmail',
+      }] })
+      .mockResolvedValueOnce({ rows: [] });
+    syncFastmailAliases.mockRejectedValue(new Error('private remote detail'));
+
+    const res = await api('/accounts', { method: 'POST', body: {
+      name: 'Fastmail', email_address: 'owner@example.com',
+      fastmail_api_token: 'valid-token',
+    } });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.fastmail_sync_error).toBe('Could not reach Fastmail');
+    expect(body.fastmail_configured).toBe(true);
+    expect(body).not.toHaveProperty('fastmail_api_token');
+    expect(syncFastmailAliases).toHaveBeenCalledWith('a1');
+  });
+
+  it('validates a replacement token before updating the account row', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 'a1' }] });
+    loadFastmailSession.mockRejectedValue(fastmailConfigError('Fastmail rejected the API token or its permissions'));
+
+    const res = await api('/accounts/a1', { method: 'PUT', body: {
+      fastmail_api_token: 'invalid-token',
+    } });
+
+    expect(res.status).toBe(422);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a saved replacement token for a post-flight synchronization', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'a1' }] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', name: 'Fastmail', email_address: 'owner@example.com',
+        fastmail_api_token: 'encrypted:new-token',
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', email_address: 'owner@example.com',
+        fastmail_api_token: 'encrypted:new-token', fastmail_sync_error: null,
+      }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await api('/accounts/a1', { method: 'PUT', body: {
+      fastmail_api_token: 'new-token',
+    } });
+
+    expect(res.status).toBe(200);
+    expect(syncFastmailAliases).toHaveBeenCalledWith('a1', { credentialChanged: true });
+  });
+
+  it('refreshes an owned configured account and returns the reloaded safe snapshot', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', fastmail_api_token: 'encrypted:token' }] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', email_address: 'owner@example.com', fastmail_api_token: 'encrypted:token',
+        fastmail_sync_error: null,
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'alias-1', account_id: 'a1', email: 'mask@example.com', provenance: 'fastmail',
+      }] });
+
+    const res = await api('/accounts/a1/fastmail/refresh', { method: 'POST' });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(syncFastmailAliases).toHaveBeenCalledWith('a1');
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('WHERE id = $1 AND user_id = $2'),
+      ['a1', 'u1'],
+    );
+    expect(body.aliases).toHaveLength(1);
+    expect(body.fastmail_configured).toBe(true);
+    expect(body).not.toHaveProperty('fastmail_api_token');
+  });
+
+  it('returns the persisted safe error when manual refresh fails', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'a1', fastmail_api_token: 'encrypted:token' }] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'a1', fastmail_api_token: 'encrypted:token',
+        fastmail_sync_error: 'Fastmail synchronization failed',
+      }] })
+      .mockResolvedValueOnce({ rows: [] });
+    syncFastmailAliases.mockRejectedValue(new Error('token and full inventory'));
+
+    const res = await api('/accounts/a1/fastmail/refresh', { method: 'POST' });
+
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: 'Fastmail synchronization failed', code: 'FASTMAIL_SYNC_FAILED',
+    });
+  });
+});

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -1,11 +1,13 @@
 import { Router } from 'express';
-import { query } from '../services/db.js';
+import { query, withTransaction } from '../services/db.js';
 import { requireAuth } from '../middleware/auth.js';
 import { imapManager } from '../index.js';
 import { encrypt } from '../services/encryption.js';
 import { sanitizeSignature } from '../services/emailSanitizer.js';
 import { validateHost } from '../services/hostValidation.js';
 import { getConnectionPolicy } from '../services/connectionPolicy.js';
+import { loadFastmailSession } from '../services/fastmailClient.js';
+import { syncFastmailAliases } from '../services/fastmailAliasSync.js';
 
 const ALLOWED_IMAP_PORTS = new Set([143, 993]);
 const ALLOWED_SMTP_PORTS = new Set([465, 587]);
@@ -35,17 +37,45 @@ router.use(requireAuth);
 // Fields safe to return to the client — matches the GET list, excludes credentials and tokens
 const SAFE_FIELDS = [
   'id', 'name', 'sender_name', 'email_address', 'color', 'protocol',
-  'imap_host', 'imap_port', 'imap_skip_tls_verify',
+  'imap_host', 'imap_port', 'imap_tls', 'imap_skip_tls_verify',
   'smtp_host', 'smtp_port', 'smtp_tls',
   'auth_user', 'oauth_provider', 'enabled',
   'last_sync', 'sync_error', 'sort_order', 'folder_mappings',
   'signature', 'created_at', 'categorization_enabled',
+  'fastmail_last_sync', 'fastmail_sync_error',
 ];
 function safeAccount(row) {
   const obj = Object.fromEntries(SAFE_FIELDS.map(k => [k, row[k]]));
+  obj.fastmail_configured = row.fastmail_configured ?? Boolean(row.fastmail_api_token);
   // Sanitize on read so legacy values stored before the write-time sanitizer are safe
   if (obj.signature) obj.signature = sanitizeSignature(obj.signature);
   return obj;
+}
+
+async function loadOwnedAccount(id, userId) {
+  const result = await query(
+    'SELECT * FROM email_accounts WHERE id = $1 AND user_id = $2',
+    [id, userId],
+  );
+  return result.rows[0] || null;
+}
+
+async function loadSafeAccountWithAliases(id, userId) {
+  const account = await loadOwnedAccount(id, userId);
+  if (!account) return null;
+  const aliasResult = await query(
+    `SELECT id, account_id, name, email, reply_to, signature, provenance,
+            fastmail_identity_id, fastmail_masked_email_id, fastmail_label, created_at
+     FROM account_aliases WHERE account_id = $1 ORDER BY created_at`,
+    [id],
+  );
+  return {
+    ...safeAccount(account),
+    aliases: aliasResult.rows.map(alias => ({
+      ...alias,
+      signature: alias.signature ? sanitizeSignature(alias.signature) : alias.signature,
+    })),
+  };
 }
 
 router.get('/', async (req, res) => {
@@ -53,7 +83,9 @@ router.get('/', async (req, res) => {
     `SELECT id, name, sender_name, email_address, color, protocol, imap_host, imap_port, imap_tls, imap_skip_tls_verify,
             smtp_host, smtp_port, smtp_tls, auth_user, oauth_provider, enabled,
             last_sync, sync_error, sort_order, folder_mappings, signature, created_at,
-            categorization_enabled
+            categorization_enabled,
+            fastmail_last_sync, fastmail_sync_error,
+            (fastmail_api_token IS NOT NULL) AS fastmail_configured
      FROM email_accounts WHERE user_id = $1 ORDER BY sort_order, created_at`,
     [req.session.userId]
   );
@@ -63,7 +95,8 @@ router.get('/', async (req, res) => {
   let aliasMap = {};
   if (accountIds.length) {
     const aliasResult = await query(
-      `SELECT id, account_id, name, email, reply_to, signature, created_at
+      `SELECT id, account_id, name, email, reply_to, signature, provenance,
+              fastmail_identity_id, fastmail_masked_email_id, fastmail_label, created_at
        FROM account_aliases WHERE account_id = ANY($1) ORDER BY created_at`,
       [accountIds]
     );
@@ -74,8 +107,7 @@ router.get('/', async (req, res) => {
   }
 
   res.json(result.rows.map(a => ({
-    ...a,
-    signature: a.signature ? sanitizeSignature(a.signature) : a.signature,
+    ...safeAccount(a),
     aliases: (aliasMap[a.id] || []).map(alias => ({
       ...alias,
       signature: alias.signature ? sanitizeSignature(alias.signature) : alias.signature,
@@ -89,7 +121,7 @@ router.post('/', async (req, res) => {
     imap_host, imap_port = 993, imap_skip_tls_verify = false,
     smtp_host, smtp_port = 587, smtp_tls = 'STARTTLS',
     auth_user, auth_pass,
-    oauth_provider, oauth_access_token, oauth_refresh_token,
+    oauth_provider, oauth_access_token, oauth_refresh_token, fastmail_api_token,
     signature = null
   } = req.body;
 
@@ -99,6 +131,18 @@ router.post('/', async (req, res) => {
   }
   if (sender_name && hasHeaderInjectionChars(sender_name)) {
     return res.status(400).json({ error: 'Sender name cannot contain control characters' });
+  }
+
+  if (fastmail_api_token) {
+    try {
+      await loadFastmailSession(fastmail_api_token);
+    } catch (error) {
+      // A bad token / configuration fault is a client error — reject before creating the
+      // account. A transient reach failure (sync-class) is tolerated: create the account
+      // anyway and let the post-insert sync record the error, matching the refresh path.
+      if (error.code === 'FASTMAIL_CONFIG') return res.status(error.status).json({ error: error.message });
+      if (error.code !== 'FASTMAIL_SYNC') throw error;
+    }
   }
 
   const policy = await getConnectionPolicy();
@@ -120,13 +164,14 @@ router.post('/', async (req, res) => {
         user_id, name, sender_name, email_address, color, protocol,
         imap_host, imap_port, imap_tls, imap_skip_tls_verify, smtp_host, smtp_port, smtp_tls,
         auth_user, auth_pass, oauth_provider, oauth_access_token, oauth_refresh_token,
-        signature
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+        fastmail_api_token, signature
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
       RETURNING *
     `, [
       req.session.userId, name, sender_name || null, email_address, color, protocol,
       imap_host, imap_port, Number(imap_port) % 1000 === 993, !!imap_skip_tls_verify, smtp_host, smtp_port, smtp_tls,
       auth_user, encrypt(auth_pass), oauth_provider, encrypt(oauth_access_token), encrypt(oauth_refresh_token),
+      encrypt(fastmail_api_token),
       sanitizeSignature(signature) || null
     ]);
 
@@ -137,8 +182,18 @@ router.post('/', async (req, res) => {
       imapManager.connectAccount(account).catch(console.error);
     }
 
+    if (fastmail_api_token) {
+      try {
+        await syncFastmailAliases(account.id);
+      } catch {
+        return res.json(await loadSafeAccountWithAliases(account.id, req.session.userId));
+      }
+      return res.json(await loadSafeAccountWithAliases(account.id, req.session.userId));
+    }
+
     res.json(safeAccount(account));
   } catch (err) {
+    if (err.code === 'FASTMAIL_CONFIG') return res.status(err.status).json({ error: err.message });
     console.error(err);
     res.status(500).json({ error: 'Failed to add account' });
   }
@@ -151,6 +206,31 @@ router.put('/:id', async (req, res) => {
   // Verify ownership
   const check = await query('SELECT id FROM email_accounts WHERE id = $1 AND user_id = $2', [id, req.session.userId]);
   if (!check.rows.length) return res.status(404).json({ error: 'Account not found' });
+
+  if ('fastmail_api_token' in updates && !updates.fastmail_api_token) {
+    const updated = await withTransaction(async client => {
+      const result = await client.query(
+        `UPDATE email_accounts
+         SET fastmail_api_token = NULL, fastmail_last_sync = NULL, fastmail_sync_error = NULL
+         WHERE id = $1 AND user_id = $2 RETURNING *`,
+        [id, req.session.userId],
+      );
+      await client.query(
+        "DELETE FROM account_aliases WHERE account_id = $1 AND provenance = 'fastmail'",
+        [id],
+      );
+      return result.rows[0];
+    });
+    return res.json(safeAccount(updated));
+  }
+  if (updates.fastmail_api_token) {
+    try {
+      await loadFastmailSession(updates.fastmail_api_token);
+    } catch (error) {
+      if (error.code === 'FASTMAIL_CONFIG') return res.status(error.status).json({ error: error.message });
+      throw error;
+    }
+  }
 
   if ('name' in updates && hasHeaderInjectionChars(updates.name)) {
     return res.status(400).json({ error: 'Name cannot contain control characters' });
@@ -182,14 +262,14 @@ router.put('/:id', async (req, res) => {
   }
 
   if ('imap_port' in updates) updates.imap_tls = Number(updates.imap_port) % 1000 === 993;
-  const allowed = ['name', 'sender_name', 'color', 'enabled', 'auth_user', 'auth_pass', 'sort_order', 'imap_host', 'imap_port', 'imap_tls', 'imap_skip_tls_verify', 'smtp_host', 'smtp_port', 'smtp_tls', 'folder_mappings', 'signature', 'categorization_enabled'];
+  const allowed = ['name', 'sender_name', 'color', 'enabled', 'auth_user', 'auth_pass', 'fastmail_api_token', 'sort_order', 'imap_host', 'imap_port', 'imap_tls', 'imap_skip_tls_verify', 'smtp_host', 'smtp_port', 'smtp_tls', 'folder_mappings', 'signature', 'categorization_enabled'];
   const sets = [];
   const values = [];
   let i = 1;
   for (const key of allowed) {
     if (key in updates) {
       sets.push(`${key} = $${i++}`);
-      const value = (key === 'auth_pass' && updates[key]) ? encrypt(updates[key])
+      const value = ((key === 'auth_pass' || key === 'fastmail_api_token') && updates[key]) ? encrypt(updates[key])
         : (key === 'signature') ? sanitizeSignature(updates[key]) || null
         : updates[key];
       values.push(value);
@@ -203,7 +283,14 @@ router.put('/:id', async (req, res) => {
     values
   );
   const updated = result.rows[0];
-  res.json(safeAccount(updated));
+  let payload = safeAccount(updated);
+  if (updates.fastmail_api_token) {
+    try {
+      await syncFastmailAliases(updated.id, { credentialChanged: true });
+    } catch { /* the persisted safe status is returned below */ }
+    payload = await loadSafeAccountWithAliases(updated.id, req.session.userId);
+  }
+  res.json(payload);
 
   // Sync live IMAP state after DB update (fire-and-forget, non-fatal)
   const isDisabling = 'enabled' in updates && !updates.enabled;
@@ -258,6 +345,24 @@ router.post('/:id/reconnect', async (req, res) => {
   res.json({ ok: true });
 });
 
+router.post('/:id/fastmail/refresh', async (req, res) => {
+  const account = await loadOwnedAccount(req.params.id, req.session.userId);
+  if (!account) return res.status(404).json({ error: 'Account not found' });
+  if (!account.fastmail_api_token) {
+    return res.status(409).json({ error: 'Fastmail is not configured for this account' });
+  }
+  try {
+    await syncFastmailAliases(account.id);
+    return res.json(await loadSafeAccountWithAliases(account.id, req.session.userId));
+  } catch {
+    const current = await loadSafeAccountWithAliases(account.id, req.session.userId);
+    return res.status(502).json({
+      error: current?.fastmail_sync_error || 'Fastmail synchronization failed',
+      code: 'FASTMAIL_SYNC_FAILED',
+    });
+  }
+});
+
 // ── Alias CRUD ─────────────────────────────────────────────────────────────
 
 router.get('/:id/aliases', async (req, res) => {
@@ -266,7 +371,9 @@ router.get('/:id/aliases', async (req, res) => {
   if (!check.rows.length) return res.status(404).json({ error: 'Account not found' });
 
   const result = await query(
-    'SELECT id, account_id, name, email, reply_to, signature, created_at FROM account_aliases WHERE account_id = $1 ORDER BY created_at',
+    `SELECT id, account_id, name, email, reply_to, signature, provenance,
+            fastmail_identity_id, fastmail_masked_email_id, fastmail_label, created_at
+     FROM account_aliases WHERE account_id = $1 ORDER BY created_at`,
     [id]
   );
   res.json(result.rows.map(alias => ({
@@ -302,12 +409,18 @@ router.put('/:id/aliases/:aliasId', async (req, res) => {
   }
 
   const check = await query(
-    `SELECT a.id FROM account_aliases a
+    `SELECT a.id, a.provenance FROM account_aliases a
      JOIN email_accounts e ON a.account_id = e.id
      WHERE a.id = $1 AND e.user_id = $2 AND e.id = $3`,
     [aliasId, req.session.userId, id]
   );
   if (!check.rows.length) return res.status(404).json({ error: 'Alias not found' });
+  if (check.rows[0].provenance !== 'manual') {
+    return res.status(409).json({
+      error: 'Fastmail-managed addresses are read-only. Manage them in Fastmail.',
+      code: 'PROVIDER_MANAGED_ALIAS',
+    });
+  }
 
   const result = await query(
     'UPDATE account_aliases SET name = $1, email = $2, reply_to = $3, signature = $4 WHERE id = $5 RETURNING *',
@@ -320,12 +433,18 @@ router.delete('/:id/aliases/:aliasId', async (req, res) => {
   const { id, aliasId } = req.params;
 
   const check = await query(
-    `SELECT a.id FROM account_aliases a
+    `SELECT a.id, a.provenance FROM account_aliases a
      JOIN email_accounts e ON a.account_id = e.id
      WHERE a.id = $1 AND e.user_id = $2 AND e.id = $3`,
     [aliasId, req.session.userId, id]
   );
   if (!check.rows.length) return res.status(404).json({ error: 'Alias not found' });
+  if (check.rows[0].provenance !== 'manual') {
+    return res.status(409).json({
+      error: 'Fastmail-managed addresses are read-only. Manage them in Fastmail.',
+      code: 'PROVIDER_MANAGED_ALIAS',
+    });
+  }
 
   await query('DELETE FROM account_aliases WHERE id = $1', [aliasId]);
   res.json({ ok: true });

--- a/backend/src/routes/draft.js
+++ b/backend/src/routes/draft.js
@@ -6,6 +6,7 @@ import sanitizeHtml from 'sanitize-html';
 import { sanitizeSignature, sanitizeComposeBody } from '../services/emailSanitizer.js';
 import { embedInlineDataImages } from '../utils/inlineImages.js';
 import { imapManager } from '../index.js';
+import { authorizeSender } from '../services/senderAuthorization.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -21,31 +22,8 @@ function textToHtml(text) {
     .join('');
 }
 
-async function buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml, quotedBody, quotedBodyHtml, editedSignature }) {
-  const acctResult = await query(
-    'SELECT * FROM email_accounts WHERE id = $1',
-    [accountId]
-  );
-  if (!acctResult.rows.length) throw Object.assign(new Error('Account not found'), { status: 404 });
-  const account = acctResult.rows[0];
-
-  let fromName = account.sender_name || account.name;
-  let fromEmail = account.email_address;
-  let fromSignature = account.signature;
-
-  if (aliasId) {
-    const aliasResult = await query(
-      'SELECT * FROM account_aliases WHERE id = $1 AND account_id = $2',
-      [aliasId, accountId]
-    );
-    if (aliasResult.rows.length) {
-      const alias = aliasResult.rows[0];
-      fromName = alias.name;
-      fromEmail = alias.email;
-      if (alias.signature !== null) fromSignature = alias.signature;
-    }
-  }
-
+async function buildRawDraft({ authorizedSender, to, cc, bcc, subject, body, bodyIsHtml, quotedBody, quotedBodyHtml, editedSignature }) {
+  const { fromName, fromEmail, fromReplyTo, fromBcc = [], fromSignature } = authorizedSender;
   const rawSignature = editedSignature !== undefined ? (editedSignature || null) : fromSignature;
   const effectiveSignature = rawSignature ? sanitizeSignature(rawSignature) : null;
 
@@ -68,9 +46,13 @@ async function buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, b
 
   const mailOptions = {
     from: `${fromName} <${fromEmail}>`,
+    ...(fromReplyTo ? { replyTo: fromReplyTo } : {}),
     to: (Array.isArray(to) ? to : [to]).filter(Boolean).join(', ') || undefined,
     cc: (Array.isArray(cc) ? cc : []).filter(Boolean).join(', ') || undefined,
-    bcc: (Array.isArray(bcc) ? bcc : []).filter(Boolean).join(', ') || undefined,
+    bcc: [
+      ...(Array.isArray(bcc) ? bcc : []).filter(Boolean),
+      ...fromBcc,
+    ].filter(Boolean),
     subject: sanitizeHeaderValue(subject || ''),
     text: sigText ? `${bodyText}\n\n-- \n${sigText}${quotedBody || ''}` : `${bodyText}${quotedBody || ''}`,
     html: draftHtml,
@@ -85,7 +67,7 @@ async function buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, b
     streamInfo.message.on('end', resolve);
     streamInfo.message.on('error', reject);
   });
-  return { rawMessage: Buffer.concat(chunks), account };
+  return Buffer.concat(chunks);
 }
 
 async function resolveDraftsFolder(account) {
@@ -99,17 +81,35 @@ async function resolveDraftsFolder(account) {
 }
 
 router.post('/draft', async (req, res) => {
-  const { accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml = false, quotedBody, quotedBodyHtml, editedSignature, existingUid, existingFolder } = req.body;
-  if (!accountId) return res.status(400).json({ error: 'accountId required' });
+  const { sender, to, cc, bcc, subject, body, bodyIsHtml = false, quotedBody, quotedBodyHtml, editedSignature, existingUid, existingFolder } = req.body;
 
-  const ownerCheck = await query(
-    'SELECT id FROM email_accounts WHERE id = $1 AND user_id = $2',
-    [accountId, req.session.userId]
-  );
-  if (!ownerCheck.rows.length) return res.status(404).json({ error: 'Account not found' });
+  let authorizedSender;
+  try {
+    authorizedSender = await authorizeSender({ userId: req.session.userId, sender });
+  } catch (err) {
+    if (err?.code === 'SENDER_UNAVAILABLE') {
+      return res.status(422).json({ error: 'Sender unavailable', code: 'SENDER_UNAVAILABLE' });
+    }
+    // Log only the safe error shape: an unexpected failure here can carry alias or DB
+    // detail that must not reach logs (credential hygiene), so never log err.message.
+    console.error('Draft sender authorization failed:', err?.name, err?.code);
+    return res.status(500).json({ error: 'Failed to authorize sender' });
+  }
 
   try {
-    const { rawMessage, account } = await buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml, quotedBody, quotedBodyHtml, editedSignature });
+    const { account } = authorizedSender;
+    const rawMessage = await buildRawDraft({
+      authorizedSender,
+      to,
+      cc,
+      bcc,
+      subject,
+      body,
+      bodyIsHtml,
+      quotedBody,
+      quotedBodyHtml,
+      editedSignature,
+    });
 
     const draftsFolder = await resolveDraftsFolder(account);
     if (!draftsFolder) return res.status(422).json({ error: 'No Drafts folder found for this account' });
@@ -133,7 +133,10 @@ router.post('/draft', async (req, res) => {
     res.json({ uid, folder: draftsFolder });
   } catch (err) {
     console.error('Save draft failed:', err.message);
-    res.status(err.status || 500).json({ error: err.message || 'Failed to save draft' });
+    res.status(err.status || 500).json({
+      error: err.message || 'Failed to save draft',
+      ...(err.code ? { code: err.code } : {}),
+    });
   }
 });
 

--- a/backend/src/routes/draft.sender.test.js
+++ b/backend/src/routes/draft.sender.test.js
@@ -1,0 +1,183 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../services/senderAuthorization.js', () => ({ authorizeSender: vi.fn() }));
+vi.mock('../index.js', () => ({
+  imapManager: {
+    appendToFolder: vi.fn(),
+    permanentDeleteMessage: vi.fn(),
+  },
+}));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => {
+    req.session = { userId: 'u1' };
+    next();
+  },
+}));
+
+import express from 'express';
+import { query } from '../services/db.js';
+import { authorizeSender } from '../services/senderAuthorization.js';
+import { imapManager } from '../index.js';
+import draftRoutes from './draft.js';
+
+const sender = { accountId: 'a1', aliasId: 'alias-1', fromEmail: null };
+const account = {
+  id: 'a1', name: 'Fastmail', email_address: 'owner@example.com',
+  folder_mappings: { drafts: 'Drafts' },
+};
+const authorizedSender = {
+  account,
+  fromName: 'Exact Alias',
+  fromEmail: 'alias@example.com',
+  fromReplyTo: 'reply@example.com',
+  fromSignature: '<p>Alias signature</p>',
+};
+
+let server;
+let base;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json({ limit: '2mb' }));
+  app.use('/mail', draftRoutes);
+  await new Promise(resolve => { server = app.listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+beforeEach(() => {
+  query.mockReset();
+  authorizeSender.mockReset();
+  imapManager.appendToFolder.mockReset();
+  imapManager.permanentDeleteMessage.mockReset();
+  authorizeSender.mockResolvedValue(authorizedSender);
+  imapManager.appendToFolder.mockResolvedValue({ uid: 42 });
+  query.mockResolvedValue({ rows: [] });
+});
+
+const postDraft = body => fetch(`${base}/mail/draft`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+describe('POST /mail/draft explicit sender', () => {
+  it('authorizes the exact request sender and generates MIME from the trusted identity', async () => {
+    const res = await postDraft({ sender, to: ['to@example.com'], subject: 'Draft', body: 'Hello' });
+
+    expect(res.status).toBe(200);
+    expect(authorizeSender).toHaveBeenCalledWith({ userId: 'u1', sender });
+    const raw = imapManager.appendToFolder.mock.calls[0][2].toString('utf8');
+    expect(raw).toContain('From: Exact Alias <alias@example.com>');
+    expect(raw).toContain('Reply-To: reply@example.com');
+  });
+
+  it('generates an address-only From header for a blank Fastmail identity name', async () => {
+    authorizeSender.mockResolvedValue({
+      ...authorizedSender,
+      fromName: '',
+      fromEmail: 'unnamed@fastmail.example',
+    });
+
+    const res = await postDraft({ sender, to: ['to@example.com'], subject: 'Draft', body: 'Hello' });
+
+    expect(res.status).toBe(200);
+    const raw = imapManager.appendToFolder.mock.calls[0][2].toString('utf8');
+    expect(raw).toContain('From: unnamed@fastmail.example');
+    expect(raw).not.toContain('From: Account Owner');
+  });
+
+  it('applies complete Fastmail identity Reply-To and Bcc routing to draft MIME', async () => {
+    authorizeSender.mockResolvedValue({
+      ...authorizedSender,
+      fromReplyTo: [
+        { name: 'Support', address: 'support@example.com' },
+        'archive@example.com',
+      ],
+      fromBcc: [
+        { name: 'Compliance', address: 'compliance@example.com' },
+        'journal@example.com',
+      ],
+    });
+
+    const res = await postDraft({
+      sender,
+      to: ['to@example.com'],
+      bcc: ['visible-bcc@example.com'],
+      subject: 'Draft',
+      body: 'Hello',
+    });
+
+    expect(res.status).toBe(200);
+    const raw = imapManager.appendToFolder.mock.calls[0][2]
+      .toString('utf8')
+      .replace(/\r?\n[ \t]+/g, ' ');
+    expect(raw).toContain('Reply-To: Support <support@example.com>, archive@example.com');
+    expect(raw).toContain(
+      'Bcc: visible-bcc@example.com, Compliance <compliance@example.com>, journal@example.com',
+    );
+  });
+
+  it('returns SENDER_UNAVAILABLE before IMAP side effects', async () => {
+    authorizeSender.mockRejectedValue(Object.assign(new Error('Sender unavailable'), {
+      status: 422, code: 'SENDER_UNAVAILABLE',
+    }));
+
+    const res = await postDraft({ sender, to: ['to@example.com'], body: 'Hello' });
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: 'Sender unavailable', code: 'SENDER_UNAVAILABLE' });
+    expect(imapManager.appendToFolder).not.toHaveBeenCalled();
+    expect(imapManager.permanentDeleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not expose unexpected sender-authorization failures', async () => {
+    const privateDetail = 'private-database-detail-9137';
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    authorizeSender.mockRejectedValue(new Error(privateDetail));
+
+    const res = await postDraft({ sender, to: ['to@example.com'], body: 'Hello' });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to authorize sender' });
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain(privateDetail);
+    expect(imapManager.appendToFolder).not.toHaveBeenCalled();
+    errorLog.mockRestore();
+  });
+
+  it('preserves primary-sender body, signature, and inline-image MIME rendering', async () => {
+    authorizeSender.mockResolvedValue({
+      ...authorizedSender,
+      fromName: 'Account Owner',
+      fromEmail: 'owner@example.com',
+      fromReplyTo: null,
+      fromSignature: '<p>Account signature</p>',
+    });
+    const primary = { accountId: 'a1', aliasId: null, fromEmail: null };
+    const pixel = 'data:image/png;base64,iVBORw0KGgo=';
+
+    const res = await postDraft({
+      sender: primary,
+      to: ['to@example.com'],
+      subject: 'MIME regression',
+      body: `<p>Hello body</p><img src="${pixel}">`,
+      bodyIsHtml: true,
+      quotedBody: '\nQuoted text',
+      quotedBodyHtml: '<blockquote>Quoted HTML</blockquote>',
+    });
+
+    expect(res.status).toBe(200);
+    const raw = imapManager.appendToFolder.mock.calls[0][2].toString('utf8');
+    expect(raw).toContain('From: Account Owner <owner@example.com>');
+    expect(raw).toContain('Hello body');
+    expect(raw).toContain('Account signature');
+    expect(raw).toContain('<blockquote>Quoted =');
+    expect(raw).toContain('HTML</blockquote>');
+    expect(raw).toContain('Content-ID: <img-');
+    expect(raw).not.toContain('data:image/png;base64');
+  });
+});

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -11,6 +11,7 @@ import { resolveTrashFolder, resolveAllTrashPaths, resolveAllDraftsPaths, resolv
 import { listMessages } from '../services/messageService.js';
 import { validateHost } from '../services/hostValidation.js';
 import { safeFetch } from '../services/safeFetch.js';
+import { resolveMessageSender } from '../services/senderResolver.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -112,7 +113,7 @@ router.get('/messages/:id', async (req, res) => {
   try {
     const result = await query(`
       SELECT m.id, m.uid, m.folder, m.message_id, m.subject,
-             m.from_name, m.from_email, m.to_addresses, m.cc_addresses,
+             m.from_name, m.from_email, m.to_addresses, m.cc_addresses, m.delivery_addresses,
              m.reply_to, m.in_reply_to,
              m.date, m.snippet, m.is_read, m.is_starred,
              m.has_attachments, m.account_id, m.category,
@@ -130,6 +131,28 @@ router.get('/messages/:id', async (req, res) => {
   } catch (err) {
     console.error('GET /messages/:id error:', err.message);
     res.status(500).json({ error: 'Failed to load message' });
+  }
+});
+
+router.post('/messages/:id/resolve-sender', async (req, res) => {
+  if (!UUID_RE.test(req.params.id)) return res.status(400).json({ error: 'Invalid message ID' });
+  const purpose = req.body?.purpose;
+  if (purpose !== 'reply' && purpose !== 'draft') {
+    return res.status(400).json({ error: 'purpose must be reply or draft' });
+  }
+  try {
+    const result = await resolveMessageSender({
+      messageId: req.params.id,
+      userId: req.session.userId,
+      purpose,
+    });
+    res.json(result);
+  } catch (err) {
+    if (err.status === 404) return res.status(404).json({ error: 'Message not found' });
+    // Log only the safe error shape: an unexpected resolve-sender failure can carry
+    // alias or DB detail that must not reach logs (credential hygiene); never log err.message.
+    console.error('POST /messages/:id/resolve-sender failed:', err?.name, err?.code);
+    res.status(500).json({ error: 'Failed to resolve sender' });
   }
 });
 
@@ -169,7 +192,7 @@ router.get('/thread/:threadId', async (req, res) => {
       WITH deduped AS (
         SELECT DISTINCT ON (m.message_id)
                m.id, m.uid, m.folder, m.message_id, m.thread_id, m.subject,
-               m.from_name, m.from_email, m.to_addresses, m.cc_addresses,
+               m.from_name, m.from_email, m.to_addresses, m.cc_addresses, m.delivery_addresses,
                m.reply_to, m.in_reply_to,
                m.date, m.snippet, m.is_read, m.is_starred,
                m.has_attachments, m.account_id, m.category,
@@ -993,7 +1016,7 @@ router.post('/messages/bulk-delete', async (req, res) => {
           )
           INSERT INTO messages (
             account_id, uid, folder, message_id, subject,
-            from_name, from_email, to_addresses, cc_addresses,
+            from_name, from_email, to_addresses, cc_addresses, delivery_addresses,
             reply_to, in_reply_to, date, snippet, is_read, is_starred,
             has_attachments, flags, body_html, body_text, attachments,
             thread_references, thread_id, is_bulk,
@@ -1003,7 +1026,7 @@ router.post('/messages/bulk-delete', async (req, res) => {
           )
           SELECT
             d.account_id, u.new_uid, $4, d.message_id, d.subject,
-            d.from_name, d.from_email, d.to_addresses, d.cc_addresses,
+            d.from_name, d.from_email, d.to_addresses, d.cc_addresses, d.delivery_addresses,
             d.reply_to, d.in_reply_to, d.date, d.snippet, d.is_read, d.is_starred,
             d.has_attachments, d.flags, d.body_html, d.body_text, d.attachments,
             d.thread_references, d.thread_id, d.is_bulk,
@@ -1179,7 +1202,7 @@ router.post('/messages/bulk-move', async (req, res) => {
         )
         INSERT INTO messages (
           account_id, uid, folder, message_id, subject,
-          from_name, from_email, to_addresses, cc_addresses,
+          from_name, from_email, to_addresses, cc_addresses, delivery_addresses,
           reply_to, in_reply_to, date, snippet, is_read, is_starred,
           has_attachments, flags, body_html, body_text, attachments,
           thread_references, thread_id, is_bulk,
@@ -1189,7 +1212,7 @@ router.post('/messages/bulk-move', async (req, res) => {
         )
         SELECT
           d.account_id, u.new_uid, $4, d.message_id, d.subject,
-          d.from_name, d.from_email, d.to_addresses, d.cc_addresses,
+          d.from_name, d.from_email, d.to_addresses, d.cc_addresses, d.delivery_addresses,
           d.reply_to, d.in_reply_to, d.date, d.snippet, d.is_read, d.is_starred,
           d.has_attachments, d.flags, d.body_html, d.body_text, d.attachments,
           d.thread_references, d.thread_id, d.is_bulk,
@@ -1334,7 +1357,7 @@ router.post('/messages/bulk-archive', async (req, res) => {
         )
         INSERT INTO messages (
           account_id, uid, folder, message_id, subject,
-          from_name, from_email, to_addresses, cc_addresses,
+          from_name, from_email, to_addresses, cc_addresses, delivery_addresses,
           reply_to, in_reply_to, date, snippet, is_read, is_starred,
           has_attachments, flags, body_html, body_text, attachments,
           thread_references, thread_id, is_bulk,
@@ -1344,7 +1367,7 @@ router.post('/messages/bulk-archive', async (req, res) => {
         )
         SELECT
           d.account_id, u.new_uid, $4, d.message_id, d.subject,
-          d.from_name, d.from_email, d.to_addresses, d.cc_addresses,
+          d.from_name, d.from_email, d.to_addresses, d.cc_addresses, d.delivery_addresses,
           d.reply_to, d.in_reply_to, d.date, d.snippet, d.is_read, d.is_starred,
           d.has_attachments, d.flags, d.body_html, d.body_text, d.attachments,
           d.thread_references, d.thread_id, d.is_bulk,

--- a/backend/src/routes/mail.sender.test.js
+++ b/backend/src/routes/mail.sender.test.js
@@ -1,0 +1,164 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../index.js', () => ({ imapManager: {
+  _guardMoveUid: vi.fn(),
+  _unguardMoveUid: vi.fn(),
+  bulkMoveMessages: vi.fn(),
+  broadcast: vi.fn(),
+  syncFolderOnDemand: vi.fn().mockResolvedValue(undefined),
+} }));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => {
+    req.session = { userId: 'user-1' };
+    next();
+  },
+}));
+vi.mock('../services/senderResolver.js', () => ({ resolveMessageSender: vi.fn() }));
+vi.mock('../utils/mailUtils.js', async importOriginal => ({
+  ...await importOriginal(),
+  adjustFolderCounts: vi.fn(),
+  isAllMailFolder: vi.fn().mockResolvedValue(false),
+  resolveAllDraftsPaths: vi.fn().mockResolvedValue(new Set()),
+  resolveAllTrashPaths: vi.fn().mockResolvedValue(new Set()),
+  resolveArchiveFolder: vi.fn().mockResolvedValue('Archive'),
+  resolveTrashFolder: vi.fn().mockResolvedValue('Trash'),
+}));
+
+import express from 'express';
+import { query } from '../services/db.js';
+import { imapManager } from '../index.js';
+import { resolveMessageSender } from '../services/senderResolver.js';
+import mailRoutes from './mail.js';
+
+const messageId = '11111111-1111-4111-8111-111111111111';
+let server;
+let base;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/mail', mailRoutes);
+  await new Promise(resolve => { server = app.listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+beforeEach(() => {
+  query.mockReset();
+  imapManager.bulkMoveMessages.mockReset();
+  imapManager.bulkMoveMessages.mockResolvedValue({
+    uidMap: new Map([[7, 70]]),
+    succeeded: [7],
+    failed: [],
+  });
+  resolveMessageSender.mockReset();
+  resolveMessageSender.mockResolvedValue({
+    sender: { accountId: 'a1', aliasId: null, fromEmail: null, displayEmail: 'owner@example.com' },
+    requiresSelection: false,
+  });
+});
+
+const movedMessage = {
+  id: messageId,
+  account_id: 'a1',
+  uid: 7,
+  folder: 'INBOX',
+  folder_mappings: {},
+  message_id: '<message@example.com>',
+  delivery_addresses: ['mask@example.com'],
+  is_read: false,
+};
+
+const postJson = (path, body) => fetch(`${base}${path}`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+const post = (id, body) => fetch(`${base}/mail/messages/${id}/resolve-sender`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+describe('POST /mail/messages/:id/resolve-sender', () => {
+  it.each(['reply', 'draft'])('resolves an owned message for purpose %s', async purpose => {
+    const res = await post(messageId, { purpose });
+
+    expect(res.status).toBe(200);
+    expect(resolveMessageSender).toHaveBeenCalledWith({
+      messageId,
+      userId: 'user-1',
+      purpose,
+    });
+    expect(await res.json()).toMatchObject({ requiresSelection: false });
+  });
+
+  it('rejects an invalid message ID', async () => {
+    const res = await post('not-a-uuid', { purpose: 'reply' });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid message ID' });
+    expect(resolveMessageSender).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null, 'send', ''])('rejects invalid purpose %s', async purpose => {
+    const res = await post(messageId, purpose === undefined ? {} : { purpose });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'purpose must be reply or draft' });
+    expect(resolveMessageSender).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a missing or unowned message', async () => {
+    resolveMessageSender.mockRejectedValue(Object.assign(new Error('Message not found'), { status: 404 }));
+
+    const res = await post(messageId, { purpose: 'reply' });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Message not found' });
+  });
+
+  it('does not log aliases or private details from unexpected reply-time failures', async () => {
+    const sensitiveAlias = 'complete-private-alias@masked.example';
+    const privateDetail = 'private-reconciliation-marker-9137';
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    resolveMessageSender.mockRejectedValue(new Error(`${privateDetail} ${sensitiveAlias}`));
+
+    const res = await post(messageId, { purpose: 'reply' });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to resolve sender' });
+    const logs = errorLog.mock.calls.flat().join(' ');
+    expect(logs).not.toContain(sensitiveAlias);
+    expect(logs).not.toContain(privateDetail);
+    errorLog.mockRestore();
+  });
+});
+
+describe('bulk message relocation persistence', () => {
+  it.each([
+    ['move', '/mail/messages/bulk-move', { ids: [messageId], folder: 'Archive' }, [
+      { rows: [movedMessage] }, { rows: [{ exists: true }] }, { rows: [{ id: 'a1' }] }, { rows: [] },
+    ]],
+    ['trash', '/mail/messages/bulk-delete', { ids: [messageId] }, [
+      { rows: [movedMessage] }, { rows: [{ id: 'a1' }] }, { rows: [] },
+    ]],
+    ['archive', '/mail/messages/bulk-archive', { ids: [messageId] }, [
+      { rows: [movedMessage] }, { rows: [{ id: 'a1' }] }, { rows: [] },
+    ]],
+  ])('preserves delivery addresses when messages %s folders', async (_label, path, body, results) => {
+    for (const result of results) query.mockResolvedValueOnce(result);
+
+    const res = await postJson(path, body);
+
+    expect(res.status).toBe(200);
+    const relocation = query.mock.calls.find(([sql]) => sql.includes('WITH deleted AS'));
+    expect(relocation?.[0]).toMatch(/to_addresses, cc_addresses,\s+delivery_addresses/);
+    expect(relocation?.[0]).toMatch(/d\.to_addresses, d\.cc_addresses,\s+d\.delivery_addresses/);
+  });
+});

--- a/backend/src/routes/search.js
+++ b/backend/src/routes/search.js
@@ -225,9 +225,12 @@ router.get('/', searchLimiter, async (req, res) => {
   params.push(off);
 
   try {
+    // to/cc are returned so a reply composed straight from a search result can resolve
+    // which of the user's aliases to send from (senderResolver) without re-fetching.
     const result = await query(`
       SELECT
         m.id, m.uid, m.folder, m.subject, m.from_name, m.from_email,
+        m.to_addresses, m.cc_addresses,
         m.date, m.snippet, m.is_read, m.is_starred, m.has_attachments, m.account_id,
         a.name as account_name, a.email_address as account_email, a.color as account_color
       FROM messages m

--- a/backend/src/routes/search.test.js
+++ b/backend/src/routes/search.test.js
@@ -1,16 +1,53 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// search.js opens a DB handle and registers auth middleware at import time;
-// neither is exercised by the pure parser under test, so stub them out.
+// Keep route tests deterministic without opening a real DB or session store.
 vi.mock('../services/db.js', () => ({ query: vi.fn() }));
-vi.mock('../middleware/auth.js', () => ({ requireAuth: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => {
+    req.session = { userId: 'u1' };
+    next();
+  },
+}));
 
+import express from 'express';
+import { query } from '../services/db.js';
 import {
+  default as searchRoutes,
   parseSearchQuery,
   resolveSearchFolderScope,
   shouldExcludeTrashFromSearch,
   trashFolderExclusionCondition,
 } from './search.js';
+
+describe('GET /search', () => {
+  it('selects recipient metadata needed by the selected-message header', async () => {
+    const recipients = [{ name: 'Example Recipient', email: 'recipient@example.com' }];
+    query.mockReset();
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'a1' }] })
+      .mockImplementationOnce(async sql => {
+        expect(sql).toContain('m.to_addresses');
+        expect(sql).toContain('m.cc_addresses');
+        return { rows: [{ id: 'm1', to_addresses: recipients, cc_addresses: [] }] };
+      });
+
+    const app = express();
+    app.use('/search', searchRoutes);
+    const server = await new Promise(resolve => {
+      const listening = app.listen(0, () => resolve(listening));
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.address().port}/search?q=recipient`);
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        messages: [{ id: 'm1', to_addresses: recipients, cc_addresses: [] }],
+      });
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});
 
 describe('parseSearchQuery', () => {
   it('treats bare words as free-text terms', () => {

--- a/backend/src/routes/send.js
+++ b/backend/src/routes/send.js
@@ -14,6 +14,7 @@ import { generateVCard } from '../utils/vcard.js';
 import { resolveForConnection } from '../services/hostValidation.js';
 import { getConnectionPolicy } from '../services/connectionPolicy.js';
 import { imapManager } from '../index.js';
+import { authorizeSender } from '../services/senderAuthorization.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -40,6 +41,16 @@ function sanitizeSmtpError(err) {
     return 'Secure connection to the mail server failed. Check your TLS settings.';
   }
   return 'Failed to send message. Please try again.';
+}
+
+function isSenderAuthorizationRejection(err) {
+  const detail = [err?.message, err?.response, err?.code].filter(Boolean).join(' ');
+  const hasSenderStatus = err?.responseCode === 550
+    || err?.responseCode === 553
+    || /(?:^|\s)(?:550|553)(?:\s|$)/.test(detail);
+  return hasSenderStatus
+    && /\b(?:from|sender|identity)\b/i.test(detail)
+    && /\b(?:authoriz(?:e|ed|ation)|unauthoriz(?:e|ed)|not\s+(?:allowed|permitted|valid|verified)|permission)\b/i.test(detail);
 }
 
 // Extract name and email from an RFC 5322 address string.
@@ -129,15 +140,13 @@ router.use(requireAuth);
 
 
 router.post('/send', async (req, res) => {
-  const { accountId, aliasId, to, cc = [], bcc = [], subject, body, bodyIsHtml = false, quotedBody, quotedBodyHtml, inReplyTo, references, attachments, editedSignature, forwardedAttachments, priority } = req.body;
+  const { sender, to, cc = [], bcc = [], subject, body, bodyIsHtml = false, quotedBody, quotedBodyHtml, inReplyTo, references, attachments, editedSignature, forwardedAttachments, priority } = req.body;
   const VALID_PRIORITIES = new Set(['high', 'normal', 'low']);
   const emailPriority = VALID_PRIORITIES.has(priority) ? priority : 'normal';
-  if (!accountId || !to?.length) return res.status(400).json({ error: 'accountId and to required' });
+  if (!to?.length) return res.status(400).json({ error: 'sender and to required' });
 
-  // Idempotency guard. The client sends a stable X-Idempotency-Key per logical send: a
-  // sequential retry after a lost success response returns the cached result, and a
-  // concurrent same-key submit is blocked by the reservation set just before delivery
-  // (below). Neither can produce a duplicate email. Fixes audit finding [1].
+  // Return a previously completed logical send before revalidating inputs that may
+  // legitimately have gone stale after the original delivery.
   const idempotencyKey = typeof req.headers['x-idempotency-key'] === 'string'
     ? req.headers['x-idempotency-key'].slice(0, 128)
     : null;
@@ -147,6 +156,22 @@ router.post('/send', async (req, res) => {
     if (cached === '__inflight__') return res.status(409).json({ error: 'This message is already being sent.' });
     if (cached) return res.json(JSON.parse(cached));
   }
+
+  let authorizedSender;
+  try {
+    authorizedSender = await authorizeSender({ userId: req.session.userId, sender });
+  } catch (err) {
+    if (err?.code === 'SENDER_UNAVAILABLE') {
+      return res.status(422).json({ error: 'Sender unavailable', code: 'SENDER_UNAVAILABLE' });
+    }
+    // Log only the safe error shape: an unexpected failure here can carry alias or DB
+    // detail that must not reach logs (credential hygiene), so never log err.message.
+    console.error('Sender authorization failed:', err?.name, err?.code);
+    return res.status(500).json({ error: 'Failed to authorize sender' });
+  }
+  let account = authorizedSender.account;
+  const accountId = account.id;
+  const { fromName, fromEmail, fromReplyTo, fromBcc = [], fromSignature } = authorizedSender;
 
   if (attachments !== undefined) {
     if (!Array.isArray(attachments)) return res.status(400).json({ error: 'attachments must be an array' });
@@ -177,34 +202,8 @@ router.post('/send', async (req, res) => {
   }
   const normalizedSubject = sanitizeHeaderValue(subject || '');
 
-  const [result, prefResult] = await Promise.all([
-    query('SELECT * FROM email_accounts WHERE id = $1 AND user_id = $2', [accountId, req.session.userId]),
-    query('SELECT preferences FROM users WHERE id = $1', [req.session.userId]),
-  ]);
-  if (!result.rows.length) return res.status(404).json({ error: 'Account not found' });
+  const prefResult = await query('SELECT preferences FROM users WHERE id = $1', [req.session.userId]);
   const plaintextEmail = prefResult.rows[0]?.preferences?.plaintextEmail === true;
-  let account = result.rows[0];
-
-  // Resolve the From identity — account by default, alias if requested
-  let fromName = account.sender_name || account.name;
-  let fromEmail = account.email_address;
-  let fromSignature = account.signature;
-  let fromReplyTo = null;
-
-  if (aliasId) {
-    const aliasResult = await query(
-      'SELECT * FROM account_aliases WHERE id = $1 AND account_id = $2',
-      [aliasId, accountId]
-    );
-    if (aliasResult.rows.length) {
-      const alias = aliasResult.rows[0];
-      fromName = alias.name;
-      fromEmail = alias.email;
-      fromReplyTo = alias.reply_to || null;
-      // null (DB default) means inherit from account; only override when alias has an explicit signature set
-      if (alias.signature !== null) fromSignature = alias.signature;
-    }
-  }
 
   // Allow the client to override the signature per-send (editedSignature === undefined means use DB value).
   // Sanitize client-supplied HTML to prevent injecting scripts or tracking pixels into sent mail.
@@ -320,7 +319,7 @@ router.post('/send', async (req, res) => {
       ...(fromReplyTo ? { replyTo: fromReplyTo } : {}),
       to: normalizedTo.join(', '),
       cc: normalizedCc.join(', ') || undefined,
-      bcc: normalizedBcc.join(', ') || undefined,
+      bcc: [...normalizedBcc, ...fromBcc].length ? [...normalizedBcc, ...fromBcc] : undefined,
       subject: normalizedSubject,
       ...(emailPriority !== 'normal' ? { priority: emailPriority } : {}),
       text: effectiveSignature
@@ -537,7 +536,14 @@ router.post('/send', async (req, res) => {
     if (idemKeyRedis) redisClient.set(idemKeyRedis, JSON.stringify(sendResult), { EX: 86400 }).catch(() => {});
     res.json(sendResult);
   } catch (err) {
-    console.error('Send failed:', err.message);
+    const fastmailSenderRejected = !delivered
+      && account.fastmail_api_token
+      && isSenderAuthorizationRejection(err);
+    console.error('Send failed:', account.fastmail_api_token
+      ? (fastmailSenderRejected
+        ? 'Fastmail sender authorization rejected'
+        : 'Fastmail SMTP send failed')
+      : err.message);
     if (idemKeyRedis) {
       if (delivered) {
         // The message WAS delivered but a later step threw. Persist a DURABLE success
@@ -550,6 +556,12 @@ router.post('/send', async (req, res) => {
         // can proceed immediately.
         redisClient.del(idemKeyRedis).catch(() => {});
       }
+    }
+    if (fastmailSenderRejected) {
+      return res.status(422).json({
+        error: 'This sending address is no longer authorized by Fastmail. Refresh addresses or choose another sender.',
+        code: 'SENDER_NOT_AUTHORIZED',
+      });
     }
     res.status(500).json({ error: sanitizeSmtpError(err) });
   }

--- a/backend/src/routes/send.sender.test.js
+++ b/backend/src/routes/send.sender.test.js
@@ -1,0 +1,230 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const smtpSendMail = vi.fn();
+
+vi.mock('nodemailer', () => ({
+  default: { createTransport: vi.fn(() => ({ sendMail: smtpSendMail })) },
+}));
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../services/senderAuthorization.js', () => ({ authorizeSender: vi.fn() }));
+vi.mock('../services/redis.js', () => ({
+  redisClient: { get: vi.fn(), set: vi.fn(), del: vi.fn() },
+}));
+vi.mock('../services/encryption.js', () => ({ decrypt: vi.fn(() => 'access-token') }));
+vi.mock('../services/connectionPolicy.js', () => ({
+  getConnectionPolicy: vi.fn().mockResolvedValue({ allowPrivateHosts: false, allowInsecureTls: false }),
+}));
+vi.mock('../services/hostValidation.js', () => ({
+  resolveForConnection: vi.fn().mockResolvedValue({ host: 'smtp.fastmail.com', servername: 'smtp.fastmail.com' }),
+}));
+vi.mock('../routes/oauth.js', () => ({ refreshMicrosoftToken: vi.fn() }));
+vi.mock('../index.js', () => ({
+  imapManager: {
+    fetchAttachment: vi.fn(), appendToSent: vi.fn(), syncFolderOnDemand: vi.fn(),
+    upsertSentMessageRecord: vi.fn(), findUidByMessageId: vi.fn(),
+  },
+}));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => {
+    req.session = { userId: 'u1' };
+    next();
+  },
+}));
+
+import express from 'express';
+import { query } from '../services/db.js';
+import { authorizeSender } from '../services/senderAuthorization.js';
+import { redisClient } from '../services/redis.js';
+import { imapManager } from '../index.js';
+import sendRoutes from './send.js';
+
+const sender = { accountId: 'a1', aliasId: 'alias-1', fromEmail: null };
+const account = {
+  id: 'a1', name: 'Fastmail', email_address: 'owner@example.com',
+  auth_user: 'owner@example.com', oauth_provider: 'google', oauth_access_token: 'encrypted',
+  smtp_host: 'smtp.fastmail.com', smtp_port: 465, smtp_tls: 'SSL',
+  folder_mappings: {}, fastmail_api_token: 'encrypted-fastmail-token',
+};
+const authorizedSender = {
+  account,
+  fromName: 'Exact Alias',
+  fromEmail: 'alias@example.com',
+  fromReplyTo: 'reply@example.com',
+  fromSignature: '<p>Alias signature</p>',
+};
+
+let server;
+let base;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/mail', sendRoutes);
+  await new Promise(resolve => { server = app.listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+beforeEach(() => {
+  query.mockReset();
+  authorizeSender.mockReset();
+  smtpSendMail.mockReset();
+  redisClient.get.mockReset();
+  redisClient.set.mockReset();
+  redisClient.del.mockReset();
+  redisClient.get.mockResolvedValue(null);
+  for (const fn of Object.values(imapManager)) fn.mockReset();
+  authorizeSender.mockResolvedValue(authorizedSender);
+  smtpSendMail.mockResolvedValue({ accepted: ['to@example.com'] });
+  query.mockImplementation(async sql => {
+    if (sql.includes('SELECT preferences FROM users')) return { rows: [{ preferences: { plaintextEmail: true } }] };
+    if (sql.includes('special_use')) return { rows: [] };
+    return { rows: [] };
+  });
+});
+
+const postSend = (body, idempotencyKey = null) => fetch(`${base}/mail/send`, {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    ...(idempotencyKey ? { 'X-Idempotency-Key': idempotencyKey } : {}),
+  },
+  body: JSON.stringify(body),
+});
+
+describe('POST /mail/send explicit sender', () => {
+  it('authorizes the exact request sender and uses the trusted address for SMTP', async () => {
+    const res = await postSend({ sender, to: ['to@example.com'], subject: 'Hello', body: 'Message' });
+
+    expect(res.status).toBe(200);
+    expect(authorizeSender).toHaveBeenCalledWith({ userId: 'u1', sender });
+    expect(smtpSendMail).toHaveBeenCalledWith(expect.objectContaining({
+      from: 'Exact Alias <alias@example.com>',
+      replyTo: 'reply@example.com',
+    }));
+  });
+
+  it('applies complete Fastmail identity Reply-To and Bcc routing', async () => {
+    authorizeSender.mockResolvedValue({
+      ...authorizedSender,
+      fromReplyTo: [
+        { name: 'Support', address: 'support@example.com' },
+        'archive@example.com',
+      ],
+      fromBcc: [
+        { name: 'Compliance', address: 'compliance@example.com' },
+        'journal@example.com',
+      ],
+    });
+
+    const res = await postSend({
+      sender,
+      to: ['to@example.com'],
+      bcc: ['visible-bcc@example.com'],
+      subject: 'Hello',
+      body: 'Message',
+    });
+
+    expect(res.status).toBe(200);
+    expect(smtpSendMail).toHaveBeenCalledWith(expect.objectContaining({
+      replyTo: [
+        { name: 'Support', address: 'support@example.com' },
+        'archive@example.com',
+      ],
+      bcc: [
+        'visible-bcc@example.com',
+        { name: 'Compliance', address: 'compliance@example.com' },
+        'journal@example.com',
+      ],
+    }));
+  });
+
+  it('returns a cached successful send before reauthorizing a stale sender', async () => {
+    const cached = { messageId: '<cached@example.com>', sentCopySaved: true };
+    redisClient.get.mockResolvedValue(JSON.stringify(cached));
+    authorizeSender.mockRejectedValue(Object.assign(new Error('Sender unavailable'), {
+      status: 422, code: 'SENDER_UNAVAILABLE',
+    }));
+
+    const res = await postSend({ sender, to: ['to@example.com'], body: 'Message' }, 'retry-key');
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(cached);
+    expect(authorizeSender).not.toHaveBeenCalled();
+    expect(smtpSendMail).not.toHaveBeenCalled();
+  });
+
+  it('returns SENDER_UNAVAILABLE before SMTP, IMAP, or attachment side effects', async () => {
+    authorizeSender.mockRejectedValue(Object.assign(new Error('Sender unavailable'), {
+      status: 422, code: 'SENDER_UNAVAILABLE',
+    }));
+
+    const res = await postSend({
+      sender,
+      to: ['to@example.com'],
+      body: 'Message',
+      forwardedAttachments: [{ messageId: '11111111-1111-4111-8111-111111111111', part: '2' }],
+    });
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({ error: 'Sender unavailable', code: 'SENDER_UNAVAILABLE' });
+    expect(smtpSendMail).not.toHaveBeenCalled();
+    expect(imapManager.fetchAttachment).not.toHaveBeenCalled();
+    expect(imapManager.appendToSent).not.toHaveBeenCalled();
+  });
+
+  it('does not expose unexpected sender-authorization failures', async () => {
+    const privateDetail = 'private-database-detail-4581';
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    authorizeSender.mockRejectedValue(new Error(privateDetail));
+
+    const res = await postSend({ sender, to: ['to@example.com'], body: 'Message' });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to authorize sender' });
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain(privateDetail);
+    expect(smtpSendMail).not.toHaveBeenCalled();
+    errorLog.mockRestore();
+  });
+
+  it('maps a true Fastmail 553 From authorization rejection without exposing SMTP details', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    smtpSendMail.mockRejectedValue(Object.assign(new Error('private SMTP details for alias@example.com'), {
+      responseCode: 553,
+      response: '553 From address alias@example.com is not authorized for this identity',
+    }));
+
+    const res = await postSend({ sender, to: ['to@example.com'], body: 'Message' });
+
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({
+      error: 'This sending address is no longer authorized by Fastmail. Refresh addresses or choose another sender.',
+      code: 'SENDER_NOT_AUTHORIZED',
+    });
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('alias@example.com');
+    expect(errorLog.mock.calls.flat().join(' ')).not.toContain('private SMTP details');
+    errorLog.mockRestore();
+  });
+
+  it('does not misclassify a recipient 553 rejection as a sender authorization error', async () => {
+    const sensitiveAlias = 'complete-private-alias@masked.example';
+    const privateDetail = 'private-envelope-marker-8472';
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    smtpSendMail.mockRejectedValue(Object.assign(new Error(`${privateDetail} ${sensitiveAlias}`), {
+      responseCode: 553,
+      response: `553 Recipient ${sensitiveAlias} rejected: mailbox unavailable`,
+    }));
+
+    const res = await postSend({ sender, to: ['missing@example.com'], body: 'Message' });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to send message. Please try again.' });
+    const logs = errorLog.mock.calls.flat().join(' ');
+    expect(logs).not.toContain(sensitiveAlias);
+    expect(logs).not.toContain(privateDetail);
+    errorLog.mockRestore();
+  });
+});

--- a/backend/src/services/db.js
+++ b/backend/src/services/db.js
@@ -51,11 +51,12 @@ export async function encryptExistingCredentials() {
   }
 
   const result = await pool.query(`
-    SELECT id, auth_pass, oauth_access_token, oauth_refresh_token
+    SELECT id, auth_pass, oauth_access_token, oauth_refresh_token, fastmail_api_token
     FROM email_accounts
     WHERE (auth_pass IS NOT NULL AND auth_pass NOT LIKE 'enc:v1:%')
        OR (oauth_access_token IS NOT NULL AND oauth_access_token NOT LIKE 'enc:v1:%')
        OR (oauth_refresh_token IS NOT NULL AND oauth_refresh_token NOT LIKE 'enc:v1:%')
+       OR (fastmail_api_token IS NOT NULL AND fastmail_api_token NOT LIKE 'enc:v1:%')
   `);
 
   let count = 0;
@@ -67,6 +68,9 @@ export async function encryptExistingCredentials() {
       updates.oauth_access_token = encrypt(row.oauth_access_token);
     if (row.oauth_refresh_token && !isEncrypted(row.oauth_refresh_token))
       updates.oauth_refresh_token = encrypt(row.oauth_refresh_token);
+    if (row.fastmail_api_token && !isEncrypted(row.fastmail_api_token)) {
+      updates.fastmail_api_token = encrypt(row.fastmail_api_token);
+    }
 
     if (Object.keys(updates).length) {
       const keys = Object.keys(updates);

--- a/backend/src/services/fastmailAliasSync.js
+++ b/backend/src/services/fastmailAliasSync.js
@@ -1,0 +1,530 @@
+import { pool, query } from './db.js';
+import { decrypt } from './encryption.js';
+import { sanitizeSignature } from './emailSanitizer.js';
+import {
+  hasHeaderControlCharacters,
+  normalizeEmailAddress,
+  normalizeSenderAddress,
+  wildcardCovers,
+} from './senderAddress.js';
+import {
+  createFastmailIdentities,
+  fastmailSyncError,
+  fetchFastmailSnapshot,
+  loadFastmailSession,
+} from './fastmailClient.js';
+
+const FASTMAIL_SYNC_INTERVAL_MS = 15 * 60 * 1000;
+const FASTMAIL_SYNC_CONCURRENCY = 3;
+const FASTMAIL_LOCK_WAIT_MS = (3 * 60 * 1000) + 30 * 1000;
+const FASTMAIL_LOCK_RETRY_MS = 100;
+const FASTMAIL_MASK_STATES = new Set(['pending', 'enabled', 'disabled', 'deleted']);
+const FASTMAIL_LOCK_NAMESPACE = 'mailflow:fastmail-alias-sync';
+// A full session/get/set/get sequence times out within two minutes. Retain an
+// ambiguous create claim beyond that window before allowing a safe retry.
+const FASTMAIL_PROMOTION_CLAIM_TTL = '5 minutes';
+const inFlight = new Map();
+const syncWaiters = [];
+let activeSyncs = 0;
+
+// A distinct sync-class error: another worker holds the promotion claim, so this sync
+// must back off. Its own code lets the caller skip recording it as a persistent sync
+// error while still treating it as a synchronization failure.
+function fastmailPromotionPendingError() {
+  return Object.assign(
+    new Error('Fastmail identity promotion is already in progress'),
+    { code: 'FASTMAIL_PROMOTION_PENDING' },
+  );
+}
+
+async function withSyncSlot(callback) {
+  if (activeSyncs >= FASTMAIL_SYNC_CONCURRENCY) {
+    await new Promise(resolve => syncWaiters.push(resolve));
+  } else {
+    activeSyncs += 1;
+  }
+  try {
+    return await callback();
+  } finally {
+    const next = syncWaiters.shift();
+    if (next) next();
+    else activeSyncs -= 1;
+  }
+}
+
+async function acquireFastmailLock(accountId) {
+  // The database session owns this lock for the whole remote sync, so unlike a
+  // leased Redis key it cannot expire while a worker is still reconciling.
+  const client = await pool.connect();
+  const lock = { accountId, client, connectionError: null, onError: null };
+  lock.onError = error => {
+    lock.connectionError ||= error;
+  };
+  client.on('error', lock.onError);
+  const deadline = Date.now() + FASTMAIL_LOCK_WAIT_MS;
+  try {
+    do {
+      assertFastmailLock(lock);
+      const result = await client.query(
+        'SELECT pg_try_advisory_lock(hashtext($1), hashtext($2)) AS acquired',
+        [FASTMAIL_LOCK_NAMESPACE, String(accountId)],
+      );
+      assertFastmailLock(lock);
+      if (result.rows[0]?.acquired) return lock;
+      await new Promise(resolve => setTimeout(resolve, FASTMAIL_LOCK_RETRY_MS));
+    } while (Date.now() < deadline);
+  } catch (error) {
+    client.off('error', lock.onError);
+    client.release(lock.connectionError || error);
+    throw error;
+  }
+  client.off('error', lock.onError);
+  client.release();
+  throw fastmailSyncError('Fastmail synchronization is already in progress');
+}
+
+function assertFastmailLock(lock) {
+  if (lock.connectionError) {
+    throw fastmailSyncError('Fastmail synchronization lock was lost');
+  }
+}
+
+async function withFastmailLock(lock, operation) {
+  assertFastmailLock(lock);
+  const result = await operation();
+  assertFastmailLock(lock);
+  return result;
+}
+
+async function withFastmailTransaction(lock, operation) {
+  assertFastmailLock(lock);
+  await lock.client.query('BEGIN');
+  try {
+    assertFastmailLock(lock);
+    const result = await operation(lock.client);
+    assertFastmailLock(lock);
+    await lock.client.query('COMMIT');
+    return result;
+  } catch (error) {
+    await lock.client.query('ROLLBACK').catch(() => {});
+    throw error;
+  }
+}
+
+async function releaseFastmailLock(lock) {
+  let releaseError = lock.connectionError;
+  try {
+    if (!releaseError) {
+      await lock.client.query(
+        'SELECT pg_advisory_unlock(hashtext($1), hashtext($2))',
+        [FASTMAIL_LOCK_NAMESPACE, String(lock.accountId)],
+      );
+    }
+  } catch (error) {
+    releaseError = error;
+    throw error;
+  } finally {
+    lock.client.off('error', lock.onError);
+    if (releaseError) lock.client.release(releaseError);
+    else lock.client.release();
+  }
+}
+
+function identitySignature(identity) {
+  if (identity.htmlSignature.trim()) {
+    return sanitizeSignature(identity.htmlSignature);
+  }
+  if (!identity.textSignature) return '';
+  const escaped = identity.textSignature
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+    .replace(/\r\n|\r|\n/g, '<br>');
+  return sanitizeSignature(escaped);
+}
+
+function identityAddressList(value) {
+  if (value === null) return [];
+  if (!Array.isArray(value)) throw fastmailSyncError('Fastmail returned an invalid alias snapshot');
+  return value.map(address => {
+    const email = normalizeEmailAddress(address?.email);
+    const name = address?.name ?? '';
+    if (!email || typeof name !== 'string' || hasHeaderControlCharacters(name)) {
+      throw fastmailSyncError('Fastmail returned an invalid alias snapshot');
+    }
+    return { name, email };
+  });
+}
+
+function aliasFromIdentity(identity, email) {
+  const fastmailReplyTo = identityAddressList(identity.replyTo);
+  const fastmailBcc = identityAddressList(identity.bcc);
+  return {
+    email,
+    name: identity.name,
+    replyTo: fastmailReplyTo[0]?.email || null,
+    signature: identitySignature(identity),
+    fastmailReplyTo,
+    fastmailBcc,
+    fastmailIdentityId: identity.id,
+    fastmailMaskedEmailId: null,
+    fastmailLabel: null,
+  };
+}
+
+export function mergeFastmailSnapshot({ account, identities, maskedEmails }) {
+  if (!Array.isArray(identities) || !Array.isArray(maskedEmails)) {
+    throw fastmailSyncError('Fastmail returned an invalid alias snapshot');
+  }
+  const aliases = [];
+  const identitiesByAddress = new Map();
+  const wildcardIdentities = [];
+  const identityIds = new Set();
+  const maskedEmailIds = new Set();
+
+  for (const identity of identities) {
+    const email = normalizeSenderAddress(identity?.email);
+    if (
+      !identity || typeof identity.id !== 'string' || !identity.id
+      || identityIds.has(identity.id)
+      || !email
+      || typeof identity.name !== 'string'
+      || hasHeaderControlCharacters(identity.name)
+      || typeof identity.textSignature !== 'string'
+      || typeof identity.htmlSignature !== 'string'
+      || (identity.replyTo !== null && !Array.isArray(identity.replyTo))
+      || (identity.bcc !== null && !Array.isArray(identity.bcc))
+    ) {
+      throw fastmailSyncError('Fastmail returned an invalid alias snapshot');
+    }
+    identityIds.add(identity.id);
+    const alias = aliasFromIdentity(identity, email);
+    aliases.push(alias);
+    if (email.startsWith('*@')) wildcardIdentities.push(email);
+    const sameAddress = identitiesByAddress.get(email) || [];
+    sameAddress.push(alias);
+    identitiesByAddress.set(email, sameAddress);
+  }
+
+  const missingMasks = [];
+  for (const mask of maskedEmails) {
+    const email = normalizeEmailAddress(mask?.email);
+    if (
+      !mask || typeof mask.id !== 'string' || !mask.id
+      || maskedEmailIds.has(mask.id)
+      || !email
+      || !FASTMAIL_MASK_STATES.has(mask.state)
+      || typeof mask.description !== 'string'
+    ) {
+      throw fastmailSyncError('Fastmail returned an invalid alias snapshot');
+    }
+    maskedEmailIds.add(mask.id);
+    if (mask.state !== 'enabled') continue;
+    const exact = identitiesByAddress.get(email)?.[0];
+    if (exact) {
+      exact.fastmailMaskedEmailId = mask.id;
+      exact.fastmailLabel = mask.description;
+      continue;
+    }
+    const wildcard = wildcardIdentities.find(pattern => wildcardCovers(pattern, email));
+    const maskAlias = {
+      email,
+      name: account.sender_name || account.name || '',
+      replyTo: null,
+      signature: '',
+      fastmailReplyTo: [],
+      fastmailBcc: [],
+      fastmailIdentityId: null,
+      fastmailMaskedEmailId: mask.id,
+      fastmailLabel: mask.description,
+    };
+    aliases.push(maskAlias);
+    if (!wildcard) missingMasks.push({ ...mask, email });
+  }
+
+  return { aliases, missingMasks };
+}
+
+function safeSyncMessage(error) {
+  // Fastmail config/sync errors (including the promotion-pending sync sub-case) carry
+  // fixed, user-safe messages; anything else is reduced to a generic status.
+  if (error.code === 'FASTMAIL_CONFIG'
+      || error.code === 'FASTMAIL_SYNC'
+      || error.code === 'FASTMAIL_PROMOTION_PENDING') {
+    return error.message;
+  }
+  return 'Fastmail synchronization failed';
+}
+
+async function clearResolvedPromotionClaims(accountId, missingMasks) {
+  await query(
+    `DELETE FROM fastmail_identity_promotions
+     WHERE account_id = $1
+       AND NOT (masked_email_id = ANY($2::varchar[]))`,
+    [accountId, missingMasks.map(mask => mask.id)],
+  );
+}
+
+async function claimFastmailPromotions(accountId, missingMasks) {
+  if (!missingMasks.length) return [];
+  const claims = missingMasks.map(mask => ({ id: mask.id, email: mask.email }));
+  const result = await query(
+    `INSERT INTO fastmail_identity_promotions (account_id, masked_email_id, email, claimed_at)
+     SELECT $1, item.id, item.email, NOW()
+     FROM jsonb_to_recordset($2::jsonb) AS item(id varchar(255), email varchar(255))
+     ON CONFLICT (account_id, masked_email_id) DO UPDATE
+       SET email = EXCLUDED.email, claimed_at = NOW()
+       WHERE fastmail_identity_promotions.claimed_at < NOW() - $3::interval
+     RETURNING masked_email_id`,
+    [accountId, JSON.stringify(claims), FASTMAIL_PROMOTION_CLAIM_TTL],
+  );
+  const claimedIds = new Set(result.rows.map(row => row.masked_email_id));
+  return missingMasks.filter(mask => claimedIds.has(mask.id));
+}
+
+async function recordSyncError(accountId, credentialVersion, error) {
+  await query(
+    `UPDATE email_accounts
+     SET fastmail_sync_error = $2
+     WHERE id = $1 AND fastmail_api_token = $3`,
+    [accountId, safeSyncMessage(error), credentialVersion],
+  );
+}
+
+async function loadLockedAccount(client, accountId) {
+  const accountResult = await client.query(
+    `SELECT *
+     FROM email_accounts
+     WHERE id = $1
+     FOR UPDATE`,
+    [accountId],
+  );
+  return accountResult.rows[0] || null;
+}
+
+async function reconcileFastmailAliases(client, accountId, credentialVersion, aliases) {
+  const existingResult = await client.query(
+    `SELECT id, email, fastmail_identity_id, fastmail_masked_email_id
+     FROM account_aliases
+     WHERE account_id = $1 AND provenance = 'fastmail'`,
+    [accountId],
+  );
+  const providerKey = alias => {
+    if (alias.fastmailIdentityId) return `identity:${alias.fastmailIdentityId}`;
+    if (alias.fastmailMaskedEmailId) return `mask:${alias.fastmailMaskedEmailId}`;
+    return null;
+  };
+  const existingByProviderKey = new Map(
+    existingResult.rows
+      .map(row => [providerKey({
+        fastmailIdentityId: row.fastmail_identity_id,
+        fastmailMaskedEmailId: row.fastmail_masked_email_id,
+      }), row])
+      .filter(([key]) => key),
+  );
+  const existingByMaskId = new Map(
+    existingResult.rows
+      .filter(row => row.fastmail_masked_email_id)
+      .map(row => [row.fastmail_masked_email_id, row]),
+  );
+  const retainedIds = [];
+
+  for (const alias of aliases) {
+    if (!alias.fastmailMaskedEmailId) continue;
+    const previousHolder = existingByMaskId.get(alias.fastmailMaskedEmailId);
+    if (!previousHolder
+        || previousHolder.fastmail_identity_id === alias.fastmailIdentityId) continue;
+    await client.query(
+      `UPDATE account_aliases
+       SET fastmail_masked_email_id = NULL, fastmail_label = NULL
+       WHERE account_id = $1 AND provenance = 'fastmail'
+         AND fastmail_masked_email_id = $2
+         AND fastmail_identity_id IS DISTINCT FROM $3`,
+      [accountId, alias.fastmailMaskedEmailId, alias.fastmailIdentityId],
+    );
+  }
+
+  for (const alias of aliases) {
+    const existing = existingByProviderKey.get(providerKey(alias));
+    if (existing) {
+      await client.query(
+        `UPDATE account_aliases
+         SET name = $1, email = $2, reply_to = $3, signature = $4,
+             fastmail_identity_id = $5, fastmail_masked_email_id = $6,
+             fastmail_label = $7, fastmail_reply_to = $8, fastmail_bcc = $9
+         WHERE id = $10 AND account_id = $11 AND provenance = 'fastmail'`,
+        [
+          alias.name, alias.email, alias.replyTo, alias.signature,
+          alias.fastmailIdentityId, alias.fastmailMaskedEmailId, alias.fastmailLabel,
+          JSON.stringify(alias.fastmailReplyTo), JSON.stringify(alias.fastmailBcc),
+          existing.id, accountId,
+        ],
+      );
+      retainedIds.push(existing.id);
+    } else {
+      const inserted = await client.query(
+        `INSERT INTO account_aliases (
+           account_id, name, email, reply_to, signature, provenance,
+           fastmail_identity_id, fastmail_masked_email_id, fastmail_label,
+           fastmail_reply_to, fastmail_bcc
+         ) VALUES ($1, $2, $3, $4, $5, 'fastmail', $6, $7, $8, $9, $10)
+         RETURNING id`,
+        [
+          accountId, alias.name, alias.email, alias.replyTo, alias.signature,
+          alias.fastmailIdentityId, alias.fastmailMaskedEmailId, alias.fastmailLabel,
+          JSON.stringify(alias.fastmailReplyTo), JSON.stringify(alias.fastmailBcc),
+        ],
+      );
+      retainedIds.push(inserted.rows[0].id);
+    }
+  }
+
+  if (retainedIds.length) {
+    await client.query(
+      `DELETE FROM account_aliases
+       WHERE account_id = $1 AND provenance = 'fastmail' AND NOT (id = ANY($2))`,
+      [accountId, retainedIds],
+    );
+  } else {
+    await client.query(
+      "DELETE FROM account_aliases WHERE account_id = $1 AND provenance = 'fastmail'",
+      [accountId],
+    );
+  }
+  await client.query(
+    `UPDATE email_accounts
+     SET fastmail_last_sync = NOW(), fastmail_sync_error = NULL
+     WHERE id = $1 AND fastmail_api_token = $2`,
+    [accountId, credentialVersion],
+  );
+}
+
+async function performSync(accountId) {
+  return withSyncSlot(async () => {
+    const lock = await acquireFastmailLock(accountId);
+    let credentialVersion;
+    try {
+      const accountResult = await query(
+        'SELECT * FROM email_accounts WHERE id = $1',
+        [accountId],
+      );
+      const account = accountResult.rows[0];
+      if (!account?.fastmail_api_token) {
+        throw fastmailSyncError('Fastmail is not configured for this account');
+      }
+      credentialVersion = account.fastmail_api_token;
+      const token = decrypt(credentialVersion);
+      if (!token) throw fastmailSyncError('Fastmail API token could not be decrypted');
+
+      const session = await withFastmailLock(lock, () => loadFastmailSession(token));
+      let remote = await withFastmailLock(lock, () => fetchFastmailSnapshot(session, token));
+      let merged = mergeFastmailSnapshot({ account, ...remote });
+      await withFastmailLock(lock, () => clearResolvedPromotionClaims(accountId, merged.missingMasks));
+
+      if (merged.missingMasks.length) {
+        const claimed = await withFastmailLock(
+          lock,
+          () => claimFastmailPromotions(accountId, merged.missingMasks),
+        );
+        const claimedIds = new Set(claimed.map(mask => mask.id));
+        const pendingIds = new Set(
+          merged.missingMasks.filter(mask => !claimedIds.has(mask.id)).map(mask => mask.id),
+        );
+        if (claimed.length) {
+          await withFastmailLock(lock, () => createFastmailIdentities(session, token, claimed.map(mask => ({
+            name: account.sender_name || account.name,
+            email: normalizeEmailAddress(mask.email),
+          }))));
+          remote = await withFastmailLock(lock, () => fetchFastmailSnapshot(session, token));
+          merged = mergeFastmailSnapshot({ account, ...remote });
+          await withFastmailLock(lock, () => clearResolvedPromotionClaims(accountId, merged.missingMasks));
+        }
+        if (merged.missingMasks.some(mask => pendingIds.has(mask.id))) {
+          throw fastmailPromotionPendingError();
+        }
+      }
+
+      await withFastmailTransaction(lock, async client => {
+        const lockedAccount = await loadLockedAccount(client, accountId);
+        if (lockedAccount?.fastmail_api_token !== credentialVersion) {
+          throw fastmailSyncError('Fastmail credentials changed during synchronization');
+        }
+        await reconcileFastmailAliases(client, accountId, credentialVersion, merged.aliases);
+      });
+      if (merged.missingMasks.length) {
+        throw fastmailSyncError('Fastmail did not authorize every enabled Masked Email address');
+      }
+      return merged.aliases;
+    } catch (error) {
+      try {
+        if (
+          credentialVersion
+          && !lock.connectionError
+          && error.code !== 'FASTMAIL_PROMOTION_PENDING'
+        ) {
+          await recordSyncError(accountId, credentialVersion, error);
+        }
+      } catch {
+        // Preserve the original failure. Error-status persistence is best effort and
+        // intentionally has no sensitive context to log.
+      }
+      throw error;
+    } finally {
+      try {
+        await releaseFastmailLock(lock);
+      } catch {
+        console.error('Fastmail synchronization lock release failed');
+      }
+    }
+  });
+}
+
+export function syncFastmailAliases(accountId, options = {}) {
+  const current = inFlight.get(accountId);
+  if (current && !options.credentialChanged) return current;
+  const work = current
+    ? current.catch(() => {}).then(() => performSync(accountId))
+    : performSync(accountId);
+  const promise = work.finally(() => {
+    if (inFlight.get(accountId) === promise) inFlight.delete(accountId);
+  });
+  inFlight.set(accountId, promise);
+  return promise;
+}
+
+export async function syncAllFastmailAliases() {
+  const result = await query(
+    `SELECT id FROM email_accounts
+     WHERE enabled = true AND fastmail_api_token IS NOT NULL`,
+  );
+  const queue = [...result.rows];
+  let failed = false;
+  async function worker() {
+    while (queue.length) {
+      const { id } = queue.shift();
+      try {
+        await syncFastmailAliases(id);
+      } catch {
+        failed = true;
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(FASTMAIL_SYNC_CONCURRENCY, queue.length) }, worker));
+  if (failed) throw fastmailSyncError('One or more Fastmail accounts failed to synchronize');
+}
+
+function logSafeSyncFailure() {
+  console.error('Fastmail background synchronization failed');
+}
+
+export function startFastmailAliasScheduler() {
+  syncAllFastmailAliases().catch(logSafeSyncFailure);
+  const timer = setInterval(
+    () => syncAllFastmailAliases().catch(logSafeSyncFailure),
+    FASTMAIL_SYNC_INTERVAL_MS,
+  );
+  timer.unref();
+  return timer;
+}

--- a/backend/src/services/fastmailAliasSync.test.js
+++ b/backend/src/services/fastmailAliasSync.test.js
@@ -1,0 +1,970 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+vi.mock('./db.js', () => ({
+  pool: { connect: vi.fn() },
+  query: vi.fn(),
+}));
+vi.mock('./encryption.js', () => ({ decrypt: vi.fn(value => `plain:${value}`) }));
+vi.mock('./fastmailClient.js', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    loadFastmailSession: vi.fn(),
+    fetchFastmailSnapshot: vi.fn(),
+    createFastmailIdentities: vi.fn(),
+  };
+});
+
+import { pool, query } from './db.js';
+import { decrypt } from './encryption.js';
+import {
+  createFastmailIdentities,
+  fetchFastmailSnapshot,
+  loadFastmailSession,
+} from './fastmailClient.js';
+import {
+  mergeFastmailSnapshot,
+  startFastmailAliasScheduler,
+  syncAllFastmailAliases,
+  syncFastmailAliases,
+} from './fastmailAliasSync.js';
+import { wildcardCovers } from './senderAddress.js';
+
+const account = {
+  id: 'a1', name: 'Mailbox', sender_name: 'Configured Sender',
+  fastmail_api_token: 'encrypted-token',
+};
+const session = { apiUrl: 'https://api.fastmail.com/jmap/api/' };
+const tx = { query: vi.fn() };
+let advisoryLocks;
+let lockClients;
+
+function identity(email, overrides = {}) {
+  return {
+    id: `identity-${email}`, name: 'Identity Name', email,
+    replyTo: null, bcc: null, textSignature: '', htmlSignature: '', ...overrides,
+  };
+}
+
+function mask(email, overrides = {}) {
+  return { id: `mask-${email}`, email, state: 'enabled', description: '', ...overrides };
+}
+
+function completeSnapshot(email = 'alias@example.com') {
+  return { identities: [identity(email)], maskedEmails: [mask(email)] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  query.mockImplementation((sql, params) => {
+    if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [account] });
+    if (sql.includes('INSERT INTO fastmail_identity_promotions')) {
+      return Promise.resolve({
+        rows: JSON.parse(params[1]).map(item => ({ masked_email_id: item.id })),
+      });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+  advisoryLocks = new Map();
+  lockClients = [];
+  pool.connect.mockImplementation(async () => {
+    const client = new EventEmitter();
+    client.query = vi.fn(async (sql, params) => {
+      const key = params?.join(':');
+      if (sql.includes('pg_try_advisory_lock')) {
+        if (advisoryLocks.has(key)) return { rows: [{ acquired: false }] };
+        advisoryLocks.set(key, client);
+        return { rows: [{ acquired: true }] };
+      }
+      if (sql.includes('pg_advisory_unlock')) {
+        const owned = advisoryLocks.get(key) === client;
+        if (owned) advisoryLocks.delete(key);
+        return { rows: [{ pg_advisory_unlock: owned }] };
+      }
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rows: [] };
+      return tx.query(sql, params);
+    });
+    client.release = vi.fn();
+    lockClients.push(client);
+    return client;
+  });
+  let inserted = 0;
+  tx.query.mockImplementation(sql => Promise.resolve(
+    sql.includes('FOR UPDATE')
+      ? { rows: [account] }
+      : sql.includes('INSERT INTO account_aliases')
+        ? { rows: [{ id: `inserted-${++inserted}` }] }
+        : { rows: [] },
+  ));
+  loadFastmailSession.mockResolvedValue(session);
+  fetchFastmailSnapshot.mockResolvedValue(completeSnapshot());
+  createFastmailIdentities.mockResolvedValue(undefined);
+});
+
+describe('mergeFastmailSnapshot', () => {
+  it('merges identity and enabled mask case-insensitively with identity metadata precedence', () => {
+    expect(mergeFastmailSnapshot({
+      account,
+      identities: [identity('MASK@Example.com', {
+        id: 'i1', name: 'Alice',
+        replyTo: [{ name: '', email: 'reply@example.com' }],
+        htmlSignature: '<b>Alice</b>',
+      })],
+      maskedEmails: [mask('mask@example.com', { id: 'm1', description: 'Shopping' })],
+    })).toMatchObject({
+      aliases: [{
+        email: 'mask@example.com', name: 'Alice', replyTo: 'reply@example.com',
+        signature: '<b>Alice</b>', fastmailIdentityId: 'i1',
+        fastmailMaskedEmailId: 'm1', fastmailLabel: 'Shopping',
+      }],
+      missingMasks: [],
+    });
+  });
+
+  it('keeps identities and enabled masks, but ignores non-enabled masks', () => {
+    const result = mergeFastmailSnapshot({
+      account,
+      identities: [identity('send@example.com')],
+      maskedEmails: [
+        mask('pending@example.com', { state: 'pending' }),
+        mask('deleted@example.com', { state: 'deleted' }),
+      ],
+    });
+    expect(result.aliases.map(item => item.email)).toEqual(['send@example.com']);
+    expect(result.missingMasks).toEqual([]);
+  });
+
+  it('preserves distinct Fastmail identities that share one email address', () => {
+    const result = mergeFastmailSnapshot({
+      account,
+      identities: [
+        identity('shared@example.com', {
+          id: 'identity-formal',
+          name: 'Formal Name',
+          htmlSignature: '<p>Formal signature</p>',
+        }),
+        identity('SHARED@example.com', {
+          id: 'identity-casual',
+          name: 'Casual Name',
+          htmlSignature: '<p>Casual signature</p>',
+        }),
+      ],
+      maskedEmails: [],
+    });
+
+    expect(result.aliases).toMatchObject([
+      {
+        email: 'shared@example.com',
+        name: 'Formal Name',
+        signature: '<p>Formal signature</p>',
+        fastmailIdentityId: 'identity-formal',
+      },
+      {
+        email: 'shared@example.com',
+        name: 'Casual Name',
+        signature: '<p>Casual signature</p>',
+        fastmailIdentityId: 'identity-casual',
+      },
+    ]);
+  });
+
+  it.each(['pending', 'disabled', 'deleted'])(
+    'keeps an exact Identity sendable when its same-address Masked Email is %s',
+    state => {
+      const result = mergeFastmailSnapshot({
+        account,
+        identities: [identity('Overlap@Example.com', {
+          id: 'identity-overlap',
+          name: 'Verified Identity',
+          replyTo: [{ name: '', email: 'reply@example.com' }],
+          htmlSignature: '<b>Verified</b>',
+        })],
+        maskedEmails: [mask('overlap@example.com', {
+          id: `mask-${state}`,
+          state,
+          description: `Mask ${state}`,
+        })],
+      });
+
+      expect(result).toMatchObject({
+        aliases: [{
+          email: 'overlap@example.com',
+          name: 'Verified Identity',
+          replyTo: 'reply@example.com',
+          signature: '<b>Verified</b>',
+          fastmailIdentityId: 'identity-overlap',
+          fastmailMaskedEmailId: null,
+          fastmailLabel: null,
+        }],
+        missingMasks: [],
+      });
+    },
+  );
+
+  it('converts text signatures to safe HTML and sanitizes HTML signatures', () => {
+    const result = mergeFastmailSnapshot({
+      account,
+      identities: [
+        identity('text@example.com', { textSignature: '<Alice>\nTeam' }),
+        identity('html@example.com', { htmlSignature: '<b onclick="bad()">Alice</b><script>bad()</script>' }),
+      ],
+      maskedEmails: [],
+    });
+    expect(result.aliases[0].signature).toBe('&lt;Alice&gt;<br />Team');
+    expect(result.aliases[1].signature).toBe('<b>Alice</b>');
+  });
+
+  it('preserves every identity Reply-To and Bcc address', () => {
+    const result = mergeFastmailSnapshot({
+      account,
+      identities: [identity('sender@example.com', {
+        replyTo: [
+          { name: 'Support', email: 'Support@Example.com' },
+          { name: null, email: 'archive@example.com' },
+        ],
+        bcc: [
+          { name: 'Compliance', email: 'compliance@example.com' },
+          { name: '', email: 'journal@example.com' },
+        ],
+      })],
+      maskedEmails: [],
+    });
+
+    expect(result.aliases[0]).toMatchObject({
+      replyTo: 'support@example.com',
+      fastmailReplyTo: [
+        { name: 'Support', email: 'support@example.com' },
+        { name: '', email: 'archive@example.com' },
+      ],
+      fastmailBcc: [
+        { name: 'Compliance', email: 'compliance@example.com' },
+        { name: '', email: 'journal@example.com' },
+      ],
+    });
+  });
+
+  it('rejects malformed remote records instead of treating them as a complete snapshot', () => {
+    expect(() => mergeFastmailSnapshot({
+      account,
+      identities: [identity('valid@example.com')],
+      maskedEmails: [{ id: 'm1', state: 'enabled' }],
+    })).toThrow('Fastmail returned an invalid alias snapshot');
+  });
+
+  it.each([
+    'not-an-address',
+    'two@@example.com',
+    '*example.com',
+    '*@bad domain.example',
+  ])('rejects malformed remote identity address %s', email => {
+    expect(() => mergeFastmailSnapshot({
+      account,
+      identities: [identity(email)],
+      maskedEmails: [],
+    })).toThrow('Fastmail returned an invalid alias snapshot');
+  });
+
+  it('rejects malformed identity reply-to addresses', () => {
+    expect(() => mergeFastmailSnapshot({
+      account,
+      identities: [identity('valid@example.com', { replyTo: [{ email: 'not-an-address' }] })],
+      maskedEmails: [],
+    })).toThrow('Fastmail returned an invalid alias snapshot');
+  });
+
+  it.each([
+    ['name', { name: null }],
+    ['header-unsafe name', { name: 'Sender\r\nBcc: victim@example.com' }],
+    ['text signature', { textSignature: null }],
+    ['HTML signature', { htmlSignature: null }],
+    ['Reply-To list', { replyTo: undefined }],
+    ['Bcc list', { bcc: undefined }],
+  ])('rejects an identity with malformed %s metadata', (_field, overrides) => {
+    expect(() => mergeFastmailSnapshot({
+      account,
+      identities: [identity('valid@example.com', overrides)],
+      maskedEmails: [],
+    })).toThrow('Fastmail returned an invalid alias snapshot');
+  });
+
+  it.each([
+    ['Identity', {
+      identities: [
+        identity('one@example.com', { id: 'duplicate' }),
+        identity('two@example.com', { id: 'duplicate' }),
+      ],
+      maskedEmails: [],
+    }],
+    ['Masked Email', {
+      identities: [],
+      maskedEmails: [
+        mask('one@example.com', { id: 'duplicate' }),
+        mask('two@example.com', { id: 'duplicate' }),
+      ],
+    }],
+  ])('rejects duplicate %s provider IDs', (_type, snapshot) => {
+    expect(() => mergeFastmailSnapshot({ account, ...snapshot }))
+      .toThrow('Fastmail returned an invalid alias snapshot');
+  });
+
+  it.each([
+    ['unknown state', { state: 'paused' }],
+    ['non-string description', { description: null }],
+  ])('rejects a Masked Email with %s', (_field, overrides) => {
+    expect(() => mergeFastmailSnapshot({
+      account,
+      identities: [],
+      maskedEmails: [mask('valid@example.com', overrides)],
+    })).toThrow('Fastmail returned an invalid alias snapshot');
+  });
+
+  it('reports only masks lacking exact or exact-domain wildcard authorization for promotion', () => {
+    const result = mergeFastmailSnapshot({
+      account,
+      identities: [identity('*@example.com', { id: 'wild' })],
+      maskedEmails: [mask('covered@example.com'), mask('missing@sub.example.com')],
+    });
+    expect(wildcardCovers('*@example.com', 'covered@example.com')).toBe(true);
+    expect(wildcardCovers('*@example.com', 'covered@sub.example.com')).toBe(false);
+    expect(result.missingMasks.map(item => item.email)).toEqual(['missing@sub.example.com']);
+    expect(result.aliases.find(item => item.email === 'covered@example.com')).toMatchObject({
+      fastmailIdentityId: null,
+      fastmailMaskedEmailId: 'mask-covered@example.com',
+    });
+  });
+});
+
+describe('syncFastmailAliases', () => {
+  it('aborts without reconciling when the lock-owning connection is lost', async () => {
+    const connectionError = new Error('database connection lost');
+    const client = new EventEmitter();
+    client.query = vi.fn(async sql => (
+      sql.includes('pg_try_advisory_lock')
+        ? { rows: [{ acquired: true }] }
+        : { rows: [] }
+    ));
+    client.release = vi.fn();
+    pool.connect.mockResolvedValue(client);
+    let releaseRemote;
+    loadFastmailSession.mockImplementationOnce(() => new Promise(resolve => {
+      releaseRemote = () => resolve(session);
+    }));
+
+    const syncing = syncFastmailAliases('a1');
+    try {
+      await vi.waitFor(() => expect(releaseRemote).toBeTypeOf('function'));
+      expect(() => client.emit('error', connectionError)).not.toThrow();
+      releaseRemote();
+
+      await expect(syncing).rejects.toThrow('Fastmail synchronization lock was lost');
+      expect(client.query.mock.calls.some(([sql]) => sql === 'BEGIN')).toBe(false);
+      expect(client.release).toHaveBeenCalledWith(connectionError);
+      expect(query.mock.calls.some(([sql]) => sql.includes('fastmail_sync_error = $2'))).toBe(false);
+    } finally {
+      releaseRemote?.();
+      await Promise.allSettled([syncing]);
+    }
+  });
+
+  it('does not duplicate an in-flight identity promotion after lock loss', async () => {
+    const workerOne = await import('./fastmailAliasSync.js?worker=promotion-one');
+    const workerTwo = await import('./fastmailAliasSync.js?worker=promotion-two');
+    const claims = new Set();
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [account] };
+      if (sql.includes('INSERT INTO fastmail_identity_promotions')) {
+        const rows = [];
+        for (const item of JSON.parse(params[1])) {
+          if (claims.has(item.id)) continue;
+          claims.add(item.id);
+          rows.push({ masked_email_id: item.id });
+        }
+        return { rows };
+      }
+      return { rows: [] };
+    });
+    fetchFastmailSnapshot.mockResolvedValue({
+      identities: [],
+      maskedEmails: [mask('private@example.com', { id: 'mask-private' })],
+    });
+    let finishFirstPromotion;
+    createFastmailIdentities
+      .mockImplementationOnce(() => new Promise(resolve => { finishFirstPromotion = resolve; }))
+      .mockResolvedValue(undefined);
+
+    const first = workerOne.syncFastmailAliases('a1');
+    await vi.waitFor(() => expect(finishFirstPromotion).toBeTypeOf('function'));
+    const firstClient = lockClients[0];
+    firstClient.emit('error', new Error('database connection lost'));
+    for (const [key, owner] of advisoryLocks) {
+      if (owner === firstClient) advisoryLocks.delete(key);
+    }
+
+    const second = workerTwo.syncFastmailAliases('a1');
+    await expect(second).rejects.toThrow('Fastmail identity promotion is already in progress');
+    expect(createFastmailIdentities).toHaveBeenCalledOnce();
+
+    finishFirstPromotion();
+    await expect(first).rejects.toThrow('Fastmail synchronization lock was lost');
+  });
+
+  it('discards the advisory-lock connection when lock acquisition fails', async () => {
+    const error = new Error('lock connection failed');
+    const client = new EventEmitter();
+    client.query = vi.fn().mockRejectedValue(error);
+    client.release = vi.fn();
+    pool.connect.mockResolvedValue(client);
+
+    await expect(syncFastmailAliases('a1')).rejects.toThrow(error);
+    expect(client.release).toHaveBeenCalledWith(error);
+  });
+
+  it('discards the advisory-lock connection when unlock fails', async () => {
+    const error = new Error('unlock failed');
+    const client = new EventEmitter();
+    client.query = vi.fn(async (sql, params) => {
+      if (sql.includes('pg_try_advisory_lock')) return { rows: [{ acquired: true }] };
+      if (sql.includes('pg_advisory_unlock')) throw error;
+      if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return { rows: [] };
+      return tx.query(sql, params);
+    });
+    client.release = vi.fn();
+    pool.connect.mockResolvedValue(client);
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await syncFastmailAliases('a1');
+
+    expect(client.release).toHaveBeenCalledWith(error);
+    expect(errorLog).toHaveBeenCalledWith('Fastmail synchronization lock release failed');
+    errorLog.mockRestore();
+  });
+
+  it('batches all promotions, rereads, verifies, then mutates local rows transactionally', async () => {
+    fetchFastmailSnapshot
+      .mockResolvedValueOnce({ identities: [], maskedEmails: [mask('one@example.com'), mask('two@example.com')] })
+      .mockResolvedValueOnce({
+        identities: [identity('one@example.com'), identity('two@example.com')],
+        maskedEmails: [mask('one@example.com'), mask('two@example.com')],
+      });
+
+    await syncFastmailAliases('a1');
+
+    expect(createFastmailIdentities).toHaveBeenCalledOnce();
+    expect(createFastmailIdentities.mock.calls[0][2]).toEqual([
+      { name: 'Configured Sender', email: 'one@example.com' },
+      { name: 'Configured Sender', email: 'two@example.com' },
+    ]);
+    expect(fetchFastmailSnapshot).toHaveBeenCalledTimes(2);
+    expect(lockClients[0].query).toHaveBeenCalledWith('BEGIN');
+    expect(lockClients[0].query).toHaveBeenCalledWith('COMMIT');
+    expect(tx.query.mock.calls.some(([sql]) => sql.includes('INSERT INTO account_aliases'))).toBe(true);
+    expect(tx.query.mock.calls.at(-1)).toEqual([
+      expect.stringContaining('fastmail_last_sync = NOW()'), ['a1', 'encrypted-token'],
+    ]);
+  });
+
+  it('finishes Fastmail network I/O before opening the reconciliation transaction', async () => {
+    const events = [];
+    loadFastmailSession.mockImplementation(async () => {
+      events.push('session');
+      return session;
+    });
+    fetchFastmailSnapshot.mockImplementation(async () => {
+      events.push('snapshot');
+      return completeSnapshot();
+    });
+    tx.query.mockImplementation(async sql => {
+      if (sql.includes('FOR UPDATE')) {
+        events.push('transaction');
+        return { rows: [account] };
+      }
+      if (sql.includes('INSERT INTO account_aliases')) return { rows: [{ id: 'inserted-1' }] };
+      return { rows: [] };
+    });
+
+    await syncFastmailAliases('a1');
+
+    expect(events).toEqual(['session', 'snapshot', 'transaction']);
+  });
+
+  it('persists an explicit blank provider signature without inheriting the account signature', async () => {
+    fetchFastmailSnapshot.mockResolvedValue({
+      identities: [identity('blank-signature@example.com')],
+      maskedEmails: [],
+    });
+
+    await syncFastmailAliases('a1');
+
+    const insert = tx.query.mock.calls.find(([sql]) => sql.includes('INSERT INTO account_aliases'));
+    expect(insert[1][4]).toBe('');
+  });
+
+  it('reconciles a mask-only row if promotion remains incomplete', async () => {
+    fetchFastmailSnapshot.mockResolvedValue({
+      identities: [], maskedEmails: [mask('private@example.com')],
+    });
+
+    await expect(syncFastmailAliases('a1')).rejects.toThrow(
+      'Fastmail did not authorize every enabled Masked Email address',
+    );
+
+    expect(lockClients[0].query).toHaveBeenCalledWith('COMMIT');
+    expect(tx.query.mock.calls[0][0]).toContain('FOR UPDATE');
+    const insert = tx.query.mock.calls.find(([sql]) => sql.includes('INSERT INTO account_aliases'));
+    expect(insert[1][2]).toBe('private@example.com');
+    expect(insert[1][5]).toBeNull();
+    expect(insert[1][6]).toBe('mask-private@example.com');
+    expect(query).toHaveBeenLastCalledWith(
+      expect.stringContaining('fastmail_sync_error = $2'),
+      ['a1', 'Fastmail did not authorize every enabled Masked Email address', 'encrypted-token'],
+    );
+  });
+
+  it('reconciles the authoritative snapshot after a partially successful promotion', async () => {
+    fetchFastmailSnapshot
+      .mockResolvedValueOnce({
+        identities: [],
+        maskedEmails: [mask('created@example.com'), mask('rejected@example.com')],
+      })
+      .mockResolvedValueOnce({
+        identities: [identity('created@example.com')],
+        maskedEmails: [mask('created@example.com'), mask('rejected@example.com')],
+      });
+
+    await expect(syncFastmailAliases('a1')).rejects.toThrow(
+      'Fastmail did not authorize every enabled Masked Email address',
+    );
+
+    expect(createFastmailIdentities).toHaveBeenCalledOnce();
+    expect(fetchFastmailSnapshot).toHaveBeenCalledTimes(2);
+    const inserts = tx.query.mock.calls.filter(([sql]) => sql.includes('INSERT INTO account_aliases'));
+    expect(inserts).toHaveLength(2);
+    expect(inserts.map(([, params]) => params[2])).toEqual([
+      'created@example.com',
+      'rejected@example.com',
+    ]);
+    expect(query).toHaveBeenLastCalledWith(
+      expect.stringContaining('fastmail_sync_error = $2'),
+      ['a1', 'Fastmail did not authorize every enabled Masked Email address', 'encrypted-token'],
+    );
+  });
+
+  it('preserves the snapshot on remote failure and records only a fixed safe error', async () => {
+    fetchFastmailSnapshot.mockRejectedValue(new Error('secret token and alias@example.com'));
+
+    await expect(syncFastmailAliases('a1')).rejects.toThrow();
+
+    expect(lockClients[0].query.mock.calls.some(([sql]) => sql === 'BEGIN')).toBe(false);
+    expect(query).toHaveBeenLastCalledWith(
+      expect.stringContaining('fastmail_sync_error = $2'),
+      ['a1', 'Fastmail synchronization failed', 'encrypted-token'],
+    );
+  });
+
+  it('rolls back transaction failure and records a safe error afterward', async () => {
+    const events = [];
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('SELECT * FROM email_accounts')) {
+        events.push('account-load');
+        return { rows: [account] };
+      }
+      if (sql.includes('INSERT INTO fastmail_identity_promotions')) {
+        return { rows: JSON.parse(params[1]).map(item => ({ masked_email_id: item.id })) };
+      }
+      if (sql.includes('DELETE FROM fastmail_identity_promotions')) return { rows: [] };
+      events.push('safe-error-update');
+      expect(sql).toContain('fastmail_sync_error = $2');
+      return { rows: [] };
+    });
+    tx.query.mockImplementation(async sql => {
+      if (sql.includes('FOR UPDATE')) {
+        events.push('tx-credential-lock');
+        return { rows: [account] };
+      }
+      if (sql.includes('SELECT id, email')) {
+        events.push('tx-select');
+        return { rows: [] };
+      }
+      if (sql.includes('INSERT INTO account_aliases')) {
+        events.push('tx-insert');
+        return { rows: [{ id: 'inserted-1' }] };
+      }
+      events.push('tx-delete-failed');
+      throw new Error('duplicate alias@example.com');
+    });
+
+    await expect(syncFastmailAliases('a1')).rejects.toThrow();
+
+    expect(tx.query).toHaveBeenCalledTimes(4);
+    expect(tx.query.mock.calls.map(([sql]) => sql)).toEqual([
+      expect.stringContaining('FOR UPDATE'),
+      expect.stringContaining("provenance = 'fastmail'"),
+      expect.stringContaining('INSERT INTO account_aliases'),
+      expect.stringContaining('DELETE FROM account_aliases'),
+    ]);
+    expect(lockClients[0].query).toHaveBeenCalledWith('ROLLBACK');
+    expect(query.mock.calls).toHaveLength(3);
+    expect(query.mock.calls.every(([sql]) => !sql.includes('account_aliases'))).toBe(true);
+    expect(query).toHaveBeenLastCalledWith(
+      expect.stringContaining('fastmail_sync_error = $2'),
+      ['a1', 'Fastmail synchronization failed', 'encrypted-token'],
+    );
+    expect(events).toEqual([
+      'account-load', 'tx-credential-lock', 'tx-select', 'tx-insert',
+      'tx-delete-failed', 'safe-error-update',
+    ]);
+  });
+
+  it('selects and deletes only Fastmail rows inside the successful transaction', async () => {
+    tx.query
+      .mockResolvedValueOnce({ rows: [account] })
+      .mockResolvedValueOnce({ rows: [{
+        id: 'stale-id', email: 'stale@example.com',
+        fastmail_identity_id: 'stale-identity', fastmail_masked_email_id: null,
+      }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'inserted-1' }] });
+
+    await syncFastmailAliases('a1');
+
+    expect(tx.query.mock.calls[1]).toEqual([
+      expect.stringContaining("provenance = 'fastmail'"), ['a1'],
+    ]);
+    const deleteCall = tx.query.mock.calls.find(([sql]) => sql.includes('DELETE FROM account_aliases'));
+    expect(deleteCall[0]).toContain("provenance = 'fastmail'");
+    expect(deleteCall[1][0]).toBe('a1');
+    expect(deleteCall[1]).not.toContain(undefined);
+  });
+
+  it('reconciles same-address identities by Fastmail identity ID', async () => {
+    fetchFastmailSnapshot.mockResolvedValue({
+      identities: [
+        identity('shared@example.com', { id: 'identity-formal', name: 'Formal' }),
+        identity('shared@example.com', { id: 'identity-casual', name: 'Casual' }),
+      ],
+      maskedEmails: [],
+    });
+    tx.query.mockImplementation(async sql => {
+      if (sql.includes('FOR UPDATE')) {
+        return { rows: [account] };
+      }
+      if (sql.includes("provenance = 'fastmail'") && sql.includes('SELECT')) {
+        return { rows: [
+          {
+            id: 'row-formal', email: 'shared@example.com',
+            fastmail_identity_id: 'identity-formal', fastmail_masked_email_id: null,
+          },
+          {
+            id: 'row-casual', email: 'shared@example.com',
+            fastmail_identity_id: 'identity-casual', fastmail_masked_email_id: null,
+          },
+        ] };
+      }
+      return { rows: [] };
+    });
+
+    await syncFastmailAliases('a1');
+
+    const updatedRowIds = tx.query.mock.calls
+      .filter(([sql]) => sql.includes('UPDATE account_aliases'))
+      .map(([, params]) => params[9]);
+    expect(updatedRowIds).toEqual(['row-formal', 'row-casual']);
+  });
+
+  it('moves a mask association before updating its new same-address identity', async () => {
+    const rows = [
+      {
+        id: 'row-formal', email: 'shared@example.com',
+        fastmail_identity_id: 'identity-formal', fastmail_masked_email_id: 'mask-shared',
+      },
+      {
+        id: 'row-casual', email: 'shared@example.com',
+        fastmail_identity_id: 'identity-casual', fastmail_masked_email_id: null,
+      },
+    ];
+    fetchFastmailSnapshot.mockResolvedValue({
+      identities: [
+        identity('shared@example.com', { id: 'identity-casual', name: 'Casual' }),
+        identity('shared@example.com', { id: 'identity-formal', name: 'Formal' }),
+      ],
+      maskedEmails: [mask('shared@example.com', { id: 'mask-shared' })],
+    });
+    tx.query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FOR UPDATE')) return { rows: [account] };
+      if (sql.includes("provenance = 'fastmail'") && sql.includes('SELECT')) {
+        return { rows: rows.map(row => ({ ...row })) };
+      }
+      if (sql.includes('SET fastmail_masked_email_id = NULL')) {
+        for (const row of rows) {
+          if (row.fastmail_masked_email_id === params[1]
+              && row.fastmail_identity_id !== params[2]) {
+            row.fastmail_masked_email_id = null;
+          }
+        }
+        return { rows: [] };
+      }
+      if (sql.includes('UPDATE account_aliases')) {
+        const row = rows.find(candidate => candidate.id === params[9]);
+        if (params[5] && rows.some(candidate => (
+          candidate.id !== row.id && candidate.fastmail_masked_email_id === params[5]
+        ))) {
+          throw new Error('duplicate mask association');
+        }
+        row.fastmail_identity_id = params[4];
+        row.fastmail_masked_email_id = params[5];
+      }
+      return { rows: [] };
+    });
+
+    await syncFastmailAliases('a1');
+
+    expect(rows).toMatchObject([
+      { id: 'row-formal', fastmail_masked_email_id: null },
+      { id: 'row-casual', fastmail_masked_email_id: 'mask-shared' },
+    ]);
+  });
+
+  it('coalesces simultaneous triggers for one account into the same Promise', async () => {
+    let release;
+    loadFastmailSession.mockImplementationOnce(() => new Promise(resolve => { release = resolve; }));
+
+    const calls = [
+      syncFastmailAliases('a1'),
+      syncFastmailAliases('a1'),
+      syncFastmailAliases('a1'),
+      syncFastmailAliases('a1'),
+    ];
+    expect(calls.every(promise => promise === calls[0])).toBe(true);
+    await vi.waitFor(() => expect(release).toBeTypeOf('function'));
+    release(session);
+    await Promise.all(calls);
+    expect(loadFastmailSession).toHaveBeenCalledOnce();
+    expect(fetchFastmailSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('serializes remote promotion across independent process workers', async () => {
+    const workerOne = await import('./fastmailAliasSync.js?worker=one');
+    const workerTwo = await import('./fastmailAliasSync.js?worker=two');
+
+    let remoteIdentityExists = false;
+    fetchFastmailSnapshot.mockImplementation(() => {
+      if (remoteIdentityExists) return Promise.resolve(completeSnapshot('shared@example.com'));
+      return Promise.resolve({ identities: [], maskedEmails: [mask('shared@example.com')] });
+    });
+    createFastmailIdentities.mockImplementation(async () => {
+      remoteIdentityExists = true;
+    });
+
+    await Promise.all([
+      workerOne.syncFastmailAliases('a1'),
+      workerTwo.syncFastmailAliases('a1'),
+    ]);
+
+    expect(createFastmailIdentities).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps independent workers serialized throughout a long-running synchronization', async () => {
+    vi.useFakeTimers();
+    const workerOne = await import('./fastmailAliasSync.js?worker=long-one');
+    const workerTwo = await import('./fastmailAliasSync.js?worker=long-two');
+
+    let releaseFirst;
+    loadFastmailSession
+      .mockImplementationOnce(() => new Promise(resolve => { releaseFirst = () => resolve(session); }))
+      .mockResolvedValue(session);
+
+    const first = workerOne.syncFastmailAliases('a1');
+    try {
+      await vi.waitFor(() => expect(releaseFirst).toBeTypeOf('function'));
+      await vi.advanceTimersByTimeAsync((3 * 60 * 1000) + 1);
+      const second = workerTwo.syncFastmailAliases('a1');
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(loadFastmailSession).toHaveBeenCalledOnce();
+
+      releaseFirst();
+      await first;
+      await vi.advanceTimersByTimeAsync(100);
+      await second;
+    } finally {
+      releaseFirst?.();
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it('allows different account IDs to synchronize concurrently', async () => {
+    const releases = new Map();
+    tx.query.mockImplementation((sql, params) => {
+      if (!sql.includes('FOR UPDATE')) {
+        if (sql.includes('INSERT INTO account_aliases')) return Promise.resolve({ rows: [{ id: 'inserted' }] });
+        return Promise.resolve({ rows: [] });
+      }
+      return new Promise(resolve => releases.set(params[0], resolve));
+    });
+
+    const first = syncFastmailAliases('a1');
+    const second = syncFastmailAliases('a2');
+    await vi.waitFor(() => expect(releases.size).toBe(2));
+    releases.get('a1')({ rows: [{ ...account, id: 'a1' }] });
+    releases.get('a2')({ rows: [{ ...account, id: 'a2' }] });
+    await Promise.all([first, second]);
+    expect(loadFastmailSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('caps direct synchronization entry points at three concurrent remote operations', async () => {
+    let releaseRemote;
+    const remoteGate = new Promise(resolve => { releaseRemote = resolve; });
+    let active = 0;
+    let maximumActive = 0;
+    loadFastmailSession.mockImplementation(async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await remoteGate;
+      active -= 1;
+      return session;
+    });
+
+    const syncing = ['a1', 'a2', 'a3', 'a4'].map(id => syncFastmailAliases(id));
+    try {
+      await vi.waitFor(() => expect(maximumActive).toBeGreaterThanOrEqual(3));
+      expect(maximumActive).toBe(3);
+    } finally {
+      releaseRemote();
+      await Promise.allSettled(syncing);
+    }
+  });
+
+  it('queues a complete new-token sync without allowing stale-token writes', async () => {
+    const state = {
+      account: { ...account, fastmail_api_token: 'encrypted-old' },
+      aliases: [{ id: 'before', email: 'before@example.com' }],
+      lastSync: 'previous-sync',
+      syncError: 'previous-error',
+    };
+    let releaseOldRemote;
+    let inserted = 0;
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('SELECT * FROM email_accounts')) {
+        return { rows: [{ ...state.account }] };
+      }
+      if (sql.includes('fastmail_sync_error = $2')) {
+        if (state.account.fastmail_api_token === params[2]) state.syncError = params[1];
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+    fetchFastmailSnapshot.mockImplementation((_session, token) => {
+      if (token === 'plain:encrypted-old') {
+        return new Promise(resolve => { releaseOldRemote = resolve; });
+      }
+      return Promise.resolve(completeSnapshot('new@example.com'));
+    });
+    tx.query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FOR UPDATE')) {
+        return { rows: [{ ...state.account }] };
+      }
+      if (sql.includes('SELECT id, email')) return { rows: state.aliases.map(alias => ({ ...alias })) };
+      if (sql.includes('INSERT INTO account_aliases')) {
+        const alias = { id: `new-${++inserted}`, email: params[2] };
+        state.aliases.push(alias);
+        return { rows: [{ id: alias.id }] };
+      }
+      if (sql.includes('DELETE FROM account_aliases')) {
+        const retained = params[1] || [];
+        state.aliases = state.aliases.filter(alias => retained.includes(alias.id));
+        return { rows: [] };
+      }
+      if (sql.includes('fastmail_last_sync = NOW()')) {
+        state.lastSync = 'new-sync';
+        state.syncError = null;
+        return { rows: [{ id: 'a1' }] };
+      }
+      return { rows: [] };
+    });
+
+    const oldSync = syncFastmailAliases('a1');
+    await vi.waitFor(() => expect(releaseOldRemote).toBeTypeOf('function'));
+    state.account.fastmail_api_token = 'encrypted-new';
+    const replacementSync = syncFastmailAliases('a1', { credentialChanged: true });
+    expect(replacementSync).not.toBe(oldSync);
+    releaseOldRemote(completeSnapshot('old@example.com'));
+
+    await expect(oldSync).rejects.toThrow('Fastmail credentials changed during synchronization');
+    await replacementSync;
+    expect(fetchFastmailSnapshot.mock.calls.map(([, token]) => token)).toEqual([
+      'plain:encrypted-old',
+      'plain:encrypted-new',
+    ]);
+    expect(state.aliases.map(alias => alias.email)).toEqual(['new@example.com']);
+    expect(state).toMatchObject({ lastSync: 'new-sync', syncError: null });
+  });
+});
+
+describe('syncAllFastmailAliases', () => {
+  it('loads enabled configured accounts and synchronizes at most three concurrently', async () => {
+    const ids = ['a1', 'a2', 'a3', 'a4'];
+    const started = [];
+    const releases = new Map();
+    let active = 0;
+    let maximumActive = 0;
+    tx.query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FOR UPDATE')) {
+        return { rows: [{ ...account, id: params[0], fastmail_api_token: `encrypted-${params[0]}` }] };
+      }
+      if (sql.includes('INSERT INTO account_aliases')) {
+        return { rows: [{ id: `inserted-${params[0]}` }] };
+      }
+      return { rows: [] };
+    });
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('SELECT id FROM email_accounts')) {
+        return { rows: ids.map(id => ({ id })) };
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) {
+        const id = params[0];
+        return { rows: [{ ...account, id, fastmail_api_token: `encrypted-${id}` }] };
+      }
+      return { rows: [] };
+    });
+    loadFastmailSession.mockImplementation(token => new Promise(resolve => {
+      const id = token.replace('plain:encrypted-', '');
+      started.push(id);
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      releases.set(id, () => {
+        active -= 1;
+        resolve(session);
+      });
+    }));
+
+    const syncing = syncAllFastmailAliases();
+    await vi.waitFor(() => expect(started).toHaveLength(3));
+    expect(started).toEqual(['a1', 'a2', 'a3']);
+    expect(releases.has('a4')).toBe(false);
+
+    releases.get('a1')();
+    await vi.waitFor(() => expect(started).toHaveLength(4));
+    expect(started[3]).toBe('a4');
+    for (const id of ['a2', 'a3', 'a4']) releases.get(id)();
+    await syncing;
+
+    expect(query.mock.calls[0][0]).toContain('fastmail_api_token IS NOT NULL');
+    expect(loadFastmailSession).toHaveBeenCalledTimes(4);
+    expect(decrypt).toHaveBeenCalledTimes(4);
+    expect(maximumActive).toBe(3);
+  });
+
+  it('runs on startup and every fifteen minutes', async () => {
+    vi.useFakeTimers();
+    query.mockResolvedValue({ rows: [] });
+    const timer = startFastmailAliasScheduler();
+    await vi.runAllTicks();
+    expect(query).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+    expect(query).toHaveBeenCalledTimes(2);
+    clearInterval(timer);
+    vi.useRealTimers();
+  });
+});

--- a/backend/src/services/fastmailClient.js
+++ b/backend/src/services/fastmailClient.js
@@ -1,0 +1,228 @@
+export const JMAP_CORE = 'urn:ietf:params:jmap:core';
+export const JMAP_SUBMISSION = 'urn:ietf:params:jmap:submission';
+export const JMAP_MASKED_EMAIL = 'https://www.fastmail.com/dev/maskedemail';
+
+const SESSION_URL = 'https://api.fastmail.com/jmap/session';
+const FASTMAIL_ORIGIN = 'https://api.fastmail.com';
+
+// Fastmail failures follow the app-wide error idiom (see safeFetch.js, routes/draft.js):
+// a plain Error carrying a machine-readable `code`, plus a `status` where a route maps
+// it to an HTTP response. FASTMAIL_CONFIG is a caller/configuration fault (bad token,
+// missing permission) surfaced as 422; FASTMAIL_SYNC is a transient remote failure.
+export function fastmailConfigError(message) {
+  return Object.assign(new Error(message), { code: 'FASTMAIL_CONFIG', status: 422 });
+}
+
+export function fastmailSyncError(message) {
+  return Object.assign(new Error(message), { code: 'FASTMAIL_SYNC' });
+}
+
+// Pin the session-advertised API URL to Fastmail's own origin over HTTPS. The token is
+// sent as a Bearer header on every JMAP request, so a tampered or redirected apiUrl must
+// never be able to carry it to another host.
+function assertFastmailApiUrl(value) {
+  const url = new URL(value);
+  if (url.protocol !== 'https:' || url.origin !== FASTMAIL_ORIGIN) {
+    throw fastmailConfigError('Fastmail returned an unexpected API URL');
+  }
+  return url.href;
+}
+
+function safeFetchError(error) {
+  if (error.name === 'TimeoutError') {
+    return fastmailSyncError('Fastmail did not respond in time');
+  }
+  return fastmailSyncError('Could not reach Fastmail');
+}
+
+function assertSuccessfulResponse(response) {
+  if (response.status === 401 || response.status === 403) {
+    throw fastmailConfigError('Fastmail rejected the API token or its permissions');
+  }
+  if (!response.ok) throw fastmailSyncError('Fastmail synchronization failed');
+}
+
+async function responseJson(response) {
+  try {
+    return await response.json();
+  } catch {
+    throw fastmailSyncError('Fastmail returned an invalid response');
+  }
+}
+
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function invalidResponse() {
+  throw fastmailSyncError('Fastmail returned an invalid response');
+}
+
+// JMAP results drive identity/alias reconciliation, so validate the shape of every
+// method response before trusting it: reject a malformed or attacker-shaped result
+// rather than silently producing bad aliases or masking a partial provider failure.
+function validateMethodResult(methodName, result, requestArguments) {
+  if (!isObject(result)) invalidResponse();
+  if (result.accountId !== requestArguments.accountId) invalidResponse();
+
+  if (methodName === 'Identity/get' || methodName === 'MaskedEmail/get') {
+    if (!Array.isArray(result.list)) invalidResponse();
+    return;
+  }
+
+  if (methodName === 'Identity/set') {
+    const created = result.created ?? {};
+    if (!Object.hasOwn(result, 'notCreated')) invalidResponse();
+    const notCreated = result.notCreated ?? {};
+    if (!isObject(created) || !isObject(notCreated)) invalidResponse();
+
+    const requestedIds = Object.keys(requestArguments.create);
+    const createdIds = Object.keys(created);
+    const notCreatedIds = Object.keys(notCreated);
+    const returnedIds = [...createdIds, ...notCreatedIds];
+    if (
+      returnedIds.length !== requestedIds.length
+      || new Set(returnedIds).size !== returnedIds.length
+      || returnedIds.some(id => !requestedIds.includes(id))
+      || Object.values(created).some(value => !isObject(value) || typeof value.id !== 'string' || !value.id)
+      || Object.values(notCreated).some(value => (
+        !isObject(value) || typeof value.type !== 'string' || !value.type
+      ))
+    ) {
+      invalidResponse();
+    }
+  }
+}
+
+function requirePrimaryAccount(session, capability, label) {
+  const accountId = session.primaryAccounts?.[capability];
+  if (!accountId || !session.accounts?.[accountId]?.accountCapabilities?.[capability]) {
+    throw fastmailConfigError(`Fastmail did not provide a usable primary ${label} account`);
+  }
+  return accountId;
+}
+
+export async function loadFastmailSession(token, fetchFn = fetch) {
+  let response;
+  try {
+    response = await fetchFn(SESSION_URL, {
+      redirect: 'error',
+      signal: AbortSignal.timeout(30000),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+      },
+    });
+  } catch (error) {
+    throw safeFetchError(error);
+  }
+
+  assertSuccessfulResponse(response);
+  const session = await responseJson(response);
+  assertFastmailApiUrl(session.apiUrl);
+
+  if (!session.capabilities?.[JMAP_SUBMISSION]) {
+    throw fastmailConfigError('Fastmail API token is missing Email submission permission');
+  }
+  if (!session.capabilities?.[JMAP_MASKED_EMAIL]) {
+    throw fastmailConfigError('Fastmail API token is missing Masked Email permission');
+  }
+  const submissionAccountId = requirePrimaryAccount(session, JMAP_SUBMISSION, 'Email submission');
+  const maskedEmailAccountId = requirePrimaryAccount(session, JMAP_MASKED_EMAIL, 'Masked Email');
+  if (submissionAccountId !== maskedEmailAccountId) {
+    throw fastmailConfigError('Fastmail capabilities must use the same Fastmail account');
+  }
+
+  return session;
+}
+
+async function jmapRequest(session, token, methodCalls, fetchFn = fetch) {
+  const apiUrl = assertFastmailApiUrl(session.apiUrl);
+  let response;
+  try {
+    response = await fetchFn(apiUrl, {
+      method: 'POST',
+      redirect: 'error',
+      signal: AbortSignal.timeout(30000),
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        using: [JMAP_CORE, JMAP_SUBMISSION, JMAP_MASKED_EMAIL],
+        methodCalls,
+      }),
+    });
+  } catch (error) {
+    throw safeFetchError(error);
+  }
+
+  assertSuccessfulResponse(response);
+  const payload = await responseJson(response);
+  if (!Array.isArray(payload.methodResponses)) {
+    throw fastmailSyncError('Fastmail returned an invalid response');
+  }
+
+  const expectedByTag = new Map(methodCalls.map(call => [call[2], call]));
+  const seenTags = new Set();
+  for (const item of payload.methodResponses) {
+    if (!Array.isArray(item) || item.length !== 3) invalidResponse();
+    const requestedCall = expectedByTag.get(item[2]);
+    if (!requestedCall || seenTags.has(item[2])) invalidResponse();
+    seenTags.add(item[2]);
+    if (item[0] === 'error') {
+      throw fastmailSyncError('Fastmail rejected a synchronization method');
+    }
+    if (item[0] !== requestedCall[0]) invalidResponse();
+    validateMethodResult(item[0], item[1], requestedCall[1]);
+  }
+  if (seenTags.size !== expectedByTag.size) invalidResponse();
+  return payload.methodResponses;
+}
+
+function responseByTag(responses, tag) {
+  const response = responses.find(item => item[2] === tag);
+  if (!response) throw fastmailSyncError('Fastmail omitted a synchronization result');
+  return response[1];
+}
+
+export async function fetchFastmailSnapshot(session, token, fetchFn = fetch) {
+  const submissionAccountId = session.primaryAccounts[JMAP_SUBMISSION];
+  const maskedEmailAccountId = session.primaryAccounts[JMAP_MASKED_EMAIL];
+  const responses = await jmapRequest(session, token, [
+    ['Identity/get', { accountId: submissionAccountId, ids: null }, 'identities'],
+    ['MaskedEmail/get', { accountId: maskedEmailAccountId, ids: null }, 'masked-emails'],
+  ], fetchFn);
+  return {
+    identities: responseByTag(responses, 'identities').list,
+    maskedEmails: responseByTag(responses, 'masked-emails').list,
+  };
+}
+
+export async function createFastmailIdentities(session, token, identities, fetchFn = fetch) {
+  if (!identities.length) return { createdIds: [], notCreatedIds: [] };
+
+  const create = Object.fromEntries(identities.map((identity, index) => [
+    `mask-${index}`,
+    {
+      name: identity.name,
+      email: identity.email,
+      replyTo: null,
+      bcc: null,
+      textSignature: '',
+      htmlSignature: '',
+    },
+  ]));
+  const result = await jmapRequest(session, token, [
+    ['Identity/set', {
+      accountId: session.primaryAccounts[JMAP_SUBMISSION],
+      create,
+    }, 'create-identities'],
+  ], fetchFn);
+  const set = responseByTag(result, 'create-identities');
+  return {
+    createdIds: Object.keys(set.created || {}),
+    notCreatedIds: Object.keys(set.notCreated || {}),
+  };
+}

--- a/backend/src/services/fastmailClient.test.js
+++ b/backend/src/services/fastmailClient.test.js
@@ -1,0 +1,481 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logger } from './logger.js';
+import {
+  JMAP_CORE,
+  JMAP_MASKED_EMAIL,
+  JMAP_SUBMISSION,
+  createFastmailIdentities,
+  fetchFastmailSnapshot,
+  loadFastmailSession,
+} from './fastmailClient.js';
+
+const TOKEN = 'token-value';
+const ALIAS = 'private-alias@fastmail.example';
+
+const session = {
+  apiUrl: 'https://api.fastmail.com/jmap/api/',
+  capabilities: {
+    [JMAP_CORE]: {},
+    [JMAP_SUBMISSION]: {},
+    [JMAP_MASKED_EMAIL]: {},
+  },
+  accounts: {
+    'acc-1': {
+      name: 'Example account',
+      isPersonal: true,
+      isReadOnly: false,
+      accountCapabilities: {
+        [JMAP_SUBMISSION]: {},
+        [JMAP_MASKED_EMAIL]: {},
+      },
+    },
+  },
+  primaryAccounts: {
+    [JMAP_SUBMISSION]: 'acc-1',
+    [JMAP_MASKED_EMAIL]: 'acc-1',
+  },
+  username: 'owner@fastmail.example',
+};
+
+const identityList = [{
+  id: 'identity-1',
+  name: 'Private sender',
+  email: ALIAS,
+  replyTo: null,
+  bcc: null,
+  textSignature: '',
+  htmlSignature: '',
+}];
+
+const maskList = [{
+  id: 'mask-1',
+  email: ALIAS,
+  state: 'enabled',
+  forDomain: 'fastmail.example',
+  description: 'Private address',
+  createdBy: 'user',
+  createdAt: '2026-07-12T12:00:00Z',
+  lastMessageAt: null,
+}];
+
+function response(payload, { status = 200, ok = status >= 200 && status < 300 } = {}) {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    headers: new Headers({ 'Content-Type': 'application/json' }),
+    json: vi.fn().mockResolvedValue(payload),
+  };
+}
+
+function capturedText(spies) {
+  return spies.flatMap(spy => spy.mock.calls.flat()).map(value => {
+    if (typeof value === 'string') return value;
+    try { return JSON.stringify(value); } catch { return String(value); }
+  }).join('\n');
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loadFastmailSession', () => {
+  it('discovers a validated session from Fastmail fixed endpoint', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response(session));
+
+    await expect(loadFastmailSession(TOKEN, fetchFn)).resolves.toEqual(session);
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const [url, options] = fetchFn.mock.calls[0];
+    expect(url).toBe('https://api.fastmail.com/jmap/session');
+    expect(options).toMatchObject({
+      redirect: 'error',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Accept: 'application/json',
+      },
+    });
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it.each([
+    [JMAP_SUBMISSION, 'Email submission'],
+    [JMAP_MASKED_EMAIL, 'Masked Email'],
+  ])('rejects a session missing the %s capability', async (capability, safeName) => {
+    const capabilities = { ...session.capabilities };
+    delete capabilities[capability];
+    const fetchFn = vi.fn().mockResolvedValue(response({ ...session, capabilities }));
+
+    const result = loadFastmailSession(TOKEN, fetchFn);
+
+    await expect(result).rejects.toMatchObject({ code: 'FASTMAIL_CONFIG', status: 422 });
+    await expect(result).rejects.toThrow(safeName);
+  });
+
+  it('rejects a session without a primary Email submission account', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      ...session,
+      primaryAccounts: { [JMAP_MASKED_EMAIL]: 'acc-1' },
+    }));
+
+    await expect(loadFastmailSession(TOKEN, fetchFn))
+      .rejects.toThrow('Email submission');
+  });
+
+  it('rejects a session without a primary Masked Email account', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      ...session,
+      primaryAccounts: { [JMAP_SUBMISSION]: 'acc-1' },
+    }));
+
+    await expect(loadFastmailSession(TOKEN, fetchFn))
+      .rejects.toThrow('Masked Email');
+  });
+
+  it('rejects a primary account without Masked Email access', async () => {
+    const accountCapabilities = { ...session.accounts['acc-1'].accountCapabilities };
+    delete accountCapabilities[JMAP_MASKED_EMAIL];
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      ...session,
+      accounts: {
+        'acc-1': { ...session.accounts['acc-1'], accountCapabilities },
+      },
+    }));
+
+    await expect(loadFastmailSession(TOKEN, fetchFn))
+      .rejects.toThrow('Masked Email');
+  });
+
+  it('rejects submission and Masked Email capabilities from different accounts', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      ...session,
+      accounts: {
+        ...session.accounts,
+        'acc-2': {
+          ...session.accounts['acc-1'],
+          accountCapabilities: { [JMAP_MASKED_EMAIL]: {} },
+        },
+      },
+      primaryAccounts: {
+        [JMAP_SUBMISSION]: 'acc-1',
+        [JMAP_MASKED_EMAIL]: 'acc-2',
+      },
+    }));
+
+    await expect(loadFastmailSession(TOKEN, fetchFn))
+      .rejects.toThrow('same Fastmail account');
+  });
+
+  it('rejects a discovered non-Fastmail API URL', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      ...session,
+      apiUrl: 'https://evil.example/jmap',
+    }));
+
+    await expect(loadFastmailSession(TOKEN, fetchFn))
+      .rejects.toThrow('Fastmail returned an unexpected API URL');
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('fetchFastmailSnapshot', () => {
+  it('fetches identities and masks in one JMAP request', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [
+        ['Identity/get', { accountId: 'acc-1', state: 'identity-state', list: identityList, notFound: [] }, 'identities'],
+        ['MaskedEmail/get', { accountId: 'acc-1', state: 'mask-state', list: maskList, notFound: [] }, 'masked-emails'],
+      ],
+      sessionState: 'session-state',
+    }));
+
+    const result = await fetchFastmailSnapshot(session, TOKEN, fetchFn);
+
+    const [url, options] = fetchFn.mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(url).toBe(session.apiUrl);
+    expect(options.headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(options.redirect).toBe('error');
+    expect(body.using).toEqual([JMAP_CORE, JMAP_SUBMISSION, JMAP_MASKED_EMAIL]);
+    expect(body.methodCalls.map(call => call[0])).toEqual(['Identity/get', 'MaskedEmail/get']);
+    expect(result).toEqual({ identities: identityList, maskedEmails: maskList });
+  });
+
+  it('refuses an attacker-controlled API URL before sending the token', async () => {
+    const fetchFn = vi.fn();
+
+    await expect(fetchFastmailSnapshot({
+      ...session,
+      apiUrl: 'https://evil.example/jmap',
+    }, TOKEN, fetchFn)).rejects.toThrow('Fastmail returned an unexpected API URL');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects method-level errors without returning partial data', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [
+        ['Identity/get', { accountId: 'acc-1', state: 'identity-state', list: identityList, notFound: [] }, 'identities'],
+        ['error', { type: 'serverFail', description: `Failed for ${ALIAS}` }, 'masked-emails'],
+      ],
+      sessionState: 'session-state',
+    }));
+
+    const result = fetchFastmailSnapshot(session, TOKEN, fetchFn);
+
+    await expect(result).rejects.toMatchObject({ code: 'FASTMAIL_SYNC' });
+    await expect(result).rejects.toThrow('Fastmail rejected a synchronization method');
+  });
+
+  it('rejects a response method that does not match its requested tag', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [
+        ['MaskedEmail/get', { accountId: 'acc-1', state: 'identity-state', list: identityList, notFound: [] }, 'identities'],
+        ['MaskedEmail/get', { accountId: 'acc-1', state: 'mask-state', list: maskList, notFound: [] }, 'masked-emails'],
+      ],
+      sessionState: 'session-state',
+    }));
+
+    await expect(fetchFastmailSnapshot(session, TOKEN, fetchFn))
+      .rejects.toThrow('Fastmail returned an invalid response');
+  });
+
+  it('rejects a duplicate response for a requested tag', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [
+        ['Identity/get', { accountId: 'acc-1', state: 'identity-state', list: identityList, notFound: [] }, 'identities'],
+        ['Identity/get', { accountId: 'acc-1', state: 'identity-state', list: identityList, notFound: [] }, 'identities'],
+        ['MaskedEmail/get', { accountId: 'acc-1', state: 'mask-state', list: maskList, notFound: [] }, 'masked-emails'],
+      ],
+      sessionState: 'session-state',
+    }));
+
+    await expect(fetchFastmailSnapshot(session, TOKEN, fetchFn))
+      .rejects.toThrow('Fastmail returned an invalid response');
+  });
+
+  it.each([
+    ['Identity/get', null, maskList],
+    ['MaskedEmail/get', identityList, { [ALIAS]: maskList[0] }],
+  ])('rejects a malformed %s list result', async (methodName, identities, maskedEmails) => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [
+        ['Identity/get', { accountId: 'acc-1', state: 'identity-state', list: identities, notFound: [] }, 'identities'],
+        ['MaskedEmail/get', { accountId: 'acc-1', state: 'mask-state', list: maskedEmails, notFound: [] }, 'masked-emails'],
+      ],
+      sessionState: 'session-state',
+    }));
+
+    await expect(fetchFastmailSnapshot(session, TOKEN, fetchFn))
+      .rejects.toThrow('Fastmail returned an invalid response');
+  });
+
+  it('does not expose tokens or aliases through errors or logging', async () => {
+    const spies = [
+      vi.spyOn(console, 'error').mockImplementation(() => {}),
+      vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      vi.spyOn(logger, 'error').mockImplementation(() => {}),
+      vi.spyOn(logger, 'warn').mockImplementation(() => {}),
+      vi.spyOn(logger, 'info').mockImplementation(() => {}),
+      vi.spyOn(logger, 'debug').mockImplementation(() => {}),
+    ];
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [
+        ['error', { type: TOKEN, description: ALIAS }, 'identities'],
+        ['MaskedEmail/get', { accountId: 'acc-1', state: 'mask-state', list: maskList, notFound: [] }, 'masked-emails'],
+      ],
+      sessionState: 'session-state',
+    }));
+
+    let error;
+    try {
+      await fetchFastmailSnapshot(session, TOKEN, fetchFn);
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(error.code).toBe('FASTMAIL_SYNC');
+    expect(error.message).not.toContain(TOKEN);
+    expect(error.message).not.toContain(ALIAS);
+    const logs = capturedText(spies);
+    expect(logs).not.toContain(TOKEN);
+    expect(logs).not.toContain(ALIAS);
+  });
+});
+
+describe('createFastmailIdentities', () => {
+  it('creates all identities in one batched Identity/set request', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [[
+        'Identity/set',
+        {
+          accountId: 'acc-1',
+          oldState: 'old-state',
+          newState: 'new-state',
+          created: {
+            'mask-0': { id: 'identity-1' },
+            'mask-1': { id: 'identity-2' },
+          },
+          notCreated: null,
+        },
+        'create-identities',
+      ]],
+      sessionState: 'session-state',
+    }));
+    const identities = [
+      { name: 'First sender', email: 'first@fastmail.example' },
+      { name: 'Second sender', email: 'second@fastmail.example' },
+    ];
+
+    await expect(createFastmailIdentities(session, TOKEN, identities, fetchFn))
+      .resolves.toEqual({ createdIds: ['mask-0', 'mask-1'], notCreatedIds: [] });
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect(body.methodCalls).toEqual([[
+      'Identity/set',
+      {
+        accountId: 'acc-1',
+        create: {
+          'mask-0': {
+            name: 'First sender',
+            email: 'first@fastmail.example',
+            replyTo: null,
+            bcc: null,
+            textSignature: '',
+            htmlSignature: '',
+          },
+          'mask-1': {
+            name: 'Second sender',
+            email: 'second@fastmail.example',
+            replyTo: null,
+            bcc: null,
+            textSignature: '',
+            htmlSignature: '',
+          },
+        },
+      },
+      'create-identities',
+    ]]);
+  });
+
+  it('skips the request when no identities need creation', async () => {
+    const fetchFn = vi.fn();
+
+    await expect(createFastmailIdentities(session, TOKEN, [], fetchFn))
+      .resolves.toEqual({ createdIds: [], notCreatedIds: [] });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('returns rejected identity accounting without exposing provider details', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [[
+        'Identity/set',
+        {
+          accountId: 'acc-1',
+          oldState: 'old-state',
+          newState: 'new-state',
+          created: {},
+          notCreated: { 'mask-0': { type: 'forbidden', description: ALIAS } },
+        },
+        'create-identities',
+      ]],
+      sessionState: 'session-state',
+    }));
+
+    await expect(createFastmailIdentities(
+      session,
+      TOKEN,
+      [{ name: 'Private sender', email: ALIAS }],
+      fetchFn,
+    )).resolves.toEqual({ createdIds: [], notCreatedIds: ['mask-0'] });
+  });
+
+  it('returns valid mixed Identity/set accounting for authoritative re-fetch', async () => {
+    const accounting = {
+      created: { 'mask-0': { id: 'identity-1' } },
+      notCreated: { 'mask-1': { type: 'forbiddenFrom', description: ALIAS } },
+    };
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [[
+        'Identity/set',
+        {
+          accountId: 'acc-1',
+          oldState: 'old-state',
+          newState: 'new-state',
+          ...accounting,
+        },
+        'create-identities',
+      ]],
+      sessionState: 'session-state',
+    }));
+
+    await expect(createFastmailIdentities(session, TOKEN, [
+      { name: 'First sender', email: 'first@fastmail.example' },
+      { name: 'Second sender', email: 'second@fastmail.example' },
+    ], fetchFn)).resolves.toEqual({ createdIds: ['mask-0'], notCreatedIds: ['mask-1'] });
+  });
+
+  it.each([
+    ['a missing notCreated map', {
+      accountId: 'acc-1',
+      oldState: 'old-state',
+      newState: 'new-state',
+      created: { 'mask-0': { id: 'identity-1' } },
+    }],
+    ['a non-object notCreated value', {
+      accountId: 'acc-1',
+      oldState: 'old-state',
+      newState: 'new-state',
+      created: { 'mask-0': { id: 'identity-1' } },
+      notCreated: [],
+    }],
+    ['an incomplete creation-ID accounting', {
+      accountId: 'acc-1',
+      oldState: 'old-state',
+      newState: 'new-state',
+      created: { 'mask-0': { id: 'identity-1' } },
+      notCreated: {},
+    }],
+  ])('rejects an Identity/set result with %s', async (_case, setResult) => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [['Identity/set', setResult, 'create-identities']],
+      sessionState: 'session-state',
+    }));
+
+    await expect(createFastmailIdentities(session, TOKEN, [
+      { name: 'First sender', email: 'first@fastmail.example' },
+      { name: 'Second sender', email: 'second@fastmail.example' },
+    ], fetchFn)).rejects.toThrow('Fastmail returned an invalid response');
+  });
+
+  it.each([
+    ['a created entry without an id', {
+      created: { 'mask-0': {} },
+      notCreated: {},
+    }],
+    ['a notCreated entry without an error type', {
+      created: {},
+      notCreated: { 'mask-0': { description: 'Denied' } },
+    }],
+  ])('rejects an Identity/set result with %s', async (_case, accounting) => {
+    const fetchFn = vi.fn().mockResolvedValue(response({
+      methodResponses: [[
+        'Identity/set',
+        {
+          accountId: 'acc-1',
+          oldState: 'old-state',
+          newState: 'new-state',
+          ...accounting,
+        },
+        'create-identities',
+      ]],
+      sessionState: 'session-state',
+    }));
+
+    await expect(createFastmailIdentities(
+      session,
+      TOKEN,
+      [{ name: 'Private sender', email: ALIAS }],
+      fetchFn,
+    )).rejects.toThrow('Fastmail returned an invalid response');
+  });
+});

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -537,8 +537,11 @@ const RELOCATE_MESSAGE_SQL = `
     cc_addresses = CASE
       WHEN $9::jsonb::text IS NOT NULL AND $9::jsonb::text <> '[]'
       THEN $9::jsonb ELSE messages.cc_addresses END,
-    reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), $10::text)::jsonb,
-    date = $11::timestamptz
+    delivery_addresses = CASE
+      WHEN $10::jsonb::text IS NOT NULL AND $10::jsonb::text <> '[]'
+      THEN $10::jsonb ELSE messages.delivery_addresses END,
+    reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), $11::text)::jsonb,
+    date = $12::timestamptz
   WHERE account_id = $3::uuid
     AND message_id = $4::text
     AND (folder != $1::text OR uid != $2::bigint)
@@ -554,6 +557,7 @@ function relocateMessageParams(folder, parsed, accountId, msgId) {
     sanitizeStr(parsed.fromEmail),
     JSON.stringify(parsed.to),
     JSON.stringify(parsed.cc),
+    JSON.stringify(parsed.deliveryAddresses || []),
     JSON.stringify(parsed.replyTo || []),
     safeDate(parsed.date),
   ];
@@ -2001,13 +2005,13 @@ export class ImapManager {
             const result = await query(`
               INSERT INTO messages (
                 account_id, uid, folder, message_id, subject,
-                from_name, from_email, to_addresses, cc_addresses,
+                from_name, from_email, to_addresses, cc_addresses, delivery_addresses,
                 reply_to, in_reply_to,
                 date, snippet, is_read, is_starred, has_attachments, flags,
                 body_html, body_text, attachments,
                 thread_references, thread_id, is_bulk, category,
                 list_unsubscribe, list_unsubscribe_post
-              ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)
+              ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
               ON CONFLICT (account_id, uid, folder) DO UPDATE
               SET subject = CASE
                     WHEN EXCLUDED.subject IS NOT NULL
@@ -2028,6 +2032,11 @@ export class ImapManager {
                     THEN EXCLUDED.cc_addresses
                     ELSE messages.cc_addresses
                   END,
+                  delivery_addresses = CASE
+                    WHEN EXCLUDED.delivery_addresses::text IS NOT NULL AND EXCLUDED.delivery_addresses::text <> '[]'
+                    THEN EXCLUDED.delivery_addresses
+                    ELSE messages.delivery_addresses
+                  END,
                   reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), EXCLUDED.reply_to::text)::jsonb,
                   in_reply_to = COALESCE(messages.in_reply_to, EXCLUDED.in_reply_to),
                   snippet = CASE WHEN EXCLUDED.snippet != '' THEN EXCLUDED.snippet
@@ -2044,7 +2053,7 @@ export class ImapManager {
                     THEN messages.is_starred
                     ELSE EXCLUDED.is_starred
                   END,
-                  flags = $17,
+                  flags = $18,
                   body_html = COALESCE(messages.body_html, EXCLUDED.body_html),
                   body_text = COALESCE(messages.body_text, EXCLUDED.body_text),
                   attachments = COALESCE(messages.attachments::text, EXCLUDED.attachments::text)::jsonb,
@@ -2060,6 +2069,7 @@ export class ImapManager {
               msgId, sanitizeStr(parsed.subject),
               sanitizeStr(parsed.fromName), sanitizeStr(parsed.fromEmail),
               JSON.stringify(parsed.to), JSON.stringify(parsed.cc),
+              JSON.stringify(parsed.deliveryAddresses || []),
               JSON.stringify(parsed.replyTo || []), inReplyTo,
               safeDate(parsed.date), sanitizeStr(parsed.snippet),
               parsed.isRead, parsed.isStarred,
@@ -2580,13 +2590,13 @@ export class ImapManager {
                 await query(`
                   INSERT INTO messages (
                     account_id, uid, folder, message_id, subject,
-                    from_name, from_email, to_addresses, cc_addresses,
+                    from_name, from_email, to_addresses, cc_addresses, delivery_addresses,
                     reply_to, in_reply_to,
                     date, snippet, is_read, is_starred, has_attachments, flags,
                     body_html, body_text, attachments,
                     thread_references, thread_id, is_bulk, category,
                     list_unsubscribe, list_unsubscribe_post
-                  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)
+                  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
                   ON CONFLICT (account_id, uid, folder) DO UPDATE
                   SET subject = CASE
                         WHEN EXCLUDED.subject IS NOT NULL
@@ -2606,6 +2616,11 @@ export class ImapManager {
                         WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
                         THEN EXCLUDED.cc_addresses
                         ELSE messages.cc_addresses
+                      END,
+                      delivery_addresses = CASE
+                        WHEN EXCLUDED.delivery_addresses::text IS NOT NULL AND EXCLUDED.delivery_addresses::text <> '[]'
+                        THEN EXCLUDED.delivery_addresses
+                        ELSE messages.delivery_addresses
                       END,
                       reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), EXCLUDED.reply_to::text)::jsonb,
                       in_reply_to = COALESCE(messages.in_reply_to, EXCLUDED.in_reply_to),
@@ -2638,6 +2653,7 @@ export class ImapManager {
                   bfMsgId, sanitizeStr(parsed.subject),
                   sanitizeStr(parsed.fromName), sanitizeStr(parsed.fromEmail),
                   JSON.stringify(parsed.to), JSON.stringify(parsed.cc),
+                  JSON.stringify(parsed.deliveryAddresses || []),
                   JSON.stringify(parsed.replyTo || []), bfReplyTo,
                   safeDate(parsed.date), sanitizeStr(parsed.snippet),
                   parsed.isRead, parsed.isStarred,
@@ -3109,9 +3125,9 @@ export class ImapManager {
     await query(`
       INSERT INTO messages (
         account_id, uid, folder, message_id, subject,
-        from_name, from_email, to_addresses, cc_addresses,
+        from_name, from_email, to_addresses, cc_addresses, delivery_addresses,
         date, snippet, is_read, is_starred, has_attachments, flags, thread_id
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11,true,false,false,'[]',$12)
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,$11,$12,true,false,false,'[]',$13)
       ON CONFLICT (account_id, uid, folder) DO UPDATE SET
         message_id = COALESCE(EXCLUDED.message_id, messages.message_id),
         subject = CASE
@@ -3125,6 +3141,9 @@ export class ImapManager {
         cc_addresses = CASE
           WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
           THEN EXCLUDED.cc_addresses ELSE messages.cc_addresses END,
+        delivery_addresses = CASE
+          WHEN EXCLUDED.delivery_addresses::text IS NOT NULL AND EXCLUDED.delivery_addresses::text <> '[]'
+          THEN EXCLUDED.delivery_addresses ELSE messages.delivery_addresses END,
         date = EXCLUDED.date,
         snippet = CASE WHEN EXCLUDED.snippet <> '' THEN EXCLUDED.snippet ELSE messages.snippet END,
         is_read = true,
@@ -3134,6 +3153,7 @@ export class ImapManager {
       sanitizeStr(subject || '(no subject)'),
       sanitizeStr(fromName || ''), sanitizeStr(fromEmail || ''),
       JSON.stringify(to), JSON.stringify(cc),
+      JSON.stringify([]),
       safeDate(date), sanitizeStr(snippet || ''), threadId,
     ]);
   }

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('imapflow', () => ({ ImapFlow: vi.fn() }));
 vi.mock('./db.js', () => ({ query: vi.fn() }));
-vi.mock('./messageParser.js', () => ({ parseMessage: vi.fn(), buildSnippetFromHtml: vi.fn(), snippetFromBody: vi.fn(), decodeMimeWords: vi.fn(), detectBulkFromParsedHeaders: vi.fn(), parseRawHeaders: vi.fn() }));
+vi.mock('./messageParser.js', () => ({ parseMessage: vi.fn(), enrichParsedMetadata: vi.fn(), buildSnippetFromHtml: vi.fn(), snippetFromBody: vi.fn(), decodeMimeWords: vi.fn(), detectBulkFromParsedHeaders: vi.fn(), parseRawHeaders: vi.fn() }));
 vi.mock('../routes/oauth.js', () => ({ refreshMicrosoftToken: vi.fn() }));
 vi.mock('./emailSanitizer.js', () => ({ sanitizeEmail: vi.fn() }));
 vi.mock('./encryption.js', () => ({ decrypt: vi.fn() }));
@@ -10,7 +10,9 @@ vi.mock('./pushNotifications.js', () => ({ sendPushToUser: vi.fn() }));
 vi.mock('../utils/redact.js', () => ({ redactEmail: vi.fn() }));
 vi.mock('./hostValidation.js', () => ({ resolveForConnection: vi.fn() }));
 
-import { providerProfile, makeClientCfg, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, planModseqSync, connectStaggerFor } from './imapManager.js';
+import { ImapManager, providerProfile, makeClientCfg, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, planModseqSync, connectStaggerFor } from './imapManager.js';
+import { query } from './db.js';
+import { parseMessage } from './messageParser.js';
 
 const account = (imap_host, oauth_provider = null) => ({ imap_host, oauth_provider });
 
@@ -221,6 +223,91 @@ describe('makeClientCfg — rejectUnauthorized', () => {
   it('does not set servername when resolved.servername is null', () => {
     const cfg = makeClientCfg(baseAccount, resolved);
     expect(cfg.tls.servername).toBeUndefined();
+  });
+});
+
+describe('message delivery-address persistence', () => {
+  beforeEach(() => {
+    query.mockReset();
+    parseMessage.mockReset();
+  });
+
+  it('binds parsed delivery addresses in folder-sync inserts without erasing them on an empty refetch', async () => {
+    const parsed = {
+      uid: 2,
+      messageId: null,
+      subject: 'Delivered alias',
+      fromName: 'Sender',
+      fromEmail: 'sender@example.com',
+      to: [],
+      cc: [],
+      deliveryAddresses: ['mask@example.com'],
+      replyTo: [],
+      inReplyTo: null,
+      references: null,
+      parsedHeaders: {},
+      date: new Date('2026-07-12T12:00:00Z'),
+      snippet: '',
+      isRead: true,
+      isStarred: false,
+      hasAttachments: false,
+      flags: [],
+      isBulk: false,
+    };
+    parseMessage.mockResolvedValueOnce(parsed).mockResolvedValueOnce({
+      ...parsed,
+      deliveryAddresses: [],
+    });
+
+    const inserts = [];
+    query.mockImplementation(async (sql, params = []) => {
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false)')) return { rows: [{ n: 0 }] };
+      if (sql.includes('COALESCE(MAX(uid), 0) as max_uid')) return { rows: [{ max_uid: 1 }] };
+      if (sql.includes('INSERT INTO messages')) {
+        inserts.push([sql, params]);
+        return { rows: [{ id: 'msg-1', is_new: false }] };
+      }
+      return { rows: [] };
+    });
+
+    let fetchCount = 0;
+    const client = {
+      mailbox: { exists: 2 },
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      fetch: vi.fn(() => (async function* () {
+        fetchCount++;
+        if (fetchCount <= 2) yield { uid: 2 };
+      })()),
+    };
+    const manager = Object.create(ImapManager.prototype);
+    manager.broadcast = vi.fn();
+
+    await manager.syncMessages({ id: 'acct-1', user_id: 'user-1', imap_host: 'imap.fastmail.com' }, client, 'INBOX', 50, false);
+
+    expect(inserts).toHaveLength(2);
+    expect(inserts[0][0]).toMatch(/to_addresses, cc_addresses,\s+delivery_addresses/);
+    expect(inserts[0][1][9]).toBe(JSON.stringify(['mask@example.com']));
+    expect(inserts[1][1][9]).toBe(JSON.stringify([]));
+    expect(inserts[1][0]).toContain("WHEN EXCLUDED.delivery_addresses::text IS NOT NULL AND EXCLUDED.delivery_addresses::text <> '[]'");
+    expect(inserts[1][0]).toContain('ELSE messages.delivery_addresses');
+  });
+
+  it('preserves stored delivery addresses when sent metadata has no delivery header', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    const manager = Object.create(ImapManager.prototype);
+
+    await manager.upsertSentMessageRecord(
+      { id: 'acct-1' },
+      'Sent',
+      42,
+      { messageId: '<sent@example.com>', subject: 'Sent message' },
+    );
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/to_addresses, cc_addresses,\s+delivery_addresses/);
+    expect(params[9]).toBe(JSON.stringify([]));
+    expect(sql).toContain("WHEN EXCLUDED.delivery_addresses::text IS NOT NULL AND EXCLUDED.delivery_addresses::text <> '[]'");
+    expect(sql).toContain('ELSE messages.delivery_addresses');
   });
 });
 

--- a/backend/src/services/messageParser.headers.test.js
+++ b/backend/src/services/messageParser.headers.test.js
@@ -69,6 +69,56 @@ describe('snippetFromBody', () => {
 });
 
 describe('parseMessage', () => {
+  it('preserves every parseable X-Delivered-to value in header order', async () => {
+    const parsed = await parseMessage({
+      uid: 1,
+      envelope: {},
+      flags: new Set(),
+      headers: Buffer.from(
+        'X-Delivered-to: First@Example.com\r\n' +
+        'X-Delivered-to: "Mask" <second@example.com>\r\n' +
+        'X-Delivered-to: not-an-address\r\n',
+      ),
+    });
+    expect(parsed.deliveryAddresses).toEqual(['first@example.com', 'second@example.com']);
+  });
+
+  it('parses folded and comma-separated X-Delivered-to values', async () => {
+    const parsed = await parseMessage({
+      uid: 1,
+      envelope: {},
+      flags: new Set(),
+      headers: Buffer.from(
+        'X-Delivered-to: "First" <first@example.com>,\r\n' +
+        ' second@example.com\r\n',
+      ),
+    });
+    expect(parsed.deliveryAddresses).toEqual(['first@example.com', 'second@example.com']);
+  });
+
+  it('retains duplicate X-Delivered-to values in order', async () => {
+    const parsed = await parseMessage({
+      uid: 1,
+      envelope: {},
+      flags: new Set(),
+      headers: Buffer.from(
+        'X-Delivered-to: mask@example.com\r\n' +
+        'X-Delivered-to: MASK@example.com\r\n',
+      ),
+    });
+    expect(parsed.deliveryAddresses).toEqual(['mask@example.com', 'mask@example.com']);
+  });
+
+  it('returns no delivery addresses when X-Delivered-to is missing', async () => {
+    const parsed = await parseMessage({
+      uid: 1,
+      envelope: {},
+      flags: new Set(),
+      headers: Buffer.from('To: recipient@example.com\r\n'),
+    });
+    expect(parsed.deliveryAddresses).toEqual([]);
+  });
+
   it('cleans link URLs out of sync-time snippets from text/plain parts', async () => {
     const parsed = await parseMessage({
       uid: 1,

--- a/backend/src/services/messageParser.js
+++ b/backend/src/services/messageParser.js
@@ -368,6 +368,15 @@ export function parseMailboxList(headerValue) {
   return results.filter(r => r.email);
 }
 
+export function parseDeliveryAddresses(value) {
+  if (!value) return [];
+  return String(value)
+    .split(/\r?\n/)
+    .flatMap(line => parseMailboxList(line))
+    .map(entry => entry.email.trim().toLowerCase())
+    .filter(Boolean);
+}
+
 // Fill gaps when IMAP ENVELOPE is incomplete — common for multipart/related Sent copies.
 export function enrichParsedMetadata(parsed, {
   accountEmail,
@@ -537,6 +546,7 @@ export async function parseMessage(msg) {
     inReplyTo: envelope.inReplyTo || null,
     references,
     parsedHeaders,
+    deliveryAddresses: parseDeliveryAddresses(parsedHeaders['x-delivered-to']),
     date: msg.internalDate || envelope.date || new Date(),
     snippet,
     isRead,

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -92,7 +92,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
                m.id, m.uid, m.folder, m.message_id,
                m.thread_key AS thread_id,
                m.subject, m.from_name, m.from_email,
-               m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
+               m.to_addresses, m.cc_addresses, m.delivery_addresses, m.reply_to, m.in_reply_to,
                m.date, m.snippet, m.is_read, m.is_starred,
                m.has_attachments, m.account_id, m.category,
                m.list_unsubscribe, m.list_unsubscribe_post,
@@ -138,7 +138,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
       )
       SELECT id, uid, folder, message_id, thread_id, thread_subject AS subject,
              thread_from_name AS from_name, thread_from_email AS from_email,
-             to_addresses, cc_addresses, reply_to, in_reply_to,
+             to_addresses, cc_addresses, delivery_addresses, reply_to, in_reply_to,
              date, snippet, is_starred, is_read, has_attachments, account_id,
              account_name, account_email, account_color,
              category, list_unsubscribe, list_unsubscribe_post,
@@ -169,7 +169,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
 
   const result = await query(`
     SELECT m.id, m.uid, m.folder, m.message_id, m.subject, m.from_name, m.from_email,
-           m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
+           m.to_addresses, m.cc_addresses, m.delivery_addresses, m.reply_to, m.in_reply_to,
            m.date, m.snippet, m.is_read, m.is_starred,
            m.has_attachments, m.account_id, m.category,
            m.list_unsubscribe, m.list_unsubscribe_post,

--- a/backend/src/services/senderAddress.js
+++ b/backend/src/services/senderAddress.js
@@ -1,0 +1,46 @@
+function isValidDomain(domain) {
+  if (!domain || domain.length > 253 || domain.startsWith('.') || domain.endsWith('.')) return false;
+  return domain.split('.').every(label => (
+    label.length > 0
+    && label.length <= 63
+    && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(label)
+  ));
+}
+
+export function normalizeEmailAddress(value) {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  // eslint-disable-next-line no-control-regex -- sender addresses containing control characters are invalid
+  if (!normalized || /[\s<>\u0000-\u001f\u007f]/.test(normalized)) return null;
+  const parts = normalized.split('@');
+  if (parts.length !== 2 || !parts[0] || !isValidDomain(parts[1])) return null;
+  return normalized;
+}
+
+export function normalizeWildcardAddress(value) {
+  if (typeof value !== 'string') return null;
+  const match = /^\*@([^@]+)$/.exec(value.trim().toLowerCase());
+  return match && isValidDomain(match[1]) ? `*@${match[1]}` : null;
+}
+
+export function normalizeSenderAddress(value) {
+  return normalizeWildcardAddress(value) || normalizeEmailAddress(value);
+}
+
+// Identity display names and provider address labels become message headers; reject
+// control characters so they cannot inject extra header lines. Shared by the alias
+// sync and sender-authorization paths.
+export function hasHeaderControlCharacters(value) {
+  // eslint-disable-next-line no-control-regex -- header-unsafe control characters
+  return /[\u0000-\u001f\u007f]/.test(value);
+}
+
+export function wildcardCovers(pattern, candidate) {
+  const normalizedPattern = normalizeWildcardAddress(pattern);
+  const normalizedCandidate = normalizeEmailAddress(candidate);
+  return Boolean(
+    normalizedPattern
+    && normalizedCandidate
+    && normalizedCandidate.slice(normalizedCandidate.lastIndexOf('@') + 1) === normalizedPattern.slice(2)
+  );
+}

--- a/backend/src/services/senderAuthorization.js
+++ b/backend/src/services/senderAuthorization.js
@@ -1,0 +1,93 @@
+import { query } from './db.js';
+import {
+  hasHeaderControlCharacters,
+  normalizeEmailAddress,
+  normalizeWildcardAddress,
+  wildcardCovers,
+} from './senderAddress.js';
+
+// A stale/forbidden sender is a client fault surfaced as 422; the code lets routes
+// return the SENDER_UNAVAILABLE response shape without leaking why.
+function unavailable() {
+  throw Object.assign(
+    new Error('The selected sending address is no longer available. Refresh addresses or choose another sender.'),
+    { status: 422, code: 'SENDER_UNAVAILABLE' },
+  );
+}
+
+function providerAddressList(value) {
+  if (!Array.isArray(value)) unavailable();
+  return value.map(address => {
+    const email = normalizeEmailAddress(address?.email);
+    const name = address?.name ?? '';
+    if (!email || typeof name !== 'string' || hasHeaderControlCharacters(name)) unavailable();
+    return name ? { name, address: email } : email;
+  });
+}
+
+export async function authorizeSender({ userId, sender }, queryFn = query) {
+  if (!sender || typeof sender !== 'object' || !sender.accountId) unavailable();
+
+  const accountResult = await queryFn(
+    'SELECT * FROM email_accounts WHERE id = $1 AND user_id = $2',
+    [sender.accountId, userId],
+  );
+  if (!accountResult.rows.length) unavailable();
+  const account = accountResult.rows[0];
+
+  if (sender.aliasId === null) {
+    if (sender.fromEmail !== null) unavailable();
+    return {
+      account,
+      fromName: account.sender_name || account.name,
+      fromEmail: account.email_address,
+      fromReplyTo: null,
+      fromSignature: account.signature,
+    };
+  }
+
+  if (typeof sender.aliasId !== 'string' || !sender.aliasId) unavailable();
+
+  const aliasResult = await queryFn(
+    'SELECT * FROM account_aliases WHERE id = $1 AND account_id = $2',
+    [sender.aliasId, account.id],
+  );
+  if (!aliasResult.rows.length) unavailable();
+  const alias = aliasResult.rows[0];
+  if (alias.account_id !== account.id) unavailable();
+
+  const wildcardPattern = normalizeWildcardAddress(alias.email);
+  let fromEmail;
+  if (wildcardPattern) {
+    const isVerifiedWildcard = alias.provenance === 'fastmail'
+      && Boolean(alias.fastmail_identity_id)
+      && wildcardPattern === alias.email.trim().toLowerCase();
+    const normalizedFrom = normalizeEmailAddress(sender.fromEmail);
+    if (!isVerifiedWildcard || !normalizedFrom || !wildcardCovers(wildcardPattern, normalizedFrom)) unavailable();
+    fromEmail = normalizedFrom;
+  } else {
+    if (sender.fromEmail !== null) unavailable();
+    if (alias.provenance === 'fastmail' && !alias.fastmail_identity_id) unavailable();
+    fromEmail = normalizeEmailAddress(alias.email);
+    if (!fromEmail) unavailable();
+  }
+
+  const fromReplyTo = alias.provenance === 'fastmail'
+    ? providerAddressList(alias.fastmail_reply_to)
+    : (alias.reply_to || null);
+
+  return {
+    account,
+    fromName: alias.provenance === 'fastmail'
+      ? (typeof alias.name === 'string' ? alias.name : '')
+      : (alias.name || account.sender_name || account.name),
+    fromEmail,
+    // A Fastmail identity with no Reply-To yields []; normalize to null so callers omit
+    // the header (`fromReplyTo ? ... : {}`) instead of emitting an empty Reply-To.
+    fromReplyTo: Array.isArray(fromReplyTo) && !fromReplyTo.length ? null : fromReplyTo,
+    fromBcc: alias.provenance === 'fastmail'
+      ? providerAddressList(alias.fastmail_bcc)
+      : [],
+    fromSignature: alias.signature !== null ? alias.signature : account.signature,
+  };
+}

--- a/backend/src/services/senderAuthorization.test.js
+++ b/backend/src/services/senderAuthorization.test.js
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { authorizeSender } from './senderAuthorization.js';
+
+const account = {
+  id: 'a1', user_id: 'u1', name: 'Fastmail', sender_name: 'Account Owner',
+  email_address: 'owner@example.com', signature: '<p>Account signature</p>',
+};
+
+const manualAlias = {
+  id: 'manual', account_id: 'a1', name: 'Manual Alias', email: 'manual@example.com',
+  reply_to: 'reply@example.com', signature: '<p>Alias signature</p>',
+  provenance: 'manual', fastmail_identity_id: null,
+};
+
+const providerAlias = {
+  ...manualAlias, id: 'provider', name: 'Provider Alias', email: 'alias@example.com',
+  provenance: 'fastmail', fastmail_identity_id: 'identity-1',
+  fastmail_reply_to: [{ name: '', email: 'reply@example.com' }], fastmail_bcc: [],
+};
+
+const wildcardAlias = {
+  ...providerAlias, id: 'wildcard', name: 'Wildcard Identity', email: '*@example.com',
+  fastmail_identity_id: 'identity-wildcard',
+};
+
+describe('authorizeSender', () => {
+  let queryFn;
+
+  beforeEach(() => {
+    queryFn = vi.fn();
+  });
+
+  it('rejects an explicitly supplied stale alias instead of using the account address', async () => {
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [] });
+    await expect(authorizeSender({
+      userId: 'u1',
+      sender: { accountId: account.id, aliasId: 'missing', fromEmail: null },
+    }, queryFn)).rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+
+  it('allows a derived address only through its verified wildcard identity', async () => {
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [wildcardAlias] });
+    await expect(authorizeSender({
+      userId: 'u1',
+      sender: { accountId: account.id, aliasId: wildcardAlias.id, fromEmail: 'mask@example.com' },
+    }, queryFn)).resolves.toMatchObject({
+      account,
+      fromName: 'Wildcard Identity',
+      fromEmail: 'mask@example.com',
+      fromReplyTo: ['reply@example.com'],
+      fromSignature: '<p>Alias signature</p>',
+    });
+  });
+
+  it.each([
+    ['missing sender', null],
+    ['missing sender object', undefined],
+    ['missing account ID', { accountId: '', aliasId: null, fromEmail: null }],
+  ])('rejects %s', async (_label, sender) => {
+    await expect(authorizeSender({ userId: 'u1', sender }, queryFn))
+      .rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+    expect(queryFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unowned account', async () => {
+    queryFn.mockResolvedValueOnce({ rows: [] });
+    await expect(authorizeSender({
+      userId: 'other', sender: { accountId: 'a1', aliasId: null, fromEmail: null },
+    }, queryFn)).rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+
+  it('allows an explicit primary selection', async () => {
+    queryFn.mockResolvedValueOnce({ rows: [account] });
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: null, fromEmail: null },
+    }, queryFn)).resolves.toMatchObject({
+      account, fromName: 'Account Owner', fromEmail: 'owner@example.com',
+      fromReplyTo: null, fromSignature: '<p>Account signature</p>',
+    });
+    expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a derived address without an alias', async () => {
+    queryFn.mockResolvedValueOnce({ rows: [account] });
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: null, fromEmail: 'mask@example.com' },
+    }, queryFn)).rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+
+  it.each([
+    ['an omitted alias selection', { accountId: 'a1', fromEmail: null }],
+    ['an empty alias selection', { accountId: 'a1', aliasId: '', fromEmail: null }],
+    ['an omitted primary fromEmail marker', { accountId: 'a1', aliasId: null }],
+  ])('rejects %s instead of treating it as primary', async (_label, sender) => {
+    queryFn.mockResolvedValueOnce({ rows: [account] });
+    await expect(authorizeSender({ userId: 'u1', sender }, queryFn))
+      .rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+
+  it.each([
+    ['manual alias', manualAlias],
+    ['verified provider alias', providerAlias],
+  ])('allows an exact %s and returns trusted metadata', async (_label, alias) => {
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [alias] });
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: alias.id, fromEmail: null },
+    }, queryFn)).resolves.toMatchObject({
+      account, fromName: alias.name, fromEmail: alias.email,
+      fromReplyTo: alias.provenance === 'fastmail' ? ['reply@example.com'] : alias.reply_to,
+      fromSignature: alias.signature,
+    });
+  });
+
+  it('preserves a blank Fastmail identity name instead of borrowing the account name', async () => {
+    const blankNameAlias = { ...providerAlias, name: '' };
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [blankNameAlias] });
+
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: blankNameAlias.id, fromEmail: null },
+    }, queryFn)).resolves.toMatchObject({
+      fromName: '',
+      fromEmail: blankNameAlias.email,
+    });
+  });
+
+  it('omits Reply-To for a Fastmail identity with no reply-to addresses', async () => {
+    const noReplyToAlias = { ...providerAlias, fastmail_reply_to: [] };
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [noReplyToAlias] });
+
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: noReplyToAlias.id, fromEmail: null },
+    }, queryFn)).resolves.toMatchObject({ fromEmail: noReplyToAlias.email, fromReplyTo: null });
+  });
+
+  it('returns complete Fastmail identity Reply-To and Bcc routing', async () => {
+    const routedAlias = {
+      ...providerAlias,
+      fastmail_reply_to: [
+        { name: 'Support', email: 'support@example.com' },
+        { name: '', email: 'archive@example.com' },
+      ],
+      fastmail_bcc: [{ name: 'Compliance', email: 'compliance@example.com' }],
+    };
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [routedAlias] });
+
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: routedAlias.id, fromEmail: null },
+    }, queryFn)).resolves.toMatchObject({
+      fromReplyTo: [
+        { name: 'Support', address: 'support@example.com' },
+        'archive@example.com',
+      ],
+      fromBcc: [{ name: 'Compliance', address: 'compliance@example.com' }],
+    });
+  });
+
+  it('rejects a verified provider row with a malformed email address', async () => {
+    const malformedAlias = { ...providerAlias, email: 'not-an-address' };
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [malformedAlias] });
+
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: malformedAlias.id, fromEmail: null },
+    }, queryFn)).rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+
+  it('inherits the account signature when an exact alias has no signature', async () => {
+    const alias = { ...manualAlias, signature: null };
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [alias] });
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: alias.id, fromEmail: null },
+    }, queryFn)).resolves.toMatchObject({ fromSignature: account.signature });
+  });
+
+  it('rejects an exact alias when the fromEmail marker is omitted', async () => {
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [manualAlias] });
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: manualAlias.id },
+    }, queryFn)).rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+
+  it.each([
+    ['derived address with an exact alias', providerAlias, 'mask@example.com'],
+    ['wrong wildcard domain', wildcardAlias, 'mask@other.example'],
+    ['invalid wildcard syntax', { ...wildcardAlias, email: '*example.com' }, 'mask@example.com'],
+    ['Fastmail wildcard without identity ID', { ...wildcardAlias, fastmail_identity_id: null }, 'mask@example.com'],
+    ['Fastmail exact alias without identity ID', { ...providerAlias, fastmail_identity_id: null }, null],
+    ['provider mask-only exact row', { ...providerAlias, fastmail_identity_id: null, fastmail_masked_email_id: 'mask-1' }, null],
+    ['alias from another account', { ...manualAlias, account_id: 'a2' }, null],
+  ])('rejects %s', async (_label, alias, fromEmail) => {
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [alias] });
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: alias.id, fromEmail },
+    }, queryFn)).rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+
+  it.each([
+    'mask example.com',
+    'mask@example.com\r\nBcc: victim@example.com',
+    'mask@example.com\0',
+    '@example.com',
+    'mask@',
+    'mask@@example.com',
+  ])('rejects invalid derived address %j', async fromEmail => {
+    queryFn.mockResolvedValueOnce({ rows: [account] }).mockResolvedValueOnce({ rows: [wildcardAlias] });
+    await expect(authorizeSender({
+      userId: 'u1', sender: { accountId: 'a1', aliasId: wildcardAlias.id, fromEmail },
+    }, queryFn)).rejects.toMatchObject({ status: 422, code: 'SENDER_UNAVAILABLE' });
+  });
+});

--- a/backend/src/services/senderResolver.js
+++ b/backend/src/services/senderResolver.js
@@ -1,0 +1,145 @@
+import { query } from './db.js';
+import { syncFastmailAliases } from './fastmailAliasSync.js';
+import { normalizeEmailAddress, wildcardCovers } from './senderAddress.js';
+import { sanitizeSignature } from './emailSanitizer.js';
+
+function normalizeAddress(value) {
+  const address = typeof value === 'string' ? value : value?.email;
+  return normalizeEmailAddress(address);
+}
+
+function exact(left, right) {
+  const normalizedLeft = normalizeAddress(left);
+  const normalizedRight = normalizeAddress(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
+function resultForAlias(account, alias, { fromEmail, displayEmail }) {
+  const signature = alias.signature !== null ? alias.signature : account.signature;
+  return {
+    accountId: account.id,
+    aliasId: alias.id,
+    fromEmail,
+    displayEmail,
+    name: alias.provenance === 'fastmail'
+      ? (typeof alias.name === 'string' ? alias.name : '')
+      : (alias.name || account.sender_name || account.name || ''),
+    provenance: alias.provenance,
+    signature: signature === null || signature === undefined
+      ? null
+      : sanitizeSignature(signature),
+  };
+}
+
+function resultForPrimary(account) {
+  return {
+    accountId: account.id,
+    aliasId: null,
+    fromEmail: null,
+    displayEmail: account.email_address,
+    name: account.sender_name || account.name || '',
+    provenance: 'primary',
+  };
+}
+
+export function matchAuthorizedSender({ account, aliases, candidates }) {
+  for (const candidate of candidates) {
+    const providerExact = aliases.find(alias => (
+      alias.provenance === 'fastmail'
+      && alias.fastmail_identity_id
+      && exact(alias.email, candidate)
+    ));
+    const manualExact = aliases.find(alias => (
+      alias.provenance === 'manual' && exact(alias.email, candidate)
+    ));
+    if (providerExact) {
+      return resultForAlias(account, providerExact, {
+        fromEmail: null,
+        displayEmail: providerExact.email,
+      });
+    }
+    if (manualExact) {
+      return resultForAlias(account, manualExact, {
+        fromEmail: null,
+        displayEmail: manualExact.email,
+      });
+    }
+    if (exact(account.email_address, candidate)) return resultForPrimary(account);
+
+    const wildcard = aliases.find(alias => (
+      alias.provenance === 'fastmail'
+      && alias.fastmail_identity_id
+      && wildcardCovers(alias.email, candidate)
+    ));
+    if (wildcard) {
+      const exactAddress = normalizeAddress(candidate);
+      return resultForAlias(account, wildcard, {
+        fromEmail: exactAddress,
+        displayEmail: exactAddress,
+      });
+    }
+  }
+  return null;
+}
+
+function addressList(value) {
+  let parsed = value;
+  if (typeof parsed === 'string') {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.map(entry => typeof entry === 'string' ? entry : entry?.email).filter(Boolean);
+}
+
+async function loadAliases(accountId) {
+  const result = await query(
+    `SELECT id, account_id, name, email, signature, provenance, fastmail_identity_id
+     FROM account_aliases
+     WHERE account_id = $1
+     ORDER BY created_at ASC`,
+    [accountId],
+  );
+  return result.rows;
+}
+
+export async function resolveMessageSender({ messageId, userId, purpose }) {
+  const messageResult = await query(
+    `SELECT a.id, m.account_id, m.from_email, m.delivery_addresses,
+            m.to_addresses, m.cc_addresses,
+            a.email_address, a.sender_name, a.name, a.signature, a.fastmail_api_token
+     FROM messages m
+     JOIN email_accounts a ON a.id = m.account_id
+     WHERE m.id = $1 AND a.user_id = $2 AND m.is_deleted = false`,
+    [messageId, userId],
+  );
+  if (!messageResult.rows.length) {
+    throw Object.assign(new Error('Message not found'), { status: 404 });
+  }
+
+  const message = messageResult.rows[0];
+  const candidates = purpose === 'draft'
+    ? [message.from_email]
+    : [
+        ...addressList(message.delivery_addresses),
+        ...addressList(message.to_addresses),
+        ...addressList(message.cc_addresses),
+      ];
+  let aliases = await loadAliases(message.account_id);
+  let sender = matchAuthorizedSender({ account: message, aliases, candidates });
+
+  if (!sender && purpose === 'reply' && message.fastmail_api_token) {
+    try {
+      await syncFastmailAliases(message.account_id);
+    } catch {
+      return { sender: null, requiresSelection: true };
+    }
+    aliases = await loadAliases(message.account_id);
+    sender = matchAuthorizedSender({ account: message, aliases, candidates });
+  }
+
+  return { sender, requiresSelection: sender === null };
+}

--- a/backend/src/services/senderResolver.test.js
+++ b/backend/src/services/senderResolver.test.js
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => ({ query: vi.fn() }));
+vi.mock('./fastmailAliasSync.js', () => ({ syncFastmailAliases: vi.fn() }));
+
+import { query } from './db.js';
+import { syncFastmailAliases } from './fastmailAliasSync.js';
+import { matchAuthorizedSender, resolveMessageSender } from './senderResolver.js';
+
+const account = {
+  id: 'a1',
+  email_address: 'owner@example.com',
+  sender_name: 'Account Owner',
+  name: 'Fastmail',
+  fastmail_api_token: 'encrypted-token',
+};
+
+const aliases = [
+  {
+    id: 'provider', account_id: 'a1', name: 'Provider Alias', email: 'alias@example.com',
+    provenance: 'fastmail', fastmail_identity_id: 'i1',
+  },
+  {
+    id: 'manual', account_id: 'a1', name: 'Manual Alias', email: 'alias@example.com',
+    provenance: 'manual', fastmail_identity_id: null,
+  },
+  {
+    id: 'wild', account_id: 'a1', name: 'Wildcard', email: '*@example.net',
+    provenance: 'fastmail', fastmail_identity_id: 'i2',
+  },
+];
+
+describe('matchAuthorizedSender', () => {
+  it('prefers the first delivered candidate over visible To and Cc recipients', () => {
+    const result = matchAuthorizedSender({
+      account,
+      aliases,
+      candidates: ['Mask@Example.net', 'alias@example.com'],
+    });
+
+    expect(result).toMatchObject({
+      accountId: 'a1', aliasId: 'wild', fromEmail: 'mask@example.net',
+      displayEmail: 'mask@example.net', provenance: 'fastmail',
+    });
+  });
+
+  it('prefers provider exact over manual exact for the same candidate', () => {
+    expect(matchAuthorizedSender({ account, aliases, candidates: ['ALIAS@example.com'] }))
+      .toMatchObject({ aliasId: 'provider', fromEmail: null, displayEmail: 'alias@example.com' });
+  });
+
+  it('preserves a blank Fastmail identity name instead of borrowing the account name', () => {
+    const blankNameAlias = { ...aliases[0], name: '' };
+
+    expect(matchAuthorizedSender({
+      account,
+      aliases: [blankNameAlias],
+      candidates: ['alias@example.com'],
+    })).toMatchObject({
+      aliasId: 'provider',
+      displayEmail: 'alias@example.com',
+      name: '',
+    });
+  });
+
+  it('returns the effective alias signature for a resolved sender', () => {
+    const alias = { ...aliases[0], signature: '<p>Alias signature</p>' };
+
+    expect(matchAuthorizedSender({
+      account: { ...account, signature: '<p>Account signature</p>' },
+      aliases: [alias],
+      candidates: ['alias@example.com'],
+    })).toMatchObject({
+      aliasId: 'provider',
+      signature: '<p>Alias signature</p>',
+    });
+  });
+
+  it('preserves an explicitly blank provider signature in the resolved sender', () => {
+    const alias = { ...aliases[0], signature: '' };
+
+    expect(matchAuthorizedSender({
+      account: { ...account, signature: '<p>Account signature</p>' },
+      aliases: [alias],
+      candidates: ['alias@example.com'],
+    })).toMatchObject({ signature: '' });
+  });
+
+  it.each([
+    ['manual exact', [aliases[1]], 'ALIAS@example.com', { aliasId: 'manual', provenance: 'manual' }],
+    ['primary account', aliases, 'OWNER@EXAMPLE.COM', { aliasId: null, provenance: 'primary' }],
+    ['verified wildcard', aliases, 'Bcc.Mask@Example.net', {
+      aliasId: 'wild', fromEmail: 'bcc.mask@example.net', displayEmail: 'bcc.mask@example.net',
+    }],
+  ])('matches %s case-insensitively', (_label, candidateAliases, candidate, expected) => {
+    expect(matchAuthorizedSender({ account, aliases: candidateAliases, candidates: [candidate] }))
+      .toMatchObject(expected);
+  });
+
+  it('does not authorize a delivery header without a matching identity', () => {
+    expect(matchAuthorizedSender({ account, aliases, candidates: ['attacker@evil.example'] })).toBeNull();
+  });
+
+  it.each([
+    '*example.net',
+    '**@example.net',
+    '*@example.net@evil.example',
+    '*@',
+    '*@example.net/path',
+  ])('ignores invalid wildcard shape %s', email => {
+    const invalid = [{ ...aliases[2], email }];
+    expect(matchAuthorizedSender({ account, aliases: invalid, candidates: ['mask@example.net'] })).toBeNull();
+  });
+
+  it('requires a provider identity ID for wildcard authorization', () => {
+    const unverified = [{ ...aliases[2], fastmail_identity_id: null }];
+    expect(matchAuthorizedSender({ account, aliases: unverified, candidates: ['mask@example.net'] })).toBeNull();
+  });
+
+  it('returns null when no candidate matches', () => {
+    expect(matchAuthorizedSender({ account, aliases, candidates: [] })).toBeNull();
+  });
+});
+
+describe('resolveMessageSender', () => {
+  const message = {
+    id: 'm1', account_id: 'a1', from_email: 'draft-alias@example.com',
+    delivery_addresses: ['first@example.net'],
+    to_addresses: [],
+    cc_addresses: [],
+  };
+
+  beforeEach(() => {
+    query.mockReset();
+    syncFastmailAliases.mockReset();
+    syncFastmailAliases.mockResolvedValue([]);
+  });
+
+  function mockOwnedMessage(rowsBeforeSync, rowsAfterSync = rowsBeforeSync, messageOverrides = {}) {
+    let aliasLoads = 0;
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM messages m')) return { rows: [{ ...message, ...account, ...messageOverrides }] };
+      if (sql.includes('FROM account_aliases')) {
+        aliasLoads += 1;
+        return { rows: aliasLoads === 1 ? rowsBeforeSync : rowsAfterSync };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    return () => aliasLoads;
+  }
+
+  it('builds reply candidates from delivery addresses, To, then Cc without using From', async () => {
+    mockOwnedMessage([
+      { ...aliases[2], email: '*@example.net' },
+      aliases[0],
+    ], undefined, {
+      to_addresses: [{ email: 'alias@example.com' }],
+      cc_addresses: [{ email: 'owner@example.com' }],
+    });
+
+    const result = await resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'reply' });
+
+    expect(result.sender).toMatchObject({ aliasId: 'wild', fromEmail: 'first@example.net' });
+    expect(syncFastmailAliases).not.toHaveBeenCalled();
+  });
+
+  it('returns the inherited account signature through the complete resolver path', async () => {
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM messages m')) {
+        const selectedAccountFields = sql.includes('a.signature')
+          ? { signature: '<p>Account signature</p>' }
+          : {};
+        return {
+          rows: [{
+            ...message,
+            ...account,
+            delivery_addresses: ['alias@example.com'],
+            ...selectedAccountFields,
+          }],
+        };
+      }
+      if (sql.includes('FROM account_aliases')) {
+        return { rows: [{ ...aliases[0], signature: null }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const result = await resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'reply' });
+
+    expect(result.sender).toMatchObject({
+      aliasId: 'provider',
+      signature: '<p>Account signature</p>',
+    });
+  });
+
+  it('refreshes exactly once, reloads aliases, and resolves a newly created mask', async () => {
+    const aliasLoadCount = mockOwnedMessage([], [
+      { ...aliases[2], email: '*@example.net' },
+    ]);
+
+    const result = await resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'reply' });
+
+    expect(syncFastmailAliases).toHaveBeenCalledTimes(1);
+    expect(syncFastmailAliases).toHaveBeenCalledWith('a1');
+    expect(aliasLoadCount()).toBe(2);
+    expect(result).toMatchObject({
+      sender: { aliasId: 'wild', fromEmail: 'first@example.net' },
+      requiresSelection: false,
+    });
+  });
+
+  it('returns an unresolved result after the one reply-time retry', async () => {
+    const aliasLoadCount = mockOwnedMessage([], []);
+
+    const result = await resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'reply' });
+
+    expect(syncFastmailAliases).toHaveBeenCalledTimes(1);
+    expect(aliasLoadCount()).toBe(2);
+    expect(result).toEqual({ sender: null, requiresSelection: true });
+  });
+
+  it('returns an unresolved result when the reply-time refresh fails', async () => {
+    const aliasLoadCount = mockOwnedMessage([]);
+    syncFastmailAliases.mockRejectedValue(new Error('Fastmail unavailable'));
+
+    await expect(resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'reply' }))
+      .resolves.toEqual({ sender: null, requiresSelection: true });
+    expect(syncFastmailAliases).toHaveBeenCalledTimes(1);
+    expect(aliasLoadCount()).toBe(1);
+  });
+
+  it('does not refresh when the account has no Fastmail token', async () => {
+    mockOwnedMessage([]);
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM messages m')) return { rows: [{ ...message, ...account, fastmail_api_token: null }] };
+      if (sql.includes('FROM account_aliases')) return { rows: [] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    expect(await resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'reply' }))
+      .toEqual({ sender: null, requiresSelection: true });
+    expect(syncFastmailAliases).not.toHaveBeenCalled();
+  });
+
+  it('matches draft mode only against message.from_email and never refreshes', async () => {
+    mockOwnedMessage([
+      { ...aliases[1], email: 'draft-alias@example.com' },
+      aliases[0],
+    ]);
+
+    const result = await resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'draft' });
+
+    expect(result.sender).toMatchObject({ aliasId: 'manual', displayEmail: 'draft-alias@example.com' });
+    expect(syncFastmailAliases).not.toHaveBeenCalled();
+  });
+
+  it('returns unresolved draft state rather than considering reply recipients', async () => {
+    mockOwnedMessage([aliases[0]]);
+
+    expect(await resolveMessageSender({ messageId: 'm1', userId: 'u1', purpose: 'draft' }))
+      .toEqual({ sender: null, requiresSelection: true });
+    expect(syncFastmailAliases).not.toHaveBeenCalled();
+  });
+
+  it('throws a 404 error for a missing or unowned message', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(resolveMessageSender({ messageId: 'm1', userId: 'other', purpose: 'reply' }))
+      .rejects.toMatchObject({ status: 404 });
+  });
+});

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -42,6 +42,7 @@ const PRESETS = {
   gmail:   { label: 'Gmail',   imap_host: 'imap.gmail.com',        imap_port: 993, smtp_host: 'smtp.gmail.com',        smtp_port: 587 },
   yahoo:   { label: 'Yahoo',   imap_host: 'imap.mail.yahoo.com',   imap_port: 993, smtp_host: 'smtp.mail.yahoo.com',   smtp_port: 587 },
   icloud:  { label: 'iCloud',  imap_host: 'imap.mail.me.com',      imap_port: 993, smtp_host: 'smtp.mail.me.com',      smtp_port: 587 },
+  fastmail: { label: 'Fastmail', imap_host: 'imap.fastmail.com', imap_port: 993, smtp_host: 'smtp.fastmail.com', smtp_port: 465, smtp_tls: 'SSL' },
   custom:  { label: 'Custom' },
 };
 
@@ -49,6 +50,12 @@ const PRESETS = {
 function isMicrosoftImapHost(host) {
   const h = (host || '').toLowerCase();
   return h.includes('.outlook.com') || h.includes('office365.com') || h.includes('.hotmail.com') || h.includes('.live.com');
+}
+
+function isFastmailConfig(config) {
+  return !!(config?.fastmail_configured
+    || config?.imap_host === 'imap.fastmail.com'
+    || config?.smtp_host === 'smtp.fastmail.com');
 }
 
 function AccountForm({ initial, onSave, onCancel }) {
@@ -82,9 +89,18 @@ function AccountForm({ initial, onSave, onCancel }) {
 
   const handlePreset = (key) => {
     const p = PRESETS[key];
-    if (p.imap_host) setForm(f => ({ ...f, ...p, label: undefined }));
+    if (p.imap_host) setForm(f => ({
+      ...f,
+      ...p,
+      label: undefined,
+      auth_user: key === 'fastmail' && !f.auth_user ? f.email_address : f.auth_user,
+    }));
     setSelectedPreset(key);
   };
+
+  const isFastmail = selectedPreset === 'fastmail'
+    || isFastmailConfig(initial)
+    || isFastmailConfig(form);
 
   const handleSubmit = async () => {
     if (!form.email_address || !form.auth_user || !form.imap_host) {
@@ -98,7 +114,9 @@ function AccountForm({ initial, onSave, onCancel }) {
     setSaving(true);
     setError('');
     try {
-      await onSave(form);
+      const payload = { ...form };
+      if (!payload.fastmail_api_token?.trim()) delete payload.fastmail_api_token;
+      await onSave(payload);
     } catch (err) {
       setError(err.message);
       setSaving(false);
@@ -112,7 +130,7 @@ function AccountForm({ initial, onSave, onCancel }) {
         <div style={{ display: 'flex', gap: 6, marginBottom: 18, flexWrap: 'wrap' }}>
           {Object.entries(PRESETS).map(([key]) => {
             const active = selectedPreset === key;
-            const presetLabel = key === 'gmail' ? t('admin.accounts.presetGmail') : key === 'yahoo' ? t('admin.accounts.presetYahoo') : key === 'icloud' ? t('admin.accounts.presetIcloud') : t('admin.accounts.presetCustom');
+            const presetLabel = key === 'gmail' ? t('admin.accounts.presetGmail') : key === 'yahoo' ? t('admin.accounts.presetYahoo') : key === 'icloud' ? t('admin.accounts.presetIcloud') : key === 'fastmail' ? t('admin.accounts.presetFastmail') : t('admin.accounts.presetCustom');
             return (
               <button key={key} onClick={() => handlePreset(key)} style={{
                 padding: '5px 12px', borderRadius: 20, fontSize: 12, fontWeight: 500,
@@ -194,6 +212,31 @@ function AccountForm({ initial, onSave, onCancel }) {
           </button>
         </div>
       </Field>
+
+      {isFastmail && (
+        <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5, marginTop: -8, marginBottom: 14 }}>
+          {t('admin.accounts.fastmailAppPasswordHint')}
+        </div>
+      )}
+
+      {isFastmail && (
+        <Field label={t('admin.accounts.fastmailApiToken')}>
+          <input
+            type="password"
+            value={form.fastmail_api_token || ''}
+            onChange={e => set('fastmail_api_token', e.target.value)}
+            placeholder={initial?.fastmail_configured ? '••••••••' : undefined}
+            autoComplete="new-password"
+            style={inputStyle}
+            onFocus={e => e.target.style.borderColor = 'var(--accent)'}
+            onBlur={e => e.target.style.borderColor = 'var(--border)'}
+          />
+          <div style={{ fontSize: 11, color: 'var(--text-tertiary)', lineHeight: 1.5, marginTop: 5 }}>
+            <div>{t('admin.accounts.fastmailApiTokenHint')}</div>
+            <div>{t('admin.accounts.fastmailPermissionsHint')}</div>
+          </div>
+        </Field>
+      )}
 
       <div style={{ height: 1, background: 'var(--border-subtle)', margin: '16px 0' }} />
       <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 10, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase' }}>
@@ -376,6 +419,7 @@ function AccountsTab() {
   const [aliasFormId, setAliasFormId] = useState(null);
   const [aliasFormError, setAliasFormError] = useState('');
   const [aliasFormSaving, setAliasFormSaving] = useState(false);
+  const [fastmailRefreshing, setFastmailRefreshing] = useState(false);
 
   const handleAdd = async (form) => {
     const account = await api.addAccount(form);
@@ -387,8 +431,12 @@ function AccountsTab() {
     const updates = { name: form.name, sender_name: form.sender_name || null, color: form.color, imap_host: form.imap_host, imap_port: form.imap_port, imap_skip_tls_verify: !!form.imap_skip_tls_verify, smtp_host: form.smtp_host, smtp_port: form.smtp_port, smtp_tls: form.smtp_tls, signature: form.signature || null, categorization_enabled: !!form.categorization_enabled };
     if (form.auth_pass) updates.auth_pass = form.auth_pass;
     if (form.auth_user) updates.auth_user = form.auth_user;
-    await api.updateAccount(editTarget.id, updates);
-    updateAccount(editTarget.id, updates);
+    if (form.fastmail_api_token) updates.fastmail_api_token = form.fastmail_api_token;
+    const saved = await api.updateAccount(editTarget.id, updates);
+    const safeUpdates = { ...updates };
+    delete safeUpdates.auth_pass;
+    delete safeUpdates.fastmail_api_token;
+    updateAccount(editTarget.id, { ...safeUpdates, ...saved });
     setSubview('list');
     setEditTarget(null);
   };
@@ -517,6 +565,42 @@ function AccountsTab() {
         const newAliases = (editTarget.aliases || []).filter(a => a.id !== aliasId);
         updateAccount(editTarget.id, { aliases: newAliases });
         setEditTarget(prev => ({ ...prev, aliases: newAliases }));
+      },
+    });
+  };
+
+  const replaceFastmailSnapshot = (snapshot) => {
+    updateAccount(snapshot.id, snapshot);
+    setEditTarget(snapshot);
+  };
+
+  const handleFastmailRefresh = async () => {
+    setFastmailRefreshing(true);
+    try {
+      replaceFastmailSnapshot(await api.refreshFastmailAliases(editTarget.id));
+    } catch (err) {
+      addNotification({ type: 'error', title: t('admin.accounts.fastmailRefresh'), body: err.message });
+    } finally {
+      setFastmailRefreshing(false);
+    }
+  };
+
+  const handleFastmailDisconnect = () => {
+    setConfirmDialog({
+      title: t('admin.accounts.fastmailDisconnect'),
+      message: t('admin.accounts.fastmailDisconnectConfirm'),
+      confirmLabel: t('admin.accounts.fastmailDisconnect'),
+      onConfirm: async () => {
+        try {
+          const account = await api.updateAccount(editTarget.id, { fastmail_api_token: null });
+          replaceFastmailSnapshot({
+            ...editTarget,
+            ...account,
+            aliases: (editTarget.aliases || []).filter(alias => alias.provenance === 'manual'),
+          });
+        } catch (err) {
+          addNotification({ type: 'error', title: t('admin.accounts.fastmailDisconnect'), body: err.message });
+        }
       },
     });
   };
@@ -654,6 +738,82 @@ function AccountsTab() {
     }
 
     const aliases = editTarget.aliases || [];
+    const fastmailAliases = aliases.filter(a =>
+      a.provenance === 'fastmail' && a.fastmail_identity_id && !a.fastmail_masked_email_id && !a.email.startsWith('*@')
+    );
+    const maskedEmails = aliases.filter(a => a.provenance === 'fastmail' && a.fastmail_masked_email_id);
+    const wildcardIdentities = aliases.filter(a => a.provenance === 'fastmail' && a.email.startsWith('*@'));
+    const manualAliases = aliases.filter(a => a.provenance === 'manual');
+    const isFastmailAccount = isFastmailConfig(editTarget)
+      || aliases.some(alias => alias.provenance === 'fastmail');
+
+    const renderAliasRows = (group, managed) => group.map(alias => (
+      <div key={alias.id} style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '12px 14px', marginBottom: 8,
+        border: '1px solid var(--border-subtle)', borderRadius: 10,
+        background: 'var(--bg-tertiary)',
+      }}>
+        <div style={{
+          width: 34, height: 34, borderRadius: '50%', flexShrink: 0,
+          background: 'var(--bg-hover)', display: 'flex',
+          alignItems: 'center', justifyContent: 'center',
+          color: 'var(--text-secondary)',
+        }}>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
+            <circle cx="12" cy="8" r="4"/>
+            <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
+          </svg>
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-primary)' }}>{alias.name}</div>
+          <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 1 }}>{alias.email}</div>
+          {managed && (
+            <>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 1 }}>
+                {t('admin.aliases.managedInFastmail')}
+              </div>
+              {alias.fastmail_label && (
+                <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 1 }}>{alias.fastmail_label}</div>
+              )}
+            </>
+          )}
+          {alias.reply_to && (
+            <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 1 }}>
+              {t('admin.aliases.replyToLabel')} {alias.reply_to}
+            </div>
+          )}
+        </div>
+        {!managed && (
+          <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
+            <IconBtn onClick={() => handleAliasEdit(alias)} title={t('common.edit')}>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/>
+                <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/>
+              </svg>
+            </IconBtn>
+            <IconBtn onClick={() => handleAliasDelete(alias.id)} title={t('common.delete')} danger>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <polyline points="3 6 5 6 21 6"/>
+                <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a1 1 0 011-1h4a1 1 0 011 1v2"/>
+              </svg>
+            </IconBtn>
+          </div>
+        )}
+      </div>
+    ));
+
+    const renderGroup = (title, group, managed) => {
+      if (!group.length) return null;
+      return (
+        <div style={{ marginBottom: 18 }}>
+          <div style={{ fontSize: 11, color: 'var(--text-secondary)', marginBottom: 8, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+            {title}
+          </div>
+          {renderAliasRows(group, managed)}
+        </div>
+      );
+    };
     return (
       <>
       <div>
@@ -667,6 +827,43 @@ function AccountsTab() {
         <div style={{ fontSize: 12, color: 'var(--text-secondary)', marginBottom: 16, lineHeight: 1.6, padding: '10px 12px', background: 'var(--bg-tertiary)', borderRadius: 8, border: '1px solid var(--border-subtle)' }}>
           {t('admin.aliases.description')}
         </div>
+
+        {isFastmailAccount && (
+          <>
+            <div style={{ padding: '12px 14px', marginBottom: 16, border: '1px solid var(--border-subtle)', borderRadius: 10, background: 'var(--bg-secondary)' }}>
+              <div style={{ fontSize: 13, color: editTarget.fastmail_configured ? 'var(--green)' : 'var(--text-secondary)', marginBottom: 6 }}>
+                {editTarget.fastmail_configured ? t('admin.accounts.fastmailConfigured') : t('admin.accounts.fastmailNotConfigured')}
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginBottom: editTarget.fastmail_sync_error ? 6 : 10 }}>
+                {t('admin.accounts.fastmailLastSync')}: {editTarget.fastmail_last_sync ? new Date(editTarget.fastmail_last_sync).toLocaleString() : t('common.never')}
+              </div>
+              {editTarget.fastmail_sync_error && (
+                <div style={{ fontSize: 12, color: 'var(--red)', marginBottom: 10 }}>{editTarget.fastmail_sync_error}</div>
+              )}
+              {editTarget.fastmail_configured && (
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                  <button onClick={handleFastmailRefresh} disabled={fastmailRefreshing} style={{
+                    padding: '7px 12px', background: 'var(--accent)', border: 'none', borderRadius: 7,
+                    color: 'white', cursor: fastmailRefreshing ? 'not-allowed' : 'pointer', fontSize: 12,
+                    opacity: fastmailRefreshing ? 0.7 : 1,
+                  }}>
+                    {fastmailRefreshing ? t('admin.accounts.fastmailRefreshing') : t('admin.accounts.fastmailRefresh')}
+                  </button>
+                  <button onClick={handleFastmailDisconnect} style={{
+                    padding: '7px 12px', background: 'transparent', border: '1px solid var(--red)', borderRadius: 7,
+                    color: 'var(--red)', cursor: 'pointer', fontSize: 12,
+                  }}>
+                    {t('admin.accounts.fastmailDisconnect')}
+                  </button>
+                </div>
+              )}
+            </div>
+
+            <a href="https://app.fastmail.com/settings/addresses" target="_blank" rel="noreferrer" style={{ display: 'inline-block', color: 'var(--accent)', fontSize: 12, marginBottom: 16 }}>
+              {t('admin.aliases.manageInFastmail')}
+            </a>
+          </>
+        )}
 
         <button
           onClick={() => { setAliasFormData({ name: '', email: '', reply_to: '', signature: '' }); setAliasFormMode('add'); }}
@@ -683,58 +880,14 @@ function AccountsTab() {
           {t('admin.aliases.addButton')}
         </button>
 
-        {aliases.length === 0 ? (
-          <div style={{ textAlign: 'center', padding: '24px 0', color: 'var(--text-tertiary)', fontSize: 13 }}>
+        {isFastmailAccount && renderGroup(t('admin.aliases.fastmailAliases'), fastmailAliases, true)}
+        {isFastmailAccount && renderGroup(t('admin.aliases.maskedEmails'), maskedEmails, true)}
+        {isFastmailAccount && renderGroup(t('admin.aliases.wildcardIdentities'), wildcardIdentities, true)}
+        {renderGroup(t('admin.aliases.manualAliases'), manualAliases, false)}
+        {aliases.length === 0 && (
+          <div style={{ textAlign: 'center', padding: '12px 0', color: 'var(--text-tertiary)', fontSize: 13 }}>
             {t('admin.aliases.empty')}
           </div>
-        ) : (
-          aliases.map(alias => (
-            <div key={alias.id} style={{
-              display: 'flex', alignItems: 'center', gap: 12,
-              padding: '12px 14px', marginBottom: 8,
-              border: '1px solid var(--border-subtle)', borderRadius: 10,
-              background: 'var(--bg-tertiary)',
-            }}>
-              <div style={{
-                width: 34, height: 34, borderRadius: '50%', flexShrink: 0,
-                background: 'var(--bg-hover)', display: 'flex',
-                alignItems: 'center', justifyContent: 'center',
-                color: 'var(--text-secondary)',
-              }}>
-                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75">
-                  <circle cx="12" cy="8" r="4"/>
-                  <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
-                </svg>
-              </div>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--text-primary)' }}>
-                  {alias.name}
-                </div>
-                <div style={{ fontSize: 12, color: 'var(--text-tertiary)', marginTop: 1 }}>
-                  {alias.email}
-                </div>
-                {alias.reply_to && (
-                  <div style={{ fontSize: 11, color: 'var(--text-tertiary)', marginTop: 1 }}>
-                    {t('admin.aliases.replyToLabel')} {alias.reply_to}
-                  </div>
-                )}
-              </div>
-              <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
-                <IconBtn onClick={() => handleAliasEdit(alias)} title={t('common.edit')}>
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/>
-                    <path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/>
-                  </svg>
-                </IconBtn>
-                <IconBtn onClick={() => handleAliasDelete(alias.id)} title={t('common.delete')} danger>
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <polyline points="3 6 5 6 21 6"/>
-                    <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a1 1 0 011-1h4a1 1 0 011 1v2"/>
-                  </svg>
-                </IconBtn>
-              </div>
-            </div>
-          ))
         )}
       </div>
       <ConfirmOverlay dialog={confirmDialog} onClose={() => setConfirmDialog(null)} />

--- a/frontend/src/components/ComposeModal.jsx
+++ b/frontend/src/components/ComposeModal.jsx
@@ -15,6 +15,12 @@ import { Table } from '@tiptap/extension-table';
 import { TableRow } from '@tiptap/extension-table-row';
 import { TableHeader } from '@tiptap/extension-table-header';
 import { TableCell } from '@tiptap/extension-table-cell';
+import {
+  buildSenderOptions,
+  resolveSenderSignature,
+  senderToValue,
+  valueToSender,
+} from '../utils/senderIdentity.js';
 
 // Resize an image blob/file to max maxW pixels wide, preserving aspect ratio.
 // Returns a Promise<string> of a base64 data URL.
@@ -173,6 +179,24 @@ function parseChips(val) {
   return parts;
 }
 
+function SenderOptions({ fromValue, groups, emptyLabel }) {
+  return <>
+    {!fromValue && <option value="" disabled>{emptyLabel}</option>}
+    {groups.map(({ account, options }) => (
+      <optgroup key={account.id} label={account.name} style={{ background: 'var(--bg-tertiary)' }}>
+        {options.map(option => {
+          const value = senderToValue(option.sender);
+          return (
+            <option key={value} value={value} style={{ background: 'var(--bg-tertiary)' }}>
+              {option.label}
+            </option>
+          );
+        })}
+      </optgroup>
+    ))}
+  </>;
+}
+
 export default function ComposeModal() {
   const { t } = useTranslation();
   const { closeCompose, composeData, accounts, addNotification, setSelectedAccount, plaintextEmail, setThreadMessages } = useStore();
@@ -234,36 +258,34 @@ export default function ComposeModal() {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- form initialisation runs once on mount; re-running on composeData changes would reset user edits
 
   const initialFromValue = () => {
-    if (composeData?.aliasId && composeData?.accountId) {
-      return `alias:${composeData.aliasId}:${composeData.accountId}`;
-    }
+    if (composeData?.senderRequired) return '';
+    if (composeData?.sender) return senderToValue(composeData.sender);
     const lastUsedId = localStorage.getItem('mailflow_last_from_account');
     const acctId = composeData?.accountId
       || useStore.getState().selectedAccountId
       || (lastUsedId && accounts.find(a => a.id === lastUsedId) ? lastUsedId : null)
       || accounts[0]?.id
       || '';
-    return acctId ? `account:${acctId}` : '';
+    return acctId ? senderToValue({ accountId: acctId, aliasId: null, fromEmail: null }) : '';
   };
   const [fromValue, setFromValue] = useState(initialFromValue);
 
-  const resolveFrom = (val) => {
-    if (!val) return { accountId: '', aliasId: null };
-    if (val.startsWith('alias:')) {
-      const parts = val.split(':');
-      return { aliasId: parts[1], accountId: parts[2] };
-    }
-    return { accountId: val.replace('account:', ''), aliasId: null };
-  };
+  const senderOptionGroups = accounts.map(account => ({
+    account,
+    options: buildSenderOptions(account, composeData?.sender),
+  }));
 
-  const fromResolved = resolveFrom(fromValue);
+  const fromResolved = valueToSender(fromValue) || { accountId: '', aliasId: null, fromEmail: null };
   const fromAccount = accounts.find(a => a.id === fromResolved.accountId);
   const fromAlias = fromResolved.aliasId
     ? fromAccount?.aliases?.find(al => al.id === fromResolved.aliasId)
     : null;
-  const fromSignature = fromAlias
-    ? (fromAlias.signature !== null && fromAlias.signature !== undefined ? fromAlias.signature : fromAccount?.signature || null)
-    : (fromAccount?.signature || null);
+  const fromSignature = resolveSenderSignature({
+    account: fromAccount,
+    alias: fromAlias,
+    selectedSender: fromResolved,
+    resolvedSender: composeData?.sender,
+  });
 
   const getSuggestions = useCallback(async (q) => {
     try {
@@ -740,9 +762,14 @@ export default function ComposeModal() {
 
   const handleSend = async ({ skipSubjectWarn = false, skipAttachWarn = false } = {}) => {
     if (sending) return; // guard against a rapid double-submit (e.g. double Ctrl/Cmd+Enter)
-    const { accountId, aliasId } = resolveFrom(fromValue);
+    const sender = valueToSender(fromValue);
+    if (!sender) {
+      setError(t('compose.senderRequired'));
+      return;
+    }
+    const accountId = sender.accountId;
     const toFinal = [...toChips, ...(toInput.trim() ? [toInput.trim()] : [])];
-    if (!toFinal.length || !accountId) return;
+    if (!toFinal.length) return;
 
     if (!skipSubjectWarn && subject.trim() === '') {
       setShowEmptySubjectWarn(true);
@@ -773,8 +800,7 @@ export default function ComposeModal() {
     }
     try {
       const sendResult = await api.post('/mail/send', {
-        accountId,
-        ...(aliasId ? { aliasId } : {}),
+        sender,
         to: toFinal,
         cc: [...ccChips, ...(ccInput.trim() ? [ccInput.trim()] : [])],
         bcc: [...bccChips, ...(bccInput.trim() ? [bccInput.trim()] : [])],
@@ -856,14 +882,17 @@ export default function ComposeModal() {
   };
 
   const doSaveDraft = async ({ closeAfter = false } = {}) => {
-    const { accountId, aliasId } = resolveFrom(fromValue);
-    if (!accountId) return;
+    const sender = valueToSender(fromValue);
+    if (!sender) {
+      setError(t('compose.senderRequired'));
+      return;
+    }
+    const accountId = sender.accountId;
     setSavingDraft(true);
     try {
       const bodyToSend = plaintextEmail ? body : (htmlMode ? htmlSource : (editor?.isEmpty ? '' : (editor?.getHTML() ?? '')));
       const result = await api.saveDraft({
-        accountId,
-        ...(aliasId ? { aliasId } : {}),
+        sender,
         to: [...toChips, ...(toInput.trim() ? [toInput.trim()] : [])],
         cc: [...ccChips, ...(ccInput.trim() ? [ccInput.trim()] : [])],
         bcc: [...bccChips, ...(bccInput.trim() ? [bccInput.trim()] : [])],
@@ -1136,29 +1165,11 @@ export default function ComposeModal() {
               onChange={e => setFromValue(e.target.value)}
               style={{ ...mobileInputStyle, cursor: 'pointer' }}
             >
-              {accounts.map(a => {
-                const aliases = a.aliases || [];
-                const displayName = a.sender_name || a.name;
-                if (!aliases.length) {
-                  return (
-                    <option key={a.id} value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                      {displayName} &lt;{a.email_address}&gt;
-                    </option>
-                  );
-                }
-                return (
-                  <optgroup key={a.id} label={a.name} style={{ background: 'var(--bg-tertiary)' }}>
-                    <option value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                      {displayName} &lt;{a.email_address}&gt;
-                    </option>
-                    {aliases.map(alias => (
-                      <option key={alias.id} value={`alias:${alias.id}:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                        {alias.name} &lt;{alias.email}&gt;
-                      </option>
-                    ))}
-                  </optgroup>
-                );
-              })}
+              <SenderOptions
+                fromValue={fromValue}
+                groups={senderOptionGroups}
+                emptyLabel={t('compose.selectSender')}
+              />
             </select>
           </div>
 
@@ -1784,29 +1795,11 @@ export default function ComposeModal() {
             onChange={e => setFromValue(e.target.value)}
             style={{ flex: 1, padding: '8px 4px', background: 'transparent', border: 'none', color: 'var(--text-primary)', fontSize: 13, outline: 'none', cursor: 'pointer' }}
           >
-            {accounts.map(a => {
-              const aliases = a.aliases || [];
-              const displayName = a.sender_name || a.name;
-              if (!aliases.length) {
-                return (
-                  <option key={a.id} value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                    {displayName} &lt;{a.email_address}&gt;
-                  </option>
-                );
-              }
-              return (
-                <optgroup key={a.id} label={a.name} style={{ background: 'var(--bg-tertiary)' }}>
-                  <option value={`account:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                    {displayName} &lt;{a.email_address}&gt;
-                  </option>
-                  {aliases.map(alias => (
-                    <option key={alias.id} value={`alias:${alias.id}:${a.id}`} style={{ background: 'var(--bg-tertiary)' }}>
-                      {alias.name} &lt;{alias.email}&gt;
-                    </option>
-                  ))}
-                </optgroup>
-              );
-            })}
+            <SenderOptions
+              fromValue={fromValue}
+              groups={senderOptionGroups}
+              emptyLabel={t('compose.selectSender')}
+            />
           </select>
         </div>
 

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -11,6 +11,8 @@ import ContextMenu from './ContextMenu.jsx';
 import { shortcutBus } from '../utils/shortcutBus.js';
 import { pendingMarkReadMap, completedMarkReadMap, setPending } from '../utils/pendingReads.js';
 import { applyDeleteGuard, clearDeleteGuard, clearPendingDelete, setCompletedDelete, setPendingDelete } from '../utils/pendingDeletes.js';
+import { buildReplyComposeData } from '../utils/replyCompose.js';
+import { resolveSenderOrFallback } from '../utils/senderIdentity.js';
 
 // Folder icon for move picker
 function FolderIcon({ specialUse, size = 13 }) {
@@ -1147,75 +1149,14 @@ export default function MessageList() {
     setMessagesStarredState(message, !message.is_starred);
   }, [setMessagesStarredState]);
 
-  const handleSwipeReply = useCallback((message, replyAll = false) => {
-    const replyToArr = Array.isArray(message.reply_to)
-      ? message.reply_to
-      : (() => { try { return JSON.parse(message.reply_to || '[]'); } catch { return []; } })();
-    const replyTarget = (replyToArr.length && replyToArr[0].email)
-      ? replyToArr[0]
-      : { name: message.from_name || '', email: message.from_email || '' };
-    const sender = replyTarget.email ? [replyTarget] : [];
-
-    const myAccount = accounts.find(a => a.id === message.account_id);
-    const myEmail = myAccount?.email_address || '';
-    const myAddresses = new Set([
-      myEmail.toLowerCase(),
-      ...(myAccount?.aliases || []).map(al => al.email.toLowerCase()),
-    ]);
-
-    const replyAliasId = (() => {
-      const aliases = myAccount?.aliases || [];
-      if (!aliases.length) return null;
-      try {
-        const toArr = Array.isArray(message.to_addresses)
-          ? message.to_addresses
-          : JSON.parse(message.to_addresses || '[]');
-        const ccArr = Array.isArray(message.cc_addresses)
-          ? message.cc_addresses
-          : JSON.parse(message.cc_addresses || '[]');
-        const allEmails = [...toArr, ...ccArr].map(t => t.email?.toLowerCase()).filter(Boolean);
-        const fromEmail = (message.from_email || '').toLowerCase();
-        const match = aliases.find(al => {
-          const aliasEmail = al.email.toLowerCase();
-          return allEmails.includes(aliasEmail) || fromEmail === aliasEmail;
-        });
-        return match ? match.id : null;
-      } catch { return null; }
-    })();
-
-    const allRecipients = (() => {
-      try {
-        const toArr = Array.isArray(message.to_addresses)
-          ? message.to_addresses
-          : JSON.parse(message.to_addresses || '[]');
-        const ccArr = Array.isArray(message.cc_addresses)
-          ? message.cc_addresses
-          : JSON.parse(message.cc_addresses || '[]');
-        return [...toArr, ...ccArr].filter(
-          t => t.email && !myAddresses.has(t.email.toLowerCase()) && t.email !== replyTarget.email
-        );
-      } catch { return []; }
-    })();
-
-    const referencesChain = [message.in_reply_to, message.message_id]
-      .filter(Boolean).join(' ').trim() || null;
-    const rawSubject = (message.subject || '').trim();
-
-    openCompose({
-      to: sender,
-      cc: replyAll ? allRecipients : [],
-      subject: rawSubject.startsWith('Re:') ? rawSubject : rawSubject ? `Re: ${rawSubject}` : 'Re:',
-      body: '',
-      quotedBody: '',
-      inReplyTo: message.message_id,
-      references: referencesChain,
-      accountId: message.account_id,
-      aliasId: replyAliasId,
-      isReply: true,
-      isReplyAll: replyAll,
-      originalFrom: sender,
-      allRecipients,
-    });
+  const handleSwipeReply = useCallback(async (message, replyAll = false) => {
+    const resolved = await resolveSenderOrFallback(() => api.resolveMessageSender(message.id, 'reply'));
+    openCompose(buildReplyComposeData({
+      message,
+      account: accounts.find(account => account.id === message.account_id),
+      resolved,
+      replyAll,
+    }));
   }, [accounts, openCompose]);
   
   const runSwipeAction = useCallback((action, message) => {
@@ -1759,88 +1700,15 @@ export default function MessageList() {
       case 'replyAll': {
         const replyAll = action === 'replyAll';
 
-        const replyToArr = Array.isArray(message.reply_to)
-          ? message.reply_to
-          : (() => { try { return JSON.parse(message.reply_to || '[]'); } catch { return []; } })();
-        const replyTarget = (replyToArr.length && replyToArr[0].email)
-          ? replyToArr[0]
-          : { name: message.from_name || '', email: message.from_email || '' };
-        const sender = replyTarget.email ? [replyTarget] : [];
-
-        const myAccount = accounts.find(a => a.id === message.account_id);
-        const myEmail = myAccount?.email_address || '';
-        const myAddresses = new Set([
-          myEmail.toLowerCase(),
-          ...(myAccount?.aliases || []).map(al => al.email.toLowerCase()),
-        ]);
-
-        const replyAliasId = (() => {
-          const aliases = myAccount?.aliases || [];
-          if (!aliases.length) return null;
-          try {
-            const toArr = Array.isArray(message.to_addresses)
-              ? message.to_addresses
-              : JSON.parse(message.to_addresses || '[]');
-            const ccArr = Array.isArray(message.cc_addresses)
-              ? message.cc_addresses
-              : JSON.parse(message.cc_addresses || '[]');
-            const allEmails = [...toArr, ...ccArr].map(t => t.email?.toLowerCase()).filter(Boolean);
-            const fromEmail = (message.from_email || '').toLowerCase();
-            const match = aliases.find(al => {
-              const aliasEmail = al.email.toLowerCase();
-              return allEmails.includes(aliasEmail) || fromEmail === aliasEmail;
-            });
-            return match ? match.id : null;
-          } catch { return null; }
-        })();
-
-        const allRecipients = (() => {
-          try {
-            const toArr = Array.isArray(message.to_addresses)
-              ? message.to_addresses
-              : JSON.parse(message.to_addresses || '[]');
-            const ccArr = Array.isArray(message.cc_addresses)
-              ? message.cc_addresses
-              : JSON.parse(message.cc_addresses || '[]');
-            return [...toArr, ...ccArr].filter(
-              t => t.email && !myAddresses.has(t.email.toLowerCase()) && t.email !== replyTarget.email
-            );
-          } catch { return []; }
-        })();
-
-        const referencesChain = [message.in_reply_to, message.message_id]
-          .filter(Boolean).join(' ').trim() || null;
-        const rawSubject = (message.subject || '').trim();
-
+        const resolved = await resolveSenderOrFallback(() => api.resolveMessageSender(message.id, 'reply'));
         const replyBody = await api.getMessageBody(message.id).catch(() => null);
-        const replyDate = message.date ? new Date(message.date).toLocaleString() : '';
-        const replySafeName = (message.from_name || '').replace(/[\r\n]+/g, ' ');
-        const replyFromStr = replySafeName
-          ? `${replySafeName} <${message.from_email}>`
-          : message.from_email || '';
-        const quotedText = replyBody?.text
-          ? `\n\n---\nOn ${replyDate}, ${replyFromStr} wrote:\n${replyBody.text.split('\n').map(l => '> ' + l).join('\n')}`
-          : '';
-        const quotedBodyHtml = replyBody?.html
-          ? `<div style="border-left:3px solid var(--border,#ccc);padding-left:12px;margin-top:12px;color:var(--text-secondary,#666)"><p style="margin:0 0 6px;font-size:12px">On ${replyDate}, ${replyFromStr} wrote:</p>${replyBody.html}</div>`
-          : null;
-
-        openCompose({
-          to: sender,
-          cc: replyAll ? allRecipients : [],
-          subject: rawSubject.startsWith('Re:') ? rawSubject : rawSubject ? `Re: ${rawSubject}` : 'Re:',
-          body: '',
-          quotedBody: quotedText,
-          quotedBodyHtml,
-          inReplyTo: message.message_id,
-          references: referencesChain,
-          accountId: message.account_id,
-          aliasId: replyAliasId,
-          isReply: true,
-          isReplyAll: replyAll,
-          originalFrom: sender,
-          allRecipients,
-        });
+        openCompose(buildReplyComposeData({
+          message,
+          account: accounts.find(account => account.id === message.account_id),
+          resolved,
+          replyAll,
+          body: replyBody,
+        }));
         break;
       }
       case 'forward': {
@@ -2084,7 +1952,10 @@ export default function MessageList() {
   const handleSelect = async (message) => {
     if (isDraftsFolder) {
       try {
-        const bodyData = await api.getMessageBody(message.id);
+        const [bodyData, resolved] = await Promise.all([
+          api.getMessageBody(message.id),
+          resolveSenderOrFallback(() => api.resolveMessageSender(message.id, 'draft')),
+        ]);
         openCompose({
           accountId: message.account_id,
           draftUid: message.uid,
@@ -2094,6 +1965,8 @@ export default function MessageList() {
           subject: message.subject || '',
           body: bodyData.html || bodyData.text || '',
           bodyIsHtml: !!bodyData.html,
+          sender: resolved.sender,
+          senderRequired: resolved.requiresSelection,
         });
       } catch (err) {
         console.error('Failed to open draft:', err.message);

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -8,6 +8,8 @@ import { getEffectiveShortcuts, parseModKey, modCompactLabel } from '../utils/de
 import { useMobile } from '../hooks/useMobile.js';
 import { clearDeleteGuard, clearPendingDelete, setCompletedDelete, setPendingDelete } from '../utils/pendingDeletes.js';
 import { pendingMarkReadMap, completedMarkReadMap, setPending } from '../utils/pendingReads.js';
+import { buildReplyComposeData } from '../utils/replyCompose.js';
+import { resolveSenderOrFallback } from '../utils/senderIdentity.js';
 import DOMPurify from 'dompurify';
 import { BUILTIN_SUMMARIZE } from '../aiActions.js';
 import { getResults, saveResult, removeResult } from '../aiResults.js';
@@ -863,91 +865,18 @@ export default function MessagePane() {
     };
   }, [isMobile, setSelectedMessage, resetPaneSwipeStyles]);
 
-  const handleReply = (replyAll = false) => {
+  const handleReply = async (replyAll = false) => {
     if (!message) return;
-    const date = message.date ? new Date(message.date).toLocaleString() : '';
-    const safeName = (message.from_name || '').replace(/[\r\n]+/g, ' ');
-    const fromStr = safeName
-      ? `${safeName} <${message.from_email}>`
-      : message.from_email || '';
-    const quotedText = body?.text
-      ? `\n\n---\nOn ${date}, ${fromStr} wrote:\n${body.text.split('\n').map(l => '> ' + l).join('\n')}`
-      : '';
-    const quotedBodyHtml = body?.html
-      ? `<div style="border-left:3px solid var(--border,#ccc);padding-left:12px;margin-top:12px;color:var(--text-secondary,#666)"><p style="margin:0 0 6px;font-size:12px">On ${date}, ${fromStr} wrote:</p>${body.html}</div>`
-      : null;
-
-    const replyToArr = Array.isArray(message.reply_to)
-      ? message.reply_to
-      : (() => { try { return JSON.parse(message.reply_to || '[]'); } catch { return []; } })();
-    const replyTarget = (replyToArr.length && replyToArr[0].email)
-      ? replyToArr[0]
-      : { name: message.from_name || '', email: message.from_email || '' };
-    const sender = replyTarget.email ? [replyTarget] : [];
-
-    const myAccount = accounts.find(a => a.id === message.account_id);
-    const myEmail = myAccount?.email_address || '';
-
-    const replyAliasId = (() => {
-      const aliases = myAccount?.aliases || [];
-      if (!aliases.length) return null;
-      try {
-        const toArr = Array.isArray(message.to_addresses)
-          ? message.to_addresses
-          : JSON.parse(message.to_addresses || '[]');
-        const ccArr = Array.isArray(message.cc_addresses)
-          ? message.cc_addresses
-          : JSON.parse(message.cc_addresses || '[]');
-        const allEmails = [...toArr, ...ccArr].map(t => t.email?.toLowerCase()).filter(Boolean);
-        const fromEmail = (message.from_email || '').toLowerCase();
-        const match = aliases.find(al => {
-          const aliasEmail = al.email.toLowerCase();
-          return allEmails.includes(aliasEmail) || fromEmail === aliasEmail;
-        });
-        return match ? match.id : null;
-      } catch { return null; }
-    })();
-
-    const myAddresses = new Set([
-      myEmail.toLowerCase(),
-      ...(myAccount?.aliases || []).map(al => al.email.toLowerCase()),
-    ]);
-    const allRecipients = (() => {
-      try {
-        const toArr = Array.isArray(message.to_addresses)
-          ? message.to_addresses
-          : JSON.parse(message.to_addresses || '[]');
-        const ccArr = Array.isArray(message.cc_addresses)
-          ? message.cc_addresses
-          : JSON.parse(message.cc_addresses || '[]');
-        return [...toArr, ...ccArr].filter(
-          t => t.email && !myAddresses.has(t.email.toLowerCase()) && t.email !== replyTarget.email
-        );
-      } catch { return []; }
-    })();
-
-    const referencesChain = [message.in_reply_to, message.message_id]
-      .filter(Boolean).join(' ').trim() || null;
-
-    const rawSubject = (message.subject || '').trim();
-    const reSubject = rawSubject.startsWith('Re:') ? rawSubject : rawSubject ? `Re: ${rawSubject}` : 'Re:';
-
+    const resolved = await resolveSenderOrFallback(() => api.resolveMessageSender(message.id, 'reply'));
     setShowReplyMenu(false);
     openCompose({
-      to: sender,
-      cc: replyAll ? allRecipients : [],
-      subject: reSubject,
-      body: '',
-      quotedBody: quotedText,
-      quotedBodyHtml,
-      inReplyTo: message.message_id,
-      references: referencesChain,
-      accountId: message.account_id,
-      aliasId: replyAliasId,
-      isReply: true,
-      isReplyAll: replyAll,
-      originalFrom: sender,
-      allRecipients,
+      ...buildReplyComposeData({
+        message,
+        account: accounts.find(account => account.id === message.account_id),
+        resolved,
+        replyAll,
+        body,
+      }),
       threadId: message.thread_id,
     });
   };

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -91,6 +91,8 @@
     }
   },
   "compose": {
+    "selectSender": "Absenderadresse auswählen",
+    "senderRequired": "Wähle eine Absenderadresse aus, bevor du fortfährst.",
     "newMessage": "Neue Nachricht",
     "reply": "Antworten",
     "replyAll": "Allen antworten",
@@ -557,6 +559,7 @@
       "addAccount": "Konto hinzufügen",
       "saving": "Wird gespeichert…",
       "presetGmail": "Gmail",
+      "presetFastmail": "Fastmail",
       "presetYahoo": "Yahoo Mail",
       "presetIcloud": "iCloud",
       "presetCustom": "Benutzerdefiniert",
@@ -571,7 +574,18 @@
       "categorizationSection": "E-Mail-Kategorisierung",
       "categorizationEnabled": "Posteingang-Kategorisierung aktivieren",
       "categorizationEnabledDesc": "Eingehende E-Mails in Kategorie-Tabs einteilen. Standardmäßig deaktiviert.",
-      "enabledGlobally": "Global aktiviert"
+      "enabledGlobally": "Global aktiviert",
+      "fastmailApiToken": "Fastmail-API-Token",
+      "fastmailApiTokenHint": "Nur schreibbar und verschlüsselt gespeichert. Leer lassen, um den aktuellen Token zu behalten.",
+      "fastmailAppPasswordHint": "Verwende oben im Passwortfeld ein Fastmail-App-Passwort.",
+      "fastmailPermissionsHint": "Erstelle den Token mit den Berechtigungen E-Mail-Versand und Maskierte E-Mail.",
+      "fastmailConfigured": "Fastmail-Adressabgleich eingerichtet",
+      "fastmailNotConfigured": "Fastmail-Adressabgleich nicht eingerichtet",
+      "fastmailLastSync": "Letzter Adressabgleich",
+      "fastmailRefresh": "Adressen aktualisieren",
+      "fastmailRefreshing": "Adressen werden aktualisiert…",
+      "fastmailDisconnect": "Fastmail-Abgleich trennen",
+      "fastmailDisconnectConfirm": "API-Token und alle von Fastmail verwalteten Adressen aus Mailflow entfernen? Manuelle Aliasse und das E-Mail-Konto bleiben erhalten."
     },
     "folderMappings": {
       "title": "Ordnerzuordnungen",
@@ -608,7 +622,13 @@
       "errorRequired": "Name und E-Mail sind erforderlich",
       "deleteConfirmTitle": "Alias löschen?",
       "deleteConfirmBody": "Dieser Alias wird dauerhaft entfernt. Dies kann nicht rückgängig gemacht werden.",
-      "deleteConfirmLabel": "Löschen"
+      "deleteConfirmLabel": "Löschen",
+      "fastmailAliases": "Fastmail-Aliasse",
+      "maskedEmails": "Maskierte E-Mail-Adressen",
+      "wildcardIdentities": "Wildcard-Identitäten",
+      "manualAliases": "Manuelle Mailflow-Aliasse",
+      "managedInFastmail": "In Fastmail verwaltet",
+      "manageInFastmail": "Adressen in Fastmail verwalten"
     },
     "appearance": {
       "title": "Darstellung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -91,6 +91,8 @@
     }
   },
   "compose": {
+    "selectSender": "Select a sending address",
+    "senderRequired": "Choose a sending address before continuing.",
     "newMessage": "New Message",
     "reply": "Reply",
     "replyAll": "Reply All",
@@ -624,6 +626,7 @@
       "addAccount": "Add account",
       "saving": "Saving…",
       "presetGmail": "Gmail",
+      "presetFastmail": "Fastmail",
       "presetYahoo": "Yahoo Mail",
       "presetIcloud": "iCloud",
       "presetCustom": "Custom",
@@ -638,7 +641,18 @@
       "categorizationSection": "Email Categorization",
       "categorizationEnabled": "Enable inbox categorization",
       "categorizationEnabledDesc": "Sort incoming emails into category tabs. Disabled by default.",
-      "enabledGlobally": "Enabled globally"
+      "enabledGlobally": "Enabled globally",
+      "fastmailApiToken": "Fastmail API token",
+      "fastmailApiTokenHint": "Write-only and encrypted at rest. Leave blank to keep the current token.",
+      "fastmailAppPasswordHint": "Use a Fastmail app password in the Password field above.",
+      "fastmailPermissionsHint": "Create the token with Email submission and Masked Email permissions.",
+      "fastmailConfigured": "Fastmail address sync configured",
+      "fastmailNotConfigured": "Fastmail address sync not configured",
+      "fastmailLastSync": "Last address sync",
+      "fastmailRefresh": "Refresh addresses",
+      "fastmailRefreshing": "Refreshing addresses…",
+      "fastmailDisconnect": "Disconnect Fastmail sync",
+      "fastmailDisconnectConfirm": "Remove the API token and all Fastmail-managed addresses from Mailflow? Manual aliases and the email account will remain."
     },
     "folderMappings": {
       "title": "Folder mappings",
@@ -675,7 +689,13 @@
       "errorRequired": "Name and email are required",
       "deleteConfirmTitle": "Delete alias?",
       "deleteConfirmBody": "This alias will be permanently removed. This cannot be undone.",
-      "deleteConfirmLabel": "Delete"
+      "deleteConfirmLabel": "Delete",
+      "fastmailAliases": "Fastmail aliases",
+      "maskedEmails": "Masked Email addresses",
+      "wildcardIdentities": "Wildcard identities",
+      "manualAliases": "Manual Mailflow aliases",
+      "managedInFastmail": "Managed in Fastmail",
+      "manageInFastmail": "Manage addresses in Fastmail"
     },
     "appearance": {
       "title": "Appearance",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -91,6 +91,8 @@
     }
   },
   "compose": {
+    "selectSender": "Selecciona una dirección de envío",
+    "senderRequired": "Elige una dirección de envío antes de continuar.",
     "newMessage": "Nuevo mensaje",
     "reply": "Responder",
     "replyAll": "Responder a todos",
@@ -622,6 +624,7 @@
       "addAccount": "Añadir cuenta",
       "saving": "Guardando…",
       "presetGmail": "Gmail",
+      "presetFastmail": "Fastmail",
       "presetYahoo": "Yahoo Mail",
       "presetIcloud": "iCloud",
       "presetCustom": "Personalizado",
@@ -638,7 +641,18 @@
       "categorizationSection": "Categorización de correo",
       "categorizationEnabled": "Activar categorización del buzón",
       "categorizationEnabledDesc": "Clasifica los correos entrantes en pestañas de categorías. Desactivado por defecto.",
-      "enabledGlobally": "Activado globalmente"
+      "enabledGlobally": "Activado globalmente",
+      "fastmailApiToken": "Token de API de Fastmail",
+      "fastmailApiTokenHint": "Es de solo escritura y se guarda cifrado. Déjalo vacío para conservar el token actual.",
+      "fastmailAppPasswordHint": "Usa una contraseña de aplicación de Fastmail en el campo Contraseña de arriba.",
+      "fastmailPermissionsHint": "Crea el token con permisos de Envío de correo y Correo enmascarado.",
+      "fastmailConfigured": "Sincronización de direcciones de Fastmail configurada",
+      "fastmailNotConfigured": "Sincronización de direcciones de Fastmail no configurada",
+      "fastmailLastSync": "Última sincronización de direcciones",
+      "fastmailRefresh": "Actualizar direcciones",
+      "fastmailRefreshing": "Actualizando direcciones…",
+      "fastmailDisconnect": "Desconectar la sincronización de Fastmail",
+      "fastmailDisconnectConfirm": "¿Eliminar de Mailflow el token de API y todas las direcciones gestionadas por Fastmail? Los alias manuales y la cuenta de correo se conservarán."
     },
     "folderMappings": {
       "title": "Asignación de carpetas",
@@ -675,7 +689,13 @@
       "errorRequired": "El nombre y el correo son obligatorios",
       "deleteConfirmTitle": "¿Eliminar alias?",
       "deleteConfirmBody": "Este alias será eliminado permanentemente. Esta acción no se puede deshacer.",
-      "deleteConfirmLabel": "Eliminar"
+      "deleteConfirmLabel": "Eliminar",
+      "fastmailAliases": "Alias de Fastmail",
+      "maskedEmails": "Direcciones de correo enmascarado",
+      "wildcardIdentities": "Identidades con comodín",
+      "manualAliases": "Alias manuales de Mailflow",
+      "managedInFastmail": "Gestionado en Fastmail",
+      "manageInFastmail": "Gestionar direcciones en Fastmail"
     },
     "appearance": {
       "title": "Apariencia",

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -91,6 +91,8 @@
     }
   },
   "compose": {
+    "selectSender": "Sélectionner une adresse d’envoi",
+    "senderRequired": "Choisissez une adresse d’envoi avant de continuer.",
     "newMessage": "Nouveau message",
     "reply": "Répondre",
     "replyAll": "Répondre à tous",
@@ -622,6 +624,7 @@
       "addAccount": "Ajouter un compte",
       "saving": "Enregistrement…",
       "presetGmail": "Gmail",
+      "presetFastmail": "Fastmail",
       "presetYahoo": "Yahoo Mail",
       "presetIcloud": "iCloud",
       "presetCustom": "Personnalisé",
@@ -638,7 +641,18 @@
       "categorizationSection": "Catégorisation des e-mails",
       "categorizationEnabled": "Activer la catégorisation",
       "categorizationEnabledDesc": "Classe les e-mails entrants dans des onglets de catégories. Désactivé par défaut.",
-      "enabledGlobally": "Activé globalement"
+      "enabledGlobally": "Activé globalement",
+      "fastmailApiToken": "Jeton API Fastmail",
+      "fastmailApiTokenHint": "Accessible uniquement en écriture et stocké chiffré. Laissez vide pour conserver le jeton actuel.",
+      "fastmailAppPasswordHint": "Utilisez un mot de passe d’application Fastmail dans le champ Mot de passe ci-dessus.",
+      "fastmailPermissionsHint": "Créez le jeton avec les autorisations Envoi d’e-mails et E-mail masqué.",
+      "fastmailConfigured": "Synchronisation des adresses Fastmail configurée",
+      "fastmailNotConfigured": "Synchronisation des adresses Fastmail non configurée",
+      "fastmailLastSync": "Dernière synchronisation des adresses",
+      "fastmailRefresh": "Actualiser les adresses",
+      "fastmailRefreshing": "Actualisation des adresses…",
+      "fastmailDisconnect": "Déconnecter la synchronisation Fastmail",
+      "fastmailDisconnectConfirm": "Supprimer de Mailflow le jeton API et toutes les adresses gérées par Fastmail ? Les alias manuels et le compte e-mail seront conservés."
     },
     "folderMappings": {
       "title": "Mappage des dossiers",
@@ -675,7 +689,13 @@
       "errorRequired": "Le nom et l'e-mail sont requis",
       "deleteConfirmTitle": "Supprimer l'alias ?",
       "deleteConfirmBody": "Cet alias sera définitivement supprimé. Cette action est irréversible.",
-      "deleteConfirmLabel": "Supprimer"
+      "deleteConfirmLabel": "Supprimer",
+      "fastmailAliases": "Alias Fastmail",
+      "maskedEmails": "Adresses e-mail masquées",
+      "wildcardIdentities": "Identités génériques",
+      "manualAliases": "Alias Mailflow manuels",
+      "managedInFastmail": "Géré dans Fastmail",
+      "manageInFastmail": "Gérer les adresses dans Fastmail"
     },
     "appearance": {
       "title": "Apparence",

--- a/frontend/src/locales/i18n.test.js
+++ b/frontend/src/locales/i18n.test.js
@@ -117,6 +117,7 @@ const SAME_VALUE_ALLOWED = {
   // ── Universal placeholders / brand names (all locales share) ───────────────
   'admin.accounts.imapHostPh':              'any', // imap.gmail.com
   'admin.accounts.presetGmail':             'any', // Gmail
+  'admin.accounts.presetFastmail':          'any', // Fastmail
   'admin.accounts.presetIcloud':            'any', // iCloud
   'admin.accounts.presetYahoo':             'any', // Yahoo Mail
   'admin.accounts.smtpHostPh':              'any', // smtp.gmail.com
@@ -141,6 +142,9 @@ const SAME_VALUE_ALLOWED = {
   // "Alias" — Latin origin, same spelling in es, fr, it
   'admin.accounts.aliases': [['es', 'fr', 'it']],
   'admin.aliases.title':     [['es', 'fr', 'it']],
+
+  // "Alias Fastmail" — the borrowed noun and brand form are identical in fr and it
+  'admin.aliases.fastmailAliases': [['fr', 'it']],
 
 
   // email placeholder — example.com address looks the same in en, ru, zhCN

--- a/frontend/src/locales/it.json
+++ b/frontend/src/locales/it.json
@@ -91,6 +91,8 @@
     }
   },
   "compose": {
+    "selectSender": "Seleziona un indirizzo mittente",
+    "senderRequired": "Scegli un indirizzo mittente prima di continuare.",
     "newMessage": "Nuovo messaggio",
     "reply": "Rispondi",
     "replyAll": "Rispondi a tutti",
@@ -622,6 +624,7 @@
       "addAccount": "Aggiungi account",
       "saving": "Salvataggio…",
       "presetGmail": "Gmail",
+      "presetFastmail": "Fastmail",
       "presetYahoo": "Yahoo Mail",
       "presetIcloud": "iCloud",
       "presetCustom": "Personalizzato",
@@ -638,7 +641,18 @@
       "categorizationSection": "Categorizzazione email",
       "categorizationEnabled": "Abilita categorizzazione",
       "categorizationEnabledDesc": "Ordina le email in arrivo in schede di categoria. Disabilitato per impostazione predefinita.",
-      "enabledGlobally": "Abilitato globalmente"
+      "enabledGlobally": "Abilitato globalmente",
+      "fastmailApiToken": "Token API Fastmail",
+      "fastmailApiTokenHint": "È di sola scrittura e viene archiviato cifrato. Lascia vuoto per mantenere il token attuale.",
+      "fastmailAppPasswordHint": "Usa una password per app di Fastmail nel campo Password qui sopra.",
+      "fastmailPermissionsHint": "Crea il token con le autorizzazioni Invio email ed Email mascherata.",
+      "fastmailConfigured": "Sincronizzazione indirizzi Fastmail configurata",
+      "fastmailNotConfigured": "Sincronizzazione indirizzi Fastmail non configurata",
+      "fastmailLastSync": "Ultima sincronizzazione indirizzi",
+      "fastmailRefresh": "Aggiorna indirizzi",
+      "fastmailRefreshing": "Aggiornamento indirizzi…",
+      "fastmailDisconnect": "Disconnetti sincronizzazione Fastmail",
+      "fastmailDisconnectConfirm": "Rimuovere da Mailflow il token API e tutti gli indirizzi gestiti da Fastmail? Gli alias manuali e l’account email resteranno disponibili."
     },
     "folderMappings": {
       "title": "Mappatura cartelle",
@@ -675,7 +689,13 @@
       "errorRequired": "Nome e email sono obbligatori",
       "deleteConfirmTitle": "Eliminare l'alias?",
       "deleteConfirmBody": "Questo alias verrà rimosso in modo permanente. Questa operazione non può essere annullata.",
-      "deleteConfirmLabel": "Elimina"
+      "deleteConfirmLabel": "Elimina",
+      "fastmailAliases": "Alias Fastmail",
+      "maskedEmails": "Indirizzi email mascherati",
+      "wildcardIdentities": "Identità con carattere jolly",
+      "manualAliases": "Alias Mailflow manuali",
+      "managedInFastmail": "Gestito in Fastmail",
+      "manageInFastmail": "Gestisci indirizzi in Fastmail"
     },
     "appearance": {
       "title": "Aspetto",

--- a/frontend/src/locales/ru.json
+++ b/frontend/src/locales/ru.json
@@ -91,6 +91,8 @@
     }
   },
   "compose": {
+    "selectSender": "Выберите адрес отправителя",
+    "senderRequired": "Перед продолжением выберите адрес отправителя.",
     "newMessage": "Новое сообщение",
     "reply": "Ответить",
     "replyAll": "Ответить всем",
@@ -622,6 +624,7 @@
       "addAccount": "Добавить аккаунт",
       "saving": "Сохранение…",
       "presetGmail": "Gmail",
+      "presetFastmail": "Fastmail",
       "presetYahoo": "Yahoo Mail",
       "presetIcloud": "iCloud",
       "presetCustom": "Другое",
@@ -638,7 +641,18 @@
       "categorizationSection": "Категоризация почты",
       "categorizationEnabled": "Включить категоризацию входящих",
       "categorizationEnabledDesc": "Сортирует входящие письма по вкладкам категорий. По умолчанию отключено.",
-      "enabledGlobally": "Включено глобально"
+      "enabledGlobally": "Включено глобально",
+      "fastmailApiToken": "API-токен Fastmail",
+      "fastmailApiTokenHint": "Доступен только для записи и хранится в зашифрованном виде. Оставьте поле пустым, чтобы сохранить текущий токен.",
+      "fastmailAppPasswordHint": "В поле пароля выше укажите пароль приложения Fastmail.",
+      "fastmailPermissionsHint": "Создайте токен с разрешениями «Отправка почты» и «Маскированная почта».",
+      "fastmailConfigured": "Синхронизация адресов Fastmail настроена",
+      "fastmailNotConfigured": "Синхронизация адресов Fastmail не настроена",
+      "fastmailLastSync": "Последняя синхронизация адресов",
+      "fastmailRefresh": "Обновить адреса",
+      "fastmailRefreshing": "Адреса обновляются…",
+      "fastmailDisconnect": "Отключить синхронизацию Fastmail",
+      "fastmailDisconnectConfirm": "Удалить из Mailflow API-токен и все адреса под управлением Fastmail? Ручные псевдонимы и почтовая учётная запись сохранятся."
     },
     "folderMappings": {
       "title": "Сопоставление папок",
@@ -675,7 +689,13 @@
       "errorRequired": "Требуются имя и адрес электронной почты",
       "deleteConfirmTitle": "Удалить алиас?",
       "deleteConfirmBody": "Этот алиас будет удалён безвозвратно. Это действие нельзя отменить.",
-      "deleteConfirmLabel": "Удалить"
+      "deleteConfirmLabel": "Удалить",
+      "fastmailAliases": "Псевдонимы Fastmail",
+      "maskedEmails": "Маскированные адреса",
+      "wildcardIdentities": "Подстановочные идентификаторы",
+      "manualAliases": "Ручные псевдонимы Mailflow",
+      "managedInFastmail": "Управляется в Fastmail",
+      "manageInFastmail": "Управлять адресами в Fastmail"
     },
     "appearance": {
       "title": "Внешний вид",

--- a/frontend/src/locales/zhCN.json
+++ b/frontend/src/locales/zhCN.json
@@ -91,6 +91,8 @@
     }
   },
   "compose": {
+    "selectSender": "选择发件地址",
+    "senderRequired": "请先选择发件地址再继续。",
     "newMessage": "新邮件",
     "reply": "回复",
     "replyAll": "回复全部",
@@ -624,6 +626,7 @@
       "addAccount": "添加账户",
       "saving": "保存中…",
       "presetGmail": "Gmail",
+      "presetFastmail": "Fastmail",
       "presetYahoo": "Yahoo Mail",
       "presetIcloud": "iCloud",
       "presetCustom": "自定义",
@@ -638,7 +641,18 @@
       "categorizationSection": "邮件分类",
       "categorizationEnabled": "启用收件箱分类",
       "categorizationEnabledDesc": "将收到的邮件按类别选项卡分类。默认禁用。",
-      "enabledGlobally": "已全局启用"
+      "enabledGlobally": "已全局启用",
+      "fastmailApiToken": "Fastmail API 令牌",
+      "fastmailApiTokenHint": "令牌只能写入并会加密存储。留空可保留当前令牌。",
+      "fastmailAppPasswordHint": "请在上方的密码字段中使用 Fastmail 应用密码。",
+      "fastmailPermissionsHint": "创建令牌时请授予“邮件提交”和“掩码邮箱”权限。",
+      "fastmailConfigured": "已配置 Fastmail 地址同步",
+      "fastmailNotConfigured": "尚未配置 Fastmail 地址同步",
+      "fastmailLastSync": "上次地址同步",
+      "fastmailRefresh": "刷新地址",
+      "fastmailRefreshing": "正在刷新地址…",
+      "fastmailDisconnect": "断开 Fastmail 同步",
+      "fastmailDisconnectConfirm": "要从 Mailflow 中移除 API 令牌和所有由 Fastmail 管理的地址吗？手动别名和邮箱账户将保留。"
     },
     "folderMappings": {
       "title": "文件夹映射",
@@ -675,7 +689,13 @@
       "errorRequired": "名称和邮箱地址为必填项",
       "deleteConfirmTitle": "删除此别名？",
       "deleteConfirmBody": "此别名将被永久移除，操作无法撤销。",
-      "deleteConfirmLabel": "删除"
+      "deleteConfirmLabel": "删除",
+      "fastmailAliases": "Fastmail 别名",
+      "maskedEmails": "掩码邮箱地址",
+      "wildcardIdentities": "通配符身份",
+      "manualAliases": "Mailflow 手动别名",
+      "managedInFastmail": "由 Fastmail 管理",
+      "manageInFastmail": "在 Fastmail 中管理地址"
     },
     "appearance": {
       "title": "外观",

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -117,6 +117,7 @@ export const api = {
   deleteAccount: (id) => request('DELETE', `/accounts/${id}`),
   reconnectAccount: (id) => request('POST', `/accounts/${id}/reconnect`),
   reindexAccount: (id) => request('POST', `/accounts/${id}/reindex`),
+  refreshFastmailAliases: (id) => request('POST', `/accounts/${id}/fastmail/refresh`),
   getFolders: (accountId) => request('GET', `/accounts/${accountId}/folders`),
   getAliases: (accountId) => request('GET', `/accounts/${accountId}/aliases`),
   addAlias: (accountId, data) => request('POST', `/accounts/${accountId}/aliases`, data),
@@ -129,6 +130,7 @@ export const api = {
     return request('GET', `/mail/messages?${qs}`);
   },
   getMessage: (id) => request('GET', `/mail/messages/${id}`),
+  resolveMessageSender: (id, purpose) => request('POST', `/mail/messages/${id}/resolve-sender`, { purpose }),
   getMessageBody,
   getThread: (threadId, folder) => {
     const qs = folder ? `?folder=${encodeURIComponent(folder)}` : '';

--- a/frontend/src/utils/replyCompose.js
+++ b/frontend/src/utils/replyCompose.js
@@ -1,0 +1,75 @@
+import { wildcardCovers } from './senderIdentity.js';
+
+function parseAddresses(value) {
+  try {
+    const parsed = Array.isArray(value) ? value : JSON.parse(value || '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function buildReplyComposeData({ message, account, resolved, replyAll, body }) {
+  const replyTo = parseAddresses(message.reply_to);
+  const replyTarget = replyTo[0]?.email
+    ? replyTo[0]
+    : { name: message.from_name || '', email: message.from_email || '' };
+  const replyRecipients = replyTarget.email ? [replyTarget] : [];
+
+  const ownAddresses = new Set([
+    account?.email_address,
+    ...(account?.aliases || []).map(alias => alias.email),
+    resolved.sender?.fromEmail,
+    resolved.sender?.displayEmail,
+  ].filter(Boolean).map(address => address.toLowerCase()));
+  const ownWildcards = (account?.aliases || []).filter(alias => (
+    alias.provenance === 'fastmail'
+    && alias.fastmail_identity_id
+    && alias.email.startsWith('*@')
+  )).map(alias => alias.email);
+  const replyTargetEmail = replyTarget.email?.toLowerCase();
+  const allRecipients = [
+    ...parseAddresses(message.to_addresses),
+    ...parseAddresses(message.cc_addresses),
+  ].filter(recipient => (
+    recipient.email
+    && !ownAddresses.has(recipient.email.toLowerCase())
+    && !ownWildcards.some(pattern => wildcardCovers(pattern, recipient.email))
+    && recipient.email.toLowerCase() !== replyTargetEmail
+  ));
+
+  const rawSubject = (message.subject || '').trim();
+  const references = [message.in_reply_to, message.message_id]
+    .filter(Boolean)
+    .join(' ')
+    .trim() || null;
+  const date = message.date ? new Date(message.date).toLocaleString() : '';
+  const safeName = (message.from_name || '').replace(/[\r\n]+/g, ' ');
+  const from = safeName
+    ? `${safeName} <${message.from_email}>`
+    : message.from_email || '';
+  const quotedBody = body?.text
+    ? `\n\n---\nOn ${date}, ${from} wrote:\n${body.text.split('\n').map(line => `> ${line}`).join('\n')}`
+    : '';
+  const quotedBodyHtml = body?.html
+    ? `<div style="border-left:3px solid var(--border,#ccc);padding-left:12px;margin-top:12px;color:var(--text-secondary,#666)"><p style="margin:0 0 6px;font-size:12px">On ${date}, ${from} wrote:</p>${body.html}</div>`
+    : null;
+
+  return {
+    to: replyRecipients,
+    cc: replyAll ? allRecipients : [],
+    subject: rawSubject.startsWith('Re:') ? rawSubject : rawSubject ? `Re: ${rawSubject}` : 'Re:',
+    body: '',
+    quotedBody,
+    quotedBodyHtml,
+    inReplyTo: message.message_id,
+    references,
+    sender: resolved.sender,
+    senderRequired: resolved.requiresSelection,
+    accountId: message.account_id,
+    isReply: true,
+    isReplyAll: replyAll,
+    originalFrom: replyRecipients,
+    allRecipients,
+  };
+}

--- a/frontend/src/utils/replyCompose.test.js
+++ b/frontend/src/utils/replyCompose.test.js
@@ -1,0 +1,192 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildReplyComposeData } from './replyCompose.js';
+import { resolveSenderOrFallback } from './senderIdentity.js';
+
+test('still opens a reply requiring manual sender selection when resolution fails', async () => {
+  const resolved = await resolveSenderOrFallback(() => Promise.reject(new Error('resolve failed')));
+
+  const data = buildReplyComposeData({
+    message: {
+      account_id: 'account-1',
+      from_email: 'sender@example.net',
+      reply_to: [],
+      to_addresses: [],
+      cc_addresses: [],
+      subject: 'Needs a from address',
+      message_id: '<degraded@example.net>',
+    },
+    account: { id: 'account-1', email_address: 'owner@example.com', aliases: [] },
+    resolved,
+    replyAll: false,
+  });
+
+  assert.equal(data.sender, null);
+  assert.equal(data.senderRequired, true);
+});
+
+test('builds reply-all compose data from the resolved Fastmail sender', () => {
+  const message = {
+    account_id: 'account-1',
+    from_name: 'Original Sender',
+    from_email: 'original@example.net',
+    reply_to: JSON.stringify([{ name: 'Reply Target', email: 'reply@example.net' }]),
+    to_addresses: [
+      { name: 'Mailbox Owner', email: 'owner@example.com' },
+      { name: 'Resolved Sender', email: 'selected@example.com' },
+      { name: 'Teammate', email: 'teammate@example.net' },
+      { name: 'Reply Target', email: 'reply@example.net' },
+    ],
+    cc_addresses: JSON.stringify([
+      { name: 'Configured Alias', email: 'alias@example.com' },
+      { name: 'Another Teammate', email: 'other@example.net' },
+    ]),
+    subject: 'Status update',
+    in_reply_to: '<previous@example.net>',
+    message_id: '<current@example.net>',
+  };
+  const account = {
+    id: 'account-1',
+    email_address: 'owner@example.com',
+    aliases: [{ email: 'alias@example.com' }],
+  };
+  const resolved = {
+    sender: {
+      accountId: 'account-1',
+      aliasId: 'wildcard-identity',
+      fromEmail: 'selected@example.com',
+    },
+    requiresSelection: false,
+  };
+
+  assert.deepEqual(buildReplyComposeData({ message, account, resolved, replyAll: true }), {
+    to: [{ name: 'Reply Target', email: 'reply@example.net' }],
+    cc: [
+      { name: 'Teammate', email: 'teammate@example.net' },
+      { name: 'Another Teammate', email: 'other@example.net' },
+    ],
+    subject: 'Re: Status update',
+    body: '',
+    quotedBody: '',
+    quotedBodyHtml: null,
+    inReplyTo: '<current@example.net>',
+    references: '<previous@example.net> <current@example.net>',
+    sender: resolved.sender,
+    senderRequired: false,
+    accountId: 'account-1',
+    isReply: true,
+    isReplyAll: true,
+    originalFrom: [{ name: 'Reply Target', email: 'reply@example.net' }],
+    allRecipients: [
+      { name: 'Teammate', email: 'teammate@example.net' },
+      { name: 'Another Teammate', email: 'other@example.net' },
+    ],
+  });
+});
+
+test('includes the loaded message body in the reply quote', () => {
+  const message = {
+    account_id: 'account-1',
+    from_name: 'Original\r\nSender',
+    from_email: 'original@example.net',
+    reply_to: [],
+    to_addresses: [],
+    cc_addresses: [],
+    subject: 'Re: Existing subject',
+    message_id: '<current@example.net>',
+    date: '2026-07-12T12:00:00.000Z',
+  };
+  const body = { text: 'First line\nSecond line', html: '<p>HTML body</p>' };
+  const date = new Date(message.date).toLocaleString();
+
+  const result = buildReplyComposeData({
+    message,
+    account: { email_address: 'owner@example.com', aliases: [] },
+    resolved: { sender: null, requiresSelection: true },
+    replyAll: false,
+    body,
+  });
+
+  assert.equal(
+    result.quotedBody,
+    `\n\n---\nOn ${date}, Original Sender <original@example.net> wrote:\n> First line\n> Second line`,
+  );
+  assert.equal(
+    result.quotedBodyHtml,
+    `<div style="border-left:3px solid var(--border,#ccc);padding-left:12px;margin-top:12px;color:var(--text-secondary,#666)"><p style="margin:0 0 6px;font-size:12px">On ${date}, Original Sender <original@example.net> wrote:</p><p>HTML body</p></div>`,
+  );
+});
+
+test('excludes every address covered by an owned Fastmail wildcard from Reply All', () => {
+  const result = buildReplyComposeData({
+    message: {
+      account_id: 'account-1',
+      from_email: 'sender@example.net',
+      reply_to: [],
+      to_addresses: [
+        { email: 'first@catchall.example' },
+        { email: 'second@catchall.example' },
+        { email: 'teammate@example.net' },
+      ],
+      cc_addresses: [],
+      subject: 'Wildcard delivery',
+      message_id: '<wildcard@example.net>',
+    },
+    account: {
+      id: 'account-1',
+      email_address: 'owner@example.com',
+      aliases: [{
+        email: '*@catchall.example',
+        provenance: 'fastmail',
+        fastmail_identity_id: 'wildcard-identity',
+      }],
+    },
+    resolved: {
+      sender: {
+        accountId: 'account-1',
+        aliasId: 'wildcard-alias',
+        fromEmail: 'first@catchall.example',
+      },
+      requiresSelection: false,
+    },
+    replyAll: true,
+  });
+
+  assert.deepEqual(result.allRecipients, [{ email: 'teammate@example.net' }]);
+  assert.deepEqual(result.cc, result.allRecipients);
+});
+
+test('excludes a stale resolved exact Fastmail identity from Reply All', () => {
+  const result = buildReplyComposeData({
+    message: {
+      account_id: 'account-1',
+      from_email: 'sender@example.net',
+      reply_to: [],
+      to_addresses: [
+        { email: 'stale-alias@example.com' },
+        { email: 'teammate@example.net' },
+      ],
+      cc_addresses: [],
+      subject: 'Exact alias delivery',
+      message_id: '<exact-alias@example.net>',
+    },
+    account: {
+      id: 'account-1',
+      email_address: 'owner@example.com',
+      aliases: [],
+    },
+    resolved: {
+      sender: {
+        accountId: 'account-1',
+        aliasId: 'stale-alias',
+        fromEmail: null,
+        displayEmail: 'stale-alias@example.com',
+      },
+      requiresSelection: false,
+    },
+    replyAll: true,
+  });
+
+  assert.deepEqual(result.allRecipients, [{ email: 'teammate@example.net' }]);
+  assert.deepEqual(result.cc, result.allRecipients);
+});

--- a/frontend/src/utils/senderIdentity.js
+++ b/frontend/src/utils/senderIdentity.js
@@ -1,0 +1,96 @@
+export function senderToValue(sender) {
+  if (!sender) return '';
+  return encodeURIComponent(JSON.stringify({
+    accountId: sender.accountId,
+    aliasId: sender.aliasId || null,
+    fromEmail: sender.fromEmail || null,
+  }));
+}
+
+export function valueToSender(value) {
+  if (!value) return null;
+  const parsed = JSON.parse(decodeURIComponent(value));
+  return {
+    accountId: parsed.accountId,
+    aliasId: parsed.aliasId || null,
+    fromEmail: parsed.fromEmail || null,
+  };
+}
+
+// Resolves a message's server-side sender, degrading to manual selection when the
+// lookup fails so a transient backend hiccup never blocks replying or opening a draft.
+export async function resolveSenderOrFallback(resolve) {
+  try {
+    return await resolve();
+  } catch {
+    return { sender: null, requiresSelection: true };
+  }
+}
+
+export function wildcardCovers(pattern, candidate) {
+  const normalizedPattern = String(pattern || '').trim().toLowerCase();
+  const normalizedCandidate = String(candidate || '').trim().toLowerCase();
+  if (!normalizedPattern.startsWith('*@')) return false;
+  const at = normalizedCandidate.lastIndexOf('@');
+  return at > 0 && normalizedCandidate.slice(at + 1) === normalizedPattern.slice(2);
+}
+
+export function resolveSenderSignature({ account, alias, selectedSender, resolvedSender }) {
+  if (alias) return alias.signature ?? account?.signature ?? null;
+  if (
+    resolvedSender?.signature !== undefined
+    && senderToValue(selectedSender) === senderToValue(resolvedSender)
+  ) {
+    return resolvedSender.signature;
+  }
+  return account?.signature ?? null;
+}
+
+function senderLabel(name, email) {
+  return name ? `${name} <${email}>` : email;
+}
+
+export function buildSenderOptions(account, resolvedSender = null) {
+  const aliases = account.aliases || [];
+  const wildcards = aliases.filter(alias => (
+    alias.provenance === 'fastmail'
+    && alias.fastmail_identity_id
+    && alias.email.startsWith('*@')
+  ));
+  const options = [{
+    label: `${account.sender_name || account.name} <${account.email_address}>`,
+    sender: { accountId: account.id, aliasId: null, fromEmail: null },
+  }];
+  for (const alias of aliases) {
+    if (alias.email.startsWith('*@')) continue;
+    if (alias.provenance === 'manual' || alias.fastmail_identity_id) {
+      options.push({
+        label: senderLabel(alias.name, alias.email),
+        sender: { accountId: account.id, aliasId: alias.id, fromEmail: null },
+      });
+      continue;
+    }
+    const wildcard = wildcards.find(item => wildcardCovers(item.email, alias.email));
+    if (wildcard) {
+      options.push({
+        label: senderLabel(wildcard.name, alias.email),
+        sender: { accountId: account.id, aliasId: wildcard.id, fromEmail: alias.email },
+      });
+    }
+  }
+  if (
+    resolvedSender?.accountId === account.id
+    && (resolvedSender.displayEmail || resolvedSender.fromEmail)
+    && !options.some(option => senderToValue(option.sender) === senderToValue(resolvedSender))
+  ) {
+    const email = resolvedSender.displayEmail || resolvedSender.fromEmail;
+    const name = resolvedSender.provenance === 'fastmail'
+      ? resolvedSender.name
+      : (resolvedSender.name || account.sender_name || account.name || '');
+    options.push({
+      label: senderLabel(name, email),
+      sender: resolvedSender,
+    });
+  }
+  return options;
+}

--- a/frontend/src/utils/senderIdentity.test.js
+++ b/frontend/src/utils/senderIdentity.test.js
@@ -1,0 +1,161 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildSenderOptions,
+  resolveSenderOrFallback,
+  resolveSenderSignature,
+  senderToValue,
+  valueToSender,
+  wildcardCovers,
+} from './senderIdentity.js';
+
+test('passes a successful sender resolution through unchanged', async () => {
+  const resolved = { sender: { accountId: 'a1', aliasId: null, fromEmail: null }, requiresSelection: false };
+  assert.deepEqual(await resolveSenderOrFallback(() => Promise.resolve(resolved)), resolved);
+});
+
+test('degrades to manual sender selection when resolution rejects', async () => {
+  assert.deepEqual(
+    await resolveSenderOrFallback(() => Promise.reject(new Error('resolve failed'))),
+    { sender: null, requiresSelection: true },
+  );
+});
+
+test('round-trips a wildcard-derived exact From address', () => {
+  const sender = { accountId: 'a1', aliasId: 'wild1', fromEmail: 'mask+tag@example.com' };
+  assert.deepEqual(valueToSender(senderToValue(sender)), sender);
+});
+
+test('round-trips an explicit primary sender without inventing an alias', () => {
+  const sender = { accountId: 'account:with:opaque-id', aliasId: null, fromEmail: null };
+  assert.deepEqual(valueToSender(senderToValue(sender)), sender);
+});
+
+test('does not invent a primary sender for an unresolved reply', () => {
+  assert.equal(senderToValue(null), '');
+  assert.equal(valueToSender(''), null);
+});
+
+test('uses a stale resolved sender signature while that sender remains selected', () => {
+  const account = { id: 'a1', signature: '<p>Account signature</p>', aliases: [] };
+  const resolvedSender = {
+    accountId: 'a1',
+    aliasId: 'stale-alias',
+    fromEmail: null,
+    signature: '<p>Alias signature</p>',
+  };
+
+  assert.equal(resolveSenderSignature({
+    account,
+    alias: null,
+    selectedSender: valueToSender(senderToValue(resolvedSender)),
+    resolvedSender,
+  }), '<p>Alias signature</p>');
+});
+
+test('wildcard coverage is case-insensitive and restricted to the exact domain', () => {
+  assert.equal(wildcardCovers('*@Example.com', 'Mask@EXAMPLE.COM'), true);
+  assert.equal(wildcardCovers('*@example.com', 'mask@sub.example.com'), false);
+  assert.equal(wildcardCovers('example.com', 'mask@example.com'), false);
+});
+
+test('builds exact visible sender options and backs mask-only rows with verified wildcards', () => {
+  const account = {
+    id: 'a1', name: 'Fastmail', sender_name: 'Account Owner', email_address: 'owner@example.com',
+    aliases: [
+      { id: 'manual', name: 'Manual', email: 'manual@example.com', provenance: 'manual', fastmail_identity_id: null },
+      { id: 'exact', name: 'Exact', email: 'exact@example.com', provenance: 'fastmail', fastmail_identity_id: 'i1' },
+      { id: 'wild', name: 'Wildcard', email: '*@example.com', provenance: 'fastmail', fastmail_identity_id: 'i2' },
+      { id: 'mask', name: 'Masked row', email: 'mask@example.com', provenance: 'fastmail', fastmail_identity_id: null },
+      { id: 'unverified-wild', name: 'Unverified', email: '*@other.example', provenance: 'fastmail', fastmail_identity_id: null },
+      { id: 'unverified-mask', name: 'Unverified mask', email: 'mask@other.example', provenance: 'fastmail', fastmail_identity_id: null },
+    ],
+  };
+
+  assert.deepEqual(buildSenderOptions(account), [
+    {
+      label: 'Account Owner <owner@example.com>',
+      sender: { accountId: 'a1', aliasId: null, fromEmail: null },
+    },
+    {
+      label: 'Manual <manual@example.com>',
+      sender: { accountId: 'a1', aliasId: 'manual', fromEmail: null },
+    },
+    {
+      label: 'Exact <exact@example.com>',
+      sender: { accountId: 'a1', aliasId: 'exact', fromEmail: null },
+    },
+    {
+      label: 'Wildcard <mask@example.com>',
+      sender: { accountId: 'a1', aliasId: 'wild', fromEmail: 'mask@example.com' },
+    },
+  ]);
+});
+
+test('includes a resolved exact alias when the frontend account aliases are stale', () => {
+  const account = {
+    id: 'fastmail',
+    name: 'Fastmail',
+    sender_name: 'Test Account',
+    email_address: 'primary@fastmail.example',
+    aliases: [],
+  };
+  const resolvedSender = {
+    accountId: 'fastmail',
+    aliasId: 'unnamed-identity',
+    fromEmail: null,
+    displayEmail: 'unnamed@fastmail.example',
+    name: 'Test Account',
+    provenance: 'fastmail',
+  };
+
+  assert.deepEqual(buildSenderOptions(account, resolvedSender), [
+    {
+      label: 'Test Account <primary@fastmail.example>',
+      sender: { accountId: 'fastmail', aliasId: null, fromEmail: null },
+    },
+    {
+      label: 'Test Account <unnamed@fastmail.example>',
+      sender: resolvedSender,
+    },
+  ]);
+});
+
+test('renders a blank Fastmail identity name as an address-only sender option', () => {
+  const account = {
+    id: 'fastmail',
+    name: 'Fastmail',
+    sender_name: 'Test Account',
+    email_address: 'primary@fastmail.example',
+    aliases: [{
+      id: 'unnamed-identity',
+      name: '',
+      email: 'unnamed@fastmail.example',
+      provenance: 'fastmail',
+      fastmail_identity_id: 'identity-unnamed',
+    }],
+  };
+
+  assert.equal(buildSenderOptions(account)[1].label, 'unnamed@fastmail.example');
+});
+
+test('renders a stale resolved sender with a blank identity name as address-only', () => {
+  const account = {
+    id: 'fastmail',
+    name: 'Fastmail',
+    sender_name: 'Test Account',
+    email_address: 'primary@fastmail.example',
+    aliases: [],
+  };
+  const resolvedSender = {
+    accountId: 'fastmail',
+    aliasId: 'unnamed-identity',
+    fromEmail: null,
+    displayEmail: 'unnamed@fastmail.example',
+    name: '',
+    provenance: 'fastmail',
+  };
+
+  assert.equal(buildSenderOptions(account, resolvedSender)[1].label, 'unnamed@fastmail.example');
+});


### PR DESCRIPTION
## Summary

Adds Fastmail as a provider: MailFlow syncs the account's sending identities and Masked Email addresses over the Fastmail API and lets you send from any of them.

## Changes

- Adds Fastmail in settings as a provider
- Adds Fastmail masked email address and alias support
- Works via a Fastmail API key (no OAuth needed) — write-only, encrypted at rest
- Synced identities appear in the compose From picker; replies come from the address that received the message, including `*@domain` catch-all identities
- The server authorizes every send against the synced identity list
- Search now matches recipients, so mail sent to an alias is findable

## Testing

- Backend: 523 tests (vitest); frontend: 1159 tests (node --test); lint and build clean on both
- Exercised against a live Fastmail account: token setup, identity and Masked Email sync, reply sender resolution, sending, recipient search

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
