### PR TITLE
feat: reply from the address a message was delivered to

### DIFF
--- a/backend/migrations/0035_message_delivery_addresses.sql
+++ b/backend/migrations/0035_message_delivery_addresses.sql
@@ -1,0 +1,8 @@
+-- Addresses a message was delivered to (Delivered-To / X-Delivered-To /
+-- X-Original-To / Envelope-To), captured at ingest. Reply alias selection
+-- matches these in addition to To/Cc, so a message delivered to an alias
+-- via BCC or a catch-all still replies from that alias.
+-- Nullable like list_unsubscribe: NULL marks rows ingested before capture
+-- existed, so the sync upsert's COALESCE backfills them on a later re-sync.
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS delivery_addresses JSONB;

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -140,7 +140,7 @@ router.get('/messages/:id', async (req, res) => {
              m.reply_to, m.in_reply_to,
              m.date, m.snippet, m.is_read, m.is_starred,
              m.has_attachments, m.account_id, m.category,
-             m.list_unsubscribe, m.list_unsubscribe_post, m.unsubscribed_at,
+             m.list_unsubscribe, m.list_unsubscribe_post, m.unsubscribed_at, m.delivery_addresses,
              a.name AS account_name, a.email_address AS account_email,
              a.color AS account_color
       FROM messages m
@@ -172,7 +172,7 @@ router.get('/resolve-message', async (req, res) => {
              m.reply_to, m.in_reply_to,
              m.date, m.snippet, m.is_read, m.is_starred,
              m.has_attachments, m.account_id, m.category,
-             m.list_unsubscribe, m.list_unsubscribe_post, m.unsubscribed_at,
+             m.list_unsubscribe, m.list_unsubscribe_post, m.unsubscribed_at, m.delivery_addresses,
              a.name AS account_name, a.email_address AS account_email,
              a.color AS account_color`;
   try {
@@ -247,7 +247,7 @@ router.get('/thread/:threadId', async (req, res) => {
                m.reply_to, m.in_reply_to,
                m.date, m.snippet, m.is_read, m.is_starred,
                m.has_attachments, m.account_id, m.category,
-               m.list_unsubscribe, m.list_unsubscribe_post, m.unsubscribed_at,
+               m.list_unsubscribe, m.list_unsubscribe_post, m.unsubscribed_at, m.delivery_addresses,
                a.name AS account_name, a.email_address AS account_email, a.color AS account_color
         FROM messages m
         JOIN email_accounts a ON m.account_id = a.id

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -535,7 +535,7 @@ export async function insertCopiedSibling(accountId, uid, fromFolder, toFolder, 
       thread_references, thread_id, is_bulk,
       read_changed_at, star_changed_at, spam_score_sa, spam_score_ml,
       spam_verdict, spam_analyzed_at, spam_details, spam_user_override,
-      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at
+      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses
     )
     SELECT
       account_id, $4, $5, message_id, subject,
@@ -545,7 +545,7 @@ export async function insertCopiedSibling(accountId, uid, fromFolder, toFolder, 
       thread_references, thread_id, is_bulk,
       read_changed_at, star_changed_at, spam_score_sa, spam_score_ml,
       spam_verdict, spam_analyzed_at, spam_details, spam_user_override,
-      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at
+      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses
     FROM messages
     WHERE account_id = $1 AND folder = $2 AND uid = $3
     ON CONFLICT (account_id, uid, folder) DO NOTHING
@@ -2389,8 +2389,8 @@ export class ImapManager {
                 date, snippet, is_read, is_starred, has_attachments, flags,
                 body_html, body_text, attachments,
                 thread_references, thread_id, is_bulk, category,
-                list_unsubscribe, list_unsubscribe_post
-              ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)
+                list_unsubscribe, list_unsubscribe_post, delivery_addresses
+              ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
               ON CONFLICT (account_id, uid, folder) DO UPDATE
               SET subject = CASE
                     WHEN EXCLUDED.subject IS NOT NULL
@@ -2436,7 +2436,8 @@ export class ImapManager {
                   is_bulk = COALESCE(messages.is_bulk, EXCLUDED.is_bulk),
                   category = COALESCE(messages.category, EXCLUDED.category),
                   list_unsubscribe = COALESCE(messages.list_unsubscribe, EXCLUDED.list_unsubscribe),
-                  list_unsubscribe_post = COALESCE(messages.list_unsubscribe_post, EXCLUDED.list_unsubscribe_post)
+                  list_unsubscribe_post = COALESCE(messages.list_unsubscribe_post, EXCLUDED.list_unsubscribe_post),
+                  delivery_addresses = COALESCE(messages.delivery_addresses, EXCLUDED.delivery_addresses)
               RETURNING id, (xmax = 0) as is_new
             `, [
               account.id, parsed.uid, folder,
@@ -2451,6 +2452,7 @@ export class ImapManager {
               refs, threadId, parsed.isBulk ?? null, msgCategory,
               sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe'] ?? null)),
               sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe-post'] ?? null)),
+              JSON.stringify(parsed.deliveryAddresses || []),
             ]);
             if (result.rows[0]?.is_new) {
               insertedCount++;
@@ -3033,8 +3035,8 @@ export class ImapManager {
                     date, snippet, is_read, is_starred, has_attachments, flags,
                     body_html, body_text, attachments,
                     thread_references, thread_id, is_bulk, category,
-                    list_unsubscribe, list_unsubscribe_post
-                  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26)
+                    list_unsubscribe, list_unsubscribe_post, delivery_addresses
+                  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27)
                   ON CONFLICT (account_id, uid, folder) DO UPDATE
                   SET subject = CASE
                         WHEN EXCLUDED.subject IS NOT NULL
@@ -3080,7 +3082,8 @@ export class ImapManager {
                       is_bulk = COALESCE(messages.is_bulk, EXCLUDED.is_bulk),
                       category = COALESCE(messages.category, EXCLUDED.category),
                       list_unsubscribe = COALESCE(messages.list_unsubscribe, EXCLUDED.list_unsubscribe),
-                      list_unsubscribe_post = COALESCE(messages.list_unsubscribe_post, EXCLUDED.list_unsubscribe_post)
+                      list_unsubscribe_post = COALESCE(messages.list_unsubscribe_post, EXCLUDED.list_unsubscribe_post),
+                      delivery_addresses = COALESCE(messages.delivery_addresses, EXCLUDED.delivery_addresses)
                 `, [
                   account.id, parsed.uid, folder,
                   bfMsgId, sanitizeStr(parsed.subject),
@@ -3094,6 +3097,7 @@ export class ImapManager {
                   bfRefs, bfThreadId, parsed.isBulk ?? null, bfCategory,
                   sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe'] ?? null)),
                   sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe-post'] ?? null)),
+                  JSON.stringify(parsed.deliveryAddresses || []),
                 ]);
                 backfilledRows++;
                 if (bfThreadId && bfThreadId !== bfMsgId) {

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -282,6 +282,8 @@ describe('insertCopiedSibling', () => {
     // Idempotent against the next destination-folder sync.
     expect(ins[0]).toContain('ON CONFLICT (account_id, uid, folder) DO NOTHING');
     expect(ins[1]).toEqual(['acct-1', 'INBOX', 100, 5001, 'Todo']);
+    // delivery_addresses is copied verbatim from the source row, same as list_unsubscribe.
+    expect(ins[0]).toContain('delivery_addresses');
   });
 
   it('increments destination unread only when the copied message is unread', async () => {

--- a/backend/src/services/messageParser.headers.test.js
+++ b/backend/src/services/messageParser.headers.test.js
@@ -5,6 +5,7 @@ import {
   buildHeadersFromMessage,
   enrichParsedMetadata,
   parseMailboxList,
+  parseDeliveryAddresses,
   snippetFromBody,
   parseMessage,
 } from './messageParser.js';
@@ -136,6 +137,50 @@ describe('parseMailboxList', () => {
       { name: 'Bob', email: 'bob@example.com' },
       { name: '', email: 'cc@example.com' },
     ]);
+  });
+});
+
+describe('parseDeliveryAddresses', () => {
+  it('parses a single Delivered-To header', () => {
+    expect(parseDeliveryAddresses({ 'delivered-to': 'alice+work@example.com' }))
+      .toEqual(['alice+work@example.com']);
+  });
+
+  it('parses multiple values folded onto separate lines', () => {
+    expect(parseDeliveryAddresses({ 'delivered-to': 'a@example.com\nb@example.com' }))
+      .toEqual(['a@example.com', 'b@example.com']);
+  });
+
+  it('parses X-Original-To', () => {
+    expect(parseDeliveryAddresses({ 'x-original-to': 'catchall@example.com' }))
+      .toEqual(['catchall@example.com']);
+  });
+
+  it('dedupes the same address across headers, case-insensitively', () => {
+    expect(parseDeliveryAddresses({
+      'delivered-to': 'Alice@Example.com',
+      'x-original-to': 'alice@example.com',
+    })).toEqual(['alice@example.com']);
+  });
+
+  it('extracts the email from angle-bracket forms', () => {
+    expect(parseDeliveryAddresses({ 'delivered-to': 'Alice Smith <alice@example.com>' }))
+      .toEqual(['alice@example.com']);
+  });
+
+  it('returns [] when no delivery headers are present', () => {
+    expect(parseDeliveryAddresses({})).toEqual([]);
+    expect(parseDeliveryAddresses(undefined)).toEqual([]);
+  });
+
+  it('ignores junk lines that do not parse as an address', () => {
+    expect(parseDeliveryAddresses({ 'delivered-to': 'not-an-email\nbob@example.com' }))
+      .toEqual(['bob@example.com']);
+  });
+
+  it('caps the number of captured addresses', () => {
+    const flood = Array.from({ length: 80 }, (_, i) => `user${i}@example.com`).join(', ');
+    expect(parseDeliveryAddresses({ 'delivered-to': flood })).toHaveLength(50);
   });
 });
 

--- a/backend/src/services/messageParser.js
+++ b/backend/src/services/messageParser.js
@@ -368,6 +368,28 @@ export function parseMailboxList(headerValue) {
   return results.filter(r => r.email);
 }
 
+// Headers an MTA/mailbox uses to record the address a message was actually delivered
+// to (BCC, catch-all, forwarded alias) — may be absent from To/Cc entirely.
+const DELIVERY_HEADERS = ['delivered-to', 'x-delivered-to', 'x-original-to', 'envelope-to'];
+// Sender-controlled input persisted per message; capped like subject/snippet.
+const MAX_DELIVERY_ADDRESSES = 50;
+
+export function parseDeliveryAddresses(parsedHeaders) {
+  const emails = new Set();
+  for (const header of DELIVERY_HEADERS) {
+    const value = parsedHeaders?.[header];
+    if (!value) continue;
+    for (const line of value.split(/\r?\n/)) {
+      for (const { email } of parseMailboxList(line)) {
+        const normalized = email.trim().toLowerCase();
+        if (normalized) emails.add(normalized);
+        if (emails.size >= MAX_DELIVERY_ADDRESSES) return [...emails];
+      }
+    }
+  }
+  return [...emails];
+}
+
 // Fill gaps when IMAP ENVELOPE is incomplete — common for multipart/related Sent copies.
 export function enrichParsedMetadata(parsed, {
   accountEmail,
@@ -537,6 +559,7 @@ export async function parseMessage(msg) {
     inReplyTo: envelope.inReplyTo || null,
     references,
     parsedHeaders,
+    deliveryAddresses: parseDeliveryAddresses(parsedHeaders),
     date: msg.internalDate || envelope.date || new Date(),
     snippet,
     isRead,

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -95,7 +95,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
                m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
                m.date, m.snippet, m.is_read, m.is_starred,
                m.has_attachments, m.account_id, m.category,
-               m.list_unsubscribe, m.list_unsubscribe_post,
+               m.list_unsubscribe, m.list_unsubscribe_post, m.delivery_addresses,
                a.name  AS account_name,
                a.email_address AS account_email,
                a.color AS account_color,
@@ -141,7 +141,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
              to_addresses, cc_addresses, reply_to, in_reply_to,
              date, snippet, is_starred, is_read, has_attachments, account_id,
              account_name, account_email, account_color,
-             category, list_unsubscribe, list_unsubscribe_post,
+             category, list_unsubscribe, list_unsubscribe_post, delivery_addresses,
              message_count, unread_count,
              thread_has_contact_photo AS has_contact_photo
       FROM ranked
@@ -172,7 +172,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
            m.to_addresses, m.cc_addresses, m.reply_to, m.in_reply_to,
            m.date, m.snippet, m.is_read, m.is_starred,
            m.has_attachments, m.account_id, m.category,
-           m.list_unsubscribe, m.list_unsubscribe_post,
+           m.list_unsubscribe, m.list_unsubscribe_post, m.delivery_addresses,
            a.name as account_name, a.email_address as account_email, a.color as account_color,
            (co.id IS NOT NULL) AS has_contact_photo
     FROM messages m

--- a/backend/src/services/messageService.test.js
+++ b/backend/src/services/messageService.test.js
@@ -150,3 +150,28 @@ describe('listMessages — threaded mode', () => {
     expect(cteSql).toContain("AND folder = 'INBOX'");
   });
 });
+
+describe('listMessages — message shape', () => {
+  it('selects delivery_addresses in the flat query', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })
+      .mockResolvedValueOnce({ rows: [{ total_count: 1, unread_count: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1' });
+
+    expect(query.mock.calls[2][0]).toContain('delivery_addresses');
+  });
+
+  it('selects delivery_addresses in the threaded query', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })
+      .mockResolvedValueOnce({ rows: [{ total_count: 1, unread_count: 0 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1', threaded: 'true' });
+
+    expect(query.mock.calls[2][0]).toContain('delivery_addresses');
+  });
+});

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -12,6 +12,7 @@ import DOMPurify from 'dompurify';
 import { BUILTIN_SUMMARIZE } from '../aiActions.js';
 import { getResults, saveResult, removeResult } from '../aiResults.js';
 import { renderMarkdown } from '../utils/renderMarkdown.js';
+import { pickReplyAlias } from '../utils/replyAlias.js';
 const USE_DIV_RENDER = import.meta.env.VITE_EMAIL_DIV_RENDER === 'true';
 const MESSAGE_OPENING_EVENT = 'mailflow:message-opening';
 
@@ -889,25 +890,13 @@ export default function MessagePane() {
     const myAccount = accounts.find(a => a.id === message.account_id);
     const myEmail = myAccount?.email_address || '';
 
-    const replyAliasId = (() => {
-      const aliases = myAccount?.aliases || [];
-      if (!aliases.length) return null;
-      try {
-        const toArr = Array.isArray(message.to_addresses)
-          ? message.to_addresses
-          : JSON.parse(message.to_addresses || '[]');
-        const ccArr = Array.isArray(message.cc_addresses)
-          ? message.cc_addresses
-          : JSON.parse(message.cc_addresses || '[]');
-        const allEmails = [...toArr, ...ccArr].map(t => t.email?.toLowerCase()).filter(Boolean);
-        const fromEmail = (message.from_email || '').toLowerCase();
-        const match = aliases.find(al => {
-          const aliasEmail = al.email.toLowerCase();
-          return allEmails.includes(aliasEmail) || fromEmail === aliasEmail;
-        });
-        return match ? match.id : null;
-      } catch { return null; }
-    })();
+    const replyAliasId = pickReplyAlias({
+      aliases: myAccount?.aliases || [],
+      deliveryAddresses: message.delivery_addresses,
+      toAddresses: message.to_addresses,
+      ccAddresses: message.cc_addresses,
+      fromEmail: message.from_email,
+    });
 
     const myAddresses = new Set([
       myEmail.toLowerCase(),

--- a/frontend/src/utils/replyAlias.js
+++ b/frontend/src/utils/replyAlias.js
@@ -1,0 +1,29 @@
+export function parseAddressListField(value) {
+  if (Array.isArray(value)) return value;
+  try {
+    return JSON.parse(value || '[]');
+  } catch {
+    return [];
+  }
+}
+
+export function pickReplyAlias({ aliases, deliveryAddresses, toAddresses, ccAddresses, fromEmail }) {
+  if (!aliases || !aliases.length) return null;
+
+  const delivered = parseAddressListField(deliveryAddresses).map(e => (e || '').toLowerCase()).filter(Boolean);
+  const to = parseAddressListField(toAddresses).map(a => a.email?.toLowerCase()).filter(Boolean);
+  const cc = parseAddressListField(ccAddresses).map(a => a.email?.toLowerCase()).filter(Boolean);
+  const from = (fromEmail || '').toLowerCase();
+
+  const deliveredMatch = aliases.find(al => delivered.includes(al.email.toLowerCase()));
+  if (deliveredMatch) return deliveredMatch.id;
+
+  // Same scan as before delivery addresses existed: aliases in creation order
+  // against the combined To/Cc/From set, so multi-alias picks don't change.
+  const headerEmails = [...to, ...cc];
+  const match = aliases.find(al => {
+    const aliasEmail = al.email.toLowerCase();
+    return headerEmails.includes(aliasEmail) || (from && from === aliasEmail);
+  });
+  return match ? match.id : null;
+}

--- a/frontend/src/utils/replyAlias.test.js
+++ b/frontend/src/utils/replyAlias.test.js
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseAddressListField, pickReplyAlias } from './replyAlias.js';
+
+const aliases = [
+  { id: 'alias-1', email: 'sales@example.com' },
+  { id: 'alias-2', email: 'support@example.com' },
+];
+
+describe('parseAddressListField', () => {
+  it('returns arrays as-is', () => {
+    const arr = [{ email: 'a@example.com' }];
+    assert.equal(parseAddressListField(arr), arr);
+  });
+
+  it('parses a JSON string', () => {
+    assert.deepEqual(parseAddressListField('[{"email":"a@example.com"}]'), [{ email: 'a@example.com' }]);
+  });
+
+  it('is null-safe for malformed JSON', () => {
+    assert.deepEqual(parseAddressListField('not json'), []);
+  });
+
+  it('defaults missing input to []', () => {
+    assert.deepEqual(parseAddressListField(undefined), []);
+    assert.deepEqual(parseAddressListField(null), []);
+  });
+});
+
+describe('pickReplyAlias', () => {
+  it('matches a delivery address not present in To/Cc (BCC / catch-all case)', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: ['sales@example.com'],
+      toAddresses: [{ email: 'someone-else@example.com' }],
+      ccAddresses: [],
+      fromEmail: 'them@example.com',
+    });
+    assert.equal(result, 'alias-1');
+  });
+
+  it('matches To when there is no delivery address hit (unchanged semantics)', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: [],
+      toAddresses: [{ email: 'support@example.com' }],
+      ccAddresses: [],
+      fromEmail: 'them@example.com',
+    });
+    assert.equal(result, 'alias-2');
+  });
+
+  it('matches Cc when there is no delivery or To hit', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: [],
+      toAddresses: [],
+      ccAddresses: [{ email: 'sales@example.com' }],
+      fromEmail: 'them@example.com',
+    });
+    assert.equal(result, 'alias-1');
+  });
+
+  it('falls back to from_email when nothing else matches', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: [],
+      toAddresses: [],
+      ccAddresses: [],
+      fromEmail: 'support@example.com',
+    });
+    assert.equal(result, 'alias-2');
+  });
+
+  it('prefers the delivery address match over a different To/Cc match', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: ['sales@example.com'],
+      toAddresses: [{ email: 'support@example.com' }],
+      ccAddresses: [],
+      fromEmail: 'them@example.com',
+    });
+    assert.equal(result, 'alias-1');
+  });
+
+  it('returns null when the account has no aliases', () => {
+    const result = pickReplyAlias({
+      aliases: [],
+      deliveryAddresses: ['sales@example.com'],
+      toAddresses: [],
+      ccAddresses: [],
+      fromEmail: '',
+    });
+    assert.equal(result, null);
+  });
+
+  it('is null-safe against malformed JSON strings', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: 'not json',
+      toAddresses: 'not json',
+      ccAddresses: 'not json',
+      fromEmail: '',
+    });
+    assert.equal(result, null);
+  });
+
+  it('matches case-insensitively', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: ['SALES@Example.com'],
+      toAddresses: [],
+      ccAddresses: [],
+      fromEmail: '',
+    });
+    assert.equal(result, 'alias-1');
+  });
+
+  it('keeps alias creation order as the tiebreak when To and Cc match different aliases', () => {
+    // alias-1 was created first; the original matcher scanned aliases against
+    // the combined To+Cc set, so it wins even though alias-2 is in To.
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: [],
+      toAddresses: [{ email: 'support@example.com' }],
+      ccAddresses: [{ email: 'sales@example.com' }],
+      fromEmail: 'them@example.com',
+    });
+    assert.equal(result, 'alias-1');
+  });
+
+  it('keeps alias creation order as the tiebreak between a From match and a Cc match', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: [],
+      toAddresses: [],
+      ccAddresses: [{ email: 'support@example.com' }],
+      fromEmail: 'sales@example.com',
+    });
+    assert.equal(result, 'alias-1');
+  });
+
+  it('lets a delivery match beat alias creation order', () => {
+    const result = pickReplyAlias({
+      aliases,
+      deliveryAddresses: ['support@example.com'],
+      toAddresses: [{ email: 'sales@example.com' }],
+      ccAddresses: [],
+      fromEmail: '',
+    });
+    assert.equal(result, 'alias-2');
+  });
+});


### PR DESCRIPTION
## Summary

When a message arrives at an alias through a BCC delivery or a catch-all, the alias never appears in To/Cc — so the existing reply alias auto-selection (which matches To/Cc/From against the account's aliases) misses, and the reply comes from the primary address. This follows up on the #256 discussion: "MailFlow doesn't yet auto-select the alias a message was delivered to when you hit reply."

This PR captures the envelope recipient (`Delivered-To` / `X-Delivered-To` / `X-Original-To` / `Envelope-To`) at ingest and lets the reply alias matcher check it first, ahead of To/Cc/From. Selection stays transient — nothing is auto-created or persisted into aliases, per the direction in #256. Existing messages carry no capture (NULL) and behave exactly as today, then backfill on their next sync touch; the send path is untouched — the matched alias flows through the existing `aliasId` mechanism.

## Changes

- Migration 0035 (IF NOT EXISTS-guarded, numbered after main's current 0034): nullable `messages.delivery_addresses JSONB`, same shape as `list_unsubscribe`
- `messageParser.js`: `parseDeliveryAddresses()` reads the four delivery headers from the already-parsed header map (reuses `parseMailboxList`; no IMAP fetch changes), deduped and capped at 50 addresses (sender-controlled input, capped like subject/snippet)
- `imapManager.js`: persists the parsed addresses at the message INSERT sites with the same `COALESCE` upsert plumbing as `list_unsubscribe` (the synthesized sent-copy record has no delivery headers and is deliberately left out)
- `messageService.js` + `mail.js`: expose `delivery_addresses` on the message shapes the frontend actually replies from (list, thread, single message, resolve)
- `MessagePane.jsx`: the inline reply-alias matcher is extracted to `frontend/src/utils/replyAlias.js` (pure, testable) and now checks delivery addresses first; the existing To/Cc/From matching semantics — including the alias-creation-order tiebreak for multi-alias accounts — are preserved bit-for-bit and pinned by tests

## Testing

- Backend: 633/633 (vitest), lint clean (`--max-warnings 0`) — new parser cases: repeated/multi-line headers, angle-bracket forms, cross-header dedupe, junk lines, the size cap
- Frontend: 1359/1359 (node --test), lint clean, production build clean — matcher tests pin: delivered-to beats To/Cc, the unchanged multi-alias tiebreak, malformed-JSON safety, case-insensitivity
- No new dependencies; no behavior change for existing messages (NULL capture ⇒ identical selection to today)

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
