### PR TITLE
fix: sync the first message into a previously-empty folder despite a stored modseq

### DIFF
--- a/backend/src/routes/accounts.aliases.test.js
+++ b/backend/src/routes/accounts.aliases.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+
+// Alias CRUD is exercised through the mounted accounts router so these tests cover the
+// ownership checks, successful mutations, and the owner-address cache boundary together.
+// The DB, app entrypoint, and auth middleware are stubbed to keep the harness isolated.
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => { req.session = { userId: 'u1' }; next(); },
+}));
+vi.mock('../index.js', () => ({ imapManager: {} }));
+vi.mock('../services/gtdTransitions.js', () => ({
+  invalidateOwnerAddressesCache: vi.fn(),
+}));
+
+// index.js normally installs this Express 4 patch before mounting routes. Because index.js is
+// mocked above, install it explicitly and give rejected async handlers the same 500 boundary.
+import 'express-async-errors';
+import express from 'express';
+import { query } from '../services/db.js';
+import { invalidateOwnerAddressesCache } from '../services/gtdTransitions.js';
+import accountRoutes from './accounts.js';
+
+const URL_ACCOUNT_ID = 'account-from-url';
+const CHECKED_ACCOUNT_ID = 'account-from-ownership-check';
+const ALIAS_ID = 'alias-1';
+const insertedAlias = {
+  id: ALIAS_ID,
+  account_id: URL_ACCOUNT_ID,
+  name: 'Work',
+  email: 'work@example.com',
+  reply_to: null,
+  signature: null,
+};
+const updatedAlias = { ...insertedAlias, account_id: CHECKED_ACCOUNT_ID, name: 'Updated' };
+
+// Route every query the three mutation handlers issue. The checked account id deliberately
+// differs from the URL id so PUT/DELETE cannot pass by invalidating the convenient value.
+function stubQueries({ accountExists = true, checkedAccountId = CHECKED_ACCOUNT_ID, mutationError = null } = {}) {
+  query.mockImplementation(async (sql) => {
+    if (sql.includes('FROM account_aliases a') && sql.includes('JOIN email_accounts e')) {
+      return { rows: checkedAccountId ? [{ id: ALIAS_ID, account_id: checkedAccountId }] : [] };
+    }
+    if (sql.startsWith('SELECT id FROM email_accounts')) {
+      return { rows: accountExists ? [{ id: URL_ACCOUNT_ID }] : [] };
+    }
+    if (sql.startsWith('INSERT INTO account_aliases')) {
+      if (mutationError) throw mutationError;
+      return { rows: [insertedAlias] };
+    }
+    if (sql.startsWith('UPDATE account_aliases')) {
+      if (mutationError) throw mutationError;
+      return { rows: [updatedAlias] };
+    }
+    if (sql.startsWith('DELETE FROM account_aliases')) {
+      if (mutationError) throw mutationError;
+      return { rows: [] };
+    }
+    throw new Error(`Unexpected query: ${sql}`);
+  });
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/accounts', accountRoutes);
+  app.use((err, _req, res, next) => {
+    void err;
+    void next;
+    res.status(500).json({ error: 'Internal server error' });
+  });
+  return app;
+}
+
+function request(method, path, body) {
+  return fetch(`${base}/api/accounts/${path}`, {
+    method,
+    headers: body ? { 'Content-Type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+const aliasBody = { name: 'Work', email: 'work@example.com' };
+
+let server;
+let base;
+
+beforeAll(async () => {
+  await new Promise((resolve) => { server = buildApp().listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+beforeEach(() => {
+  query.mockReset();
+  invalidateOwnerAddressesCache.mockReset();
+  stubQueries();
+});
+
+describe('account alias mutations invalidate the owner-address cache', () => {
+  it('invalidates the URL account once after a successful INSERT', async () => {
+    const res = await request('POST', `${URL_ACCOUNT_ID}/aliases`, aliasBody);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(insertedAlias);
+    expect(invalidateOwnerAddressesCache).toHaveBeenCalledOnce();
+    expect(invalidateOwnerAddressesCache).toHaveBeenCalledWith(URL_ACCOUNT_ID);
+  });
+
+  it('invalidates the ownership-check account once after a successful UPDATE', async () => {
+    const res = await request('PUT', `${URL_ACCOUNT_ID}/aliases/${ALIAS_ID}`, {
+      ...aliasBody,
+      name: 'Updated',
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(updatedAlias);
+    expect(invalidateOwnerAddressesCache).toHaveBeenCalledOnce();
+    expect(invalidateOwnerAddressesCache).toHaveBeenCalledWith(CHECKED_ACCOUNT_ID);
+  });
+
+  it('invalidates the ownership-check account once after a successful DELETE', async () => {
+    const res = await request('DELETE', `${URL_ACCOUNT_ID}/aliases/${ALIAS_ID}`);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(invalidateOwnerAddressesCache).toHaveBeenCalledOnce();
+    expect(invalidateOwnerAddressesCache).toHaveBeenCalledWith(CHECKED_ACCOUNT_ID);
+  });
+});
+
+// A missing ownership row exits before mutation, so neither a guessed URL account nor a stale
+// alias account may be evicted from the owner-address cache.
+describe('account alias ownership failures do not invalidate the cache', () => {
+  it('returns 404 for PUT when the alias ownership check finds no row', async () => {
+    stubQueries({ checkedAccountId: null });
+
+    const res = await request('PUT', `${URL_ACCOUNT_ID}/aliases/${ALIAS_ID}`, aliasBody);
+
+    expect(res.status).toBe(404);
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(invalidateOwnerAddressesCache).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for DELETE when the alias ownership check finds no row', async () => {
+    stubQueries({ checkedAccountId: null });
+
+    const res = await request('DELETE', `${URL_ACCOUNT_ID}/aliases/${ALIAS_ID}`);
+
+    expect(res.status).toBe(404);
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(invalidateOwnerAddressesCache).not.toHaveBeenCalled();
+  });
+});
+
+// Cache invalidation is sequenced after the mutation. A rejected write reaches the app-level
+// async error boundary as a 500 and must leave the existing cache entry untouched.
+describe('account alias mutation failures do not invalidate the cache', () => {
+  it('returns 500 without invalidating when INSERT rejects', async () => {
+    stubQueries({ mutationError: new Error('insert failed') });
+
+    const res = await request('POST', `${URL_ACCOUNT_ID}/aliases`, aliasBody);
+
+    expect(res.status).toBe(500);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(invalidateOwnerAddressesCache).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/routes/accounts.js
+++ b/backend/src/routes/accounts.js
@@ -7,6 +7,7 @@ import { sanitizeSignature } from '../services/emailSanitizer.js';
 import { validateHost } from '../services/hostValidation.js';
 import { getConnectionPolicy } from '../services/connectionPolicy.js';
 import { invalidateGtdConfigCache, sanitizeGtdFoldersDetailed, findGtdFolderCollisions, DEFAULT_GTD_FOLDERS } from '../services/gtdConfig.js';
+import { invalidateOwnerAddressesCache } from '../services/gtdTransitions.js';
 import { createKeyedSerializer } from '../utils/keyedSerializer.js';
 
 // Serialize an account's reconnect triggers so a rapid settings change (e.g. a
@@ -349,6 +350,7 @@ router.post('/:id/aliases', async (req, res) => {
     'INSERT INTO account_aliases (account_id, name, email, reply_to, signature) VALUES ($1, $2, $3, $4, $5) RETURNING *',
     [id, name, email, reply_to || null, sanitizeSignature(signature) || null]
   );
+  invalidateOwnerAddressesCache(id);
   res.json(result.rows[0]);
 });
 
@@ -361,7 +363,7 @@ router.put('/:id/aliases/:aliasId', async (req, res) => {
   }
 
   const check = await query(
-    `SELECT a.id FROM account_aliases a
+    `SELECT a.id, a.account_id FROM account_aliases a
      JOIN email_accounts e ON a.account_id = e.id
      WHERE a.id = $1 AND e.user_id = $2 AND e.id = $3`,
     [aliasId, req.session.userId, id]
@@ -372,6 +374,7 @@ router.put('/:id/aliases/:aliasId', async (req, res) => {
     'UPDATE account_aliases SET name = $1, email = $2, reply_to = $3, signature = $4 WHERE id = $5 RETURNING *',
     [name, email, reply_to || null, sanitizeSignature(signature) || null, aliasId]
   );
+  invalidateOwnerAddressesCache(check.rows[0].account_id);
   res.json(result.rows[0]);
 });
 
@@ -379,7 +382,7 @@ router.delete('/:id/aliases/:aliasId', async (req, res) => {
   const { id, aliasId } = req.params;
 
   const check = await query(
-    `SELECT a.id FROM account_aliases a
+    `SELECT a.id, a.account_id FROM account_aliases a
      JOIN email_accounts e ON a.account_id = e.id
      WHERE a.id = $1 AND e.user_id = $2 AND e.id = $3`,
     [aliasId, req.session.userId, id]
@@ -387,6 +390,7 @@ router.delete('/:id/aliases/:aliasId', async (req, res) => {
   if (!check.rows.length) return res.status(404).json({ error: 'Alias not found' });
 
   await query('DELETE FROM account_aliases WHERE id = $1', [aliasId]);
+  invalidateOwnerAddressesCache(check.rows[0].account_id);
   res.json({ ok: true });
 });
 

--- a/backend/src/services/gtdTransitions.js
+++ b/backend/src/services/gtdTransitions.js
@@ -23,15 +23,16 @@ const STRIP_RULE = {
 // ── Owner-address resolver ───────────────────────────────────────────────────
 // The addresses that count as "me" for an account: its login address plus every
 // configured alias. Aliases are unvalidated free text, so each is reduced to a bare
-// lowercase addr-spec. Cached with the same short TTL as gtdConfig, so an alias added
-// or removed via the account settings routes is picked up within CACHE_TTL_MS even
-// though nothing currently calls invalidateOwnerAddressesCache proactively.
+// lowercase addr-spec. Account-alias routes invalidate the short-lived cache after every
+// successful create/update/delete so a newly configured Fastmail masked sender is recognized
+// before the next GTD transition tick evaluates a just-ingested message; a stale owner set
+// would misclassify that self-sent message and strip its Watch copy for up to the full TTL.
 const ownerCache = new Map(); // accountId -> { value: Set<string>, expiry: number }
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
-// Exported for tests, which reuse one accountId across cases and need a clean cache
-// between them; nothing else calls this today, so an alias change surfaces only once
-// the TTL above lapses.
+// Exported for tests, which reuse one accountId across cases and need a clean cache, and for
+// the account-alias routes, which call it only after a mutation succeeds. The next resolver
+// read must observe the committed owner identities before a GTD transition can classify mail.
 export function invalidateOwnerAddressesCache(accountId) {
   ownerCache.delete(accountId);
 }

--- a/backend/src/services/gtdTransitions.test.js
+++ b/backend/src/services/gtdTransitions.test.js
@@ -67,6 +67,19 @@ describe('getOwnerAddresses', () => {
     await getOwnerAddresses('acct-1');
     expect(query).toHaveBeenCalledTimes(2);
   });
+
+  it('picks up changed aliases immediately after cache invalidation', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ addr: 'me@example.com' }, { addr: 'old@example.com' }] })
+      .mockResolvedValueOnce({ rows: [{ addr: 'me@example.com' }, { addr: 'masked@user.masked.fastmail.com' }] });
+    const cached = await getOwnerAddresses('acct-1');
+    expect(cached.has('old@example.com')).toBe(true);
+
+    invalidateOwnerAddressesCache('acct-1');
+    const refreshed = await getOwnerAddresses('acct-1');
+    expect(refreshed.has('old@example.com')).toBe(false);
+    expect(refreshed.has('masked@user.masked.fastmail.com')).toBe(true);
+  });
 });
 
 // ── runGtdTransitions ────────────────────────────────────────────────────────
@@ -119,6 +132,32 @@ describe('runGtdTransitions', () => {
     const mgr = fakeManager();
     await runGtdTransitions(mgr, account, ['t1']);
     expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 31, 'Todo');
+  });
+
+  it('keeps Watch when the newest message is from a configured Fastmail masked alias', async () => {
+    mockQuery({
+      owner: [{ addr: 'me@example.com' }, { addr: 'masked@user.masked.fastmail.com' }],
+      rows: [
+        { thread_key: 't1', uid: 32, folder: 'INBOX', from_email: 'masked@user.masked.fastmail.com', date: '2026-07-09T10:00:00Z', id: 'r1' },
+        { thread_key: 't1', uid: 33, folder: 'Watch', from_email: 'masked@user.masked.fastmail.com', date: '2026-07-09T10:00:00Z', id: 'r2' },
+      ],
+    });
+    const mgr = fakeManager();
+    await runGtdTransitions(mgr, account, ['t1']);
+    expect(mgr.removeMessageCopy).not.toHaveBeenCalledWith('acct-1', 33, 'Watch');
+  });
+
+  it('strips Watch when the newest message is from an external address instead', async () => {
+    mockQuery({
+      owner: [{ addr: 'me@example.com' }, { addr: 'masked@user.masked.fastmail.com' }],
+      rows: [
+        { thread_key: 't1', uid: 34, folder: 'INBOX', from_email: 'them@other.com', date: '2026-07-09T10:00:00Z', id: 'r1' },
+        { thread_key: 't1', uid: 35, folder: 'Watch', from_email: 'them@other.com', date: '2026-07-09T10:00:00Z', id: 'r2' },
+      ],
+    });
+    const mgr = fakeManager();
+    await runGtdTransitions(mgr, account, ['t1']);
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 35, 'Watch');
   });
 
   it('never strips Reference, whoever sent last', async () => {

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -101,16 +101,22 @@ export function connectCooldownMs(failures) {
 
 // Decide a folder's sync fetch strategy from its CONDSTORE modseq state. Pure and total so
 // it can be exhaustively unit-tested — it is the load-bearing correctness decision for delta
-// sync. Returns one of:
+// sync. A nonempty server mailbox with no local UID is an incomplete cache whose modseq
+// watermark must never be trusted: the delta path only applies flag updates and cannot insert
+// missing rows. A delta may then advance the watermark without inserting them, and a later
+// unchanged plan skips every fetch, leaving the message stranded. That state must take the
+// metadata-capable full path. Returns one of:
 //   'unchanged' — server HIGHESTMODSEQ equals our stored watermark: nothing changed, skip fetch.
-//   'delta'     — modseq advanced: one CHANGEDSINCE fetch returns every new message AND flag
-//                 change since the watermark (strictly more complete than the UID/seq phases).
+//   'delta'     — modseq advanced with a populated local cache: apply changed flags since the
+//                 watermark while the separate UID phase inserts new messages.
 //   'full'      — no usable baseline (first sync, UIDVALIDITY reset, or a server without
-//                 CONDSTORE): run the legacy UID-watermark + sequence phases and re-seed.
+//                 CONDSTORE), or an incomplete cache: run the metadata-capable sequence phase
+//                 and re-seed.
 // modseq values are 64-bit unsigned and only comparable within one UIDVALIDITY epoch — inputs
 // may be BigInt, decimal string, or null; comparison is done in BigInt to avoid Number()
 // precision loss above 2^53. NEVER compare these as JS Numbers.
-export function planModseqSync({ storedModseq, serverModseq, uidValidityChanged }) {
+export function planModseqSync({ storedModseq, serverModseq, uidValidityChanged, maxKnownUid, serverExists }) {
+  if (maxKnownUid === 0 && serverExists > 0) return 'full';
   if (uidValidityChanged) return 'full';    // epoch reset — the stored modseq is meaningless now
   if (serverModseq == null) return 'full';  // server didn't advertise CONDSTORE HIGHESTMODSEQ
   if (storedModseq == null) return 'full';  // no baseline yet — full sync seeds the watermark
@@ -122,11 +128,15 @@ const BODY_PREFETCH_PARTS = ['1', '1.1', '1.2', '2', '2.1', '2.2', '1.1.1', '1.2
 
 // The flag-change scan in syncMessages gets its OWN budget, shorter than the whole-sync
 // wall-clock. When a provider throttles the connection (iCloud right after a startup backfill
-// burst), the flag scan crawls — but new mail was already caught by the UID phase, so a slow
-// flag scan must not burn the full sync budget and force a reconnect (which piles another
-// connection onto the throttled account and feeds the churn). Instead it defers to the next
-// tick WITHOUT advancing the modseq watermark, so no flag change is lost. The sentinel is
-// resolved (not thrown) by the race so it's never confused with a real fetch error.
+// burst), the flag scan crawls. A deferred delta scan simply retries next tick because its
+// watermark was withheld and still lags the server's. A deferred full scan retries because
+// planModseqSync's empty-cache guard depends only on maxKnownUid, not the watermark — but any
+// rows the deferred scan did manage to insert before timing out raise maxKnownUid above zero,
+// so the next tick already falls through to delta plus the UID phase's own catch-up rather than
+// repeating the full scan. Either way the scan defers instead of burning the full sync budget
+// and forcing a reconnect (which piles another connection onto the throttled account and feeds
+// the churn), without losing mail or flag changes. The sentinel is resolved (not thrown) by the
+// race so it is never confused with a real fetch error.
 const FLAG_SCAN_TIMEOUT_MS = 20000;
 const FLAG_SCAN_TIMED_OUT = Symbol('flagScanTimedOut');
 
@@ -2478,16 +2488,21 @@ export class ImapManager {
           }
         };
 
-        // Fetch strategy. CRITICAL: new-mail detection is the UID-watermark phase below, which
-        // ALWAYS runs and never depends on the CONDSTORE modseq. The modseq only gates the more
-        // expensive flag-change scan. This is deliberate — a modseq that is stale or has wrongly
-        // advanced must NEVER cause missed mail. New mail always carries a UID above everything
-        // we already hold, so the UID watermark catches it regardless of what the modseq says.
-        const plan = planModseqSync({ storedModseq, serverModseq, uidValidityChanged });
+        // Fetch strategy. The UID-watermark phase below catches new mail only when the local
+        // cache already has a UID; maxKnownUid=0 skips it entirely. In a nonempty server mailbox,
+        // planModseqSync therefore treats that empty cache as incomplete and forces the bounded
+        // metadata-capable full scan through fetchQuery/processMsg, regardless of the modseq.
+        const plan = planModseqSync({
+          storedModseq,
+          serverModseq,
+          uidValidityChanged,
+          maxKnownUid,
+          serverExists: mailbox.exists,
+        });
 
-        // ── New-mail phase — ALWAYS runs (modseq-independent safety net). Fetches only UIDs
-        // above the highest we already have — usually just the newest message, then a no-op
-        // upsert. Skipped only on first sync (maxKnownUid=0), where backfill owns population.
+        // ── New-mail phase — UID-watermark safety net for a populated local cache. Fetches only
+        // UIDs above the highest we already have — usually just the newest message, then a no-op
+        // upsert. When no local UID exists, the full plan above owns metadata ingestion instead.
         if (maxKnownUid > 0) {
           try {
             for await (const msg of client.fetch(`${maxKnownUid + 1}:*`, fetchQuery, { uid: true })) {
@@ -2558,11 +2573,13 @@ export class ImapManager {
             }
           }
         } else if (plan === 'full') {
-          // No usable modseq baseline (first sync, UIDVALIDITY reset, or a server without
-          // CONDSTORE): scan recent messages by sequence for flag changes. Re-read exists from
-          // the live connection — ImapFlow may have decremented it if an EXPUNGE arrived during
-          // the UID phase, making a range captured at SELECT time stale. The watermark is seeded
-          // below so subsequent syncs can go delta.
+          // A missing/invalid modseq baseline or an incomplete local cache requires a recent
+          // sequence scan with full metadata. Re-read exists from the live connection — ImapFlow
+          // may have decremented it if an EXPUNGE arrived during the UID phase, making a range
+          // captured at SELECT time stale. The watermark is seeded below so subsequent syncs can
+          // go delta once the local cache has a UID. Bounded to the most recent `limit` messages —
+          // older un-cached messages in a large folder are backfill's job, not this scan's; backfill
+          // runs on connect/reconnect/reindex and its dbCount-vs-serverTotal check re-detects the gap.
           const liveExists = client.mailbox?.exists ?? 0;
           const phase2Range = liveExists > limit
             ? `${liveExists - limit + 1}:${liveExists}` : '1:*';

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('imapflow', () => ({ ImapFlow: vi.fn() }));
 vi.mock('./db.js', () => ({ query: vi.fn() }));
-vi.mock('./messageParser.js', () => ({ parseMessage: vi.fn(), buildSnippetFromHtml: vi.fn(), snippetFromBody: vi.fn(), decodeMimeWords: vi.fn(), detectBulkFromParsedHeaders: vi.fn(), parseRawHeaders: vi.fn() }));
+vi.mock('./messageParser.js', () => ({ parseMessage: vi.fn(), buildSnippetFromHtml: vi.fn(), snippetFromBody: vi.fn(), decodeMimeWords: vi.fn(), detectBulkFromParsedHeaders: vi.fn(), parseRawHeaders: vi.fn(), enrichParsedMetadata: vi.fn((parsed) => parsed) }));
 vi.mock('../routes/oauth.js', () => ({ refreshMicrosoftToken: vi.fn() }));
 vi.mock('./emailSanitizer.js', () => ({ sanitizeEmail: vi.fn() }));
 vi.mock('./encryption.js', () => ({ decrypt: vi.fn() }));
@@ -11,10 +11,11 @@ vi.mock('../utils/redact.js', () => ({ redactEmail: vi.fn() }));
 vi.mock('./hostValidation.js', () => ({ resolveForConnection: vi.fn() }));
 vi.mock('./gtdTransitions.js', () => ({ runGtdTransitions: vi.fn(), threadKeysForMessageIds: vi.fn(), threadKeysInFolders: vi.fn() }));
 
-import { providerProfile, makeClientCfg, gtdRelocateGuard, insertCopiedSibling, deleteMessageCopyRow, emitAfterDeferredCopySync, emitGtdSectionsRefreshOnDelete, emitGtdSectionsRefreshIfEnabled, selectGtdReevalIds, ensureMailbox, runGtdSyncTick, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, planModseqSync, connectStaggerFor } from './imapManager.js';
+import { ImapManager, providerProfile, makeClientCfg, gtdRelocateGuard, insertCopiedSibling, deleteMessageCopyRow, emitAfterDeferredCopySync, emitGtdSectionsRefreshOnDelete, emitGtdSectionsRefreshIfEnabled, selectGtdReevalIds, ensureMailbox, runGtdSyncTick, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, planModseqSync, connectStaggerFor } from './imapManager.js';
 import { query } from './db.js';
 import { invalidateGtdConfigCache } from './gtdConfig.js';
 import { runGtdTransitions, threadKeysInFolders } from './gtdTransitions.js';
+import { parseMessage } from './messageParser.js';
 
 const account = (imap_host, oauth_provider = null) => ({ imap_host, oauth_provider });
 
@@ -703,7 +704,7 @@ describe('runGtdSyncTick', () => {
     threadKeysInFolders.mockReset();
     [
       'acct-tick-noconn', 'acct-tick-err', 'acct-tick-off',
-      'acct-tick-same', 'acct-tick-changed', 'acct-tick-partial',
+      'acct-tick-same', 'acct-tick-changed', 'acct-tick-first', 'acct-tick-partial',
     ].forEach(invalidateGtdConfigCache);
   });
 
@@ -763,6 +764,21 @@ describe('runGtdSyncTick', () => {
     expect(runGtdTransitions).toHaveBeenCalledWith(mgr, account, ['thr-1', 'thr-2']);
     expect(mgr.broadcast).toHaveBeenCalledTimes(1);
     expect(mgr.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'acct-tick-changed' }, 'user-1');
+  });
+
+  it('broadcasts gtd_sections_updated when an empty folder gains its first message', async () => {
+    const allWatch = { todo: 'Watch', watch: 'Watch', delegated: 'Watch', someday: 'Watch', reference: 'Watch' };
+    query.mockResolvedValueOnce({ rows: [{ gtd_enabled: true, gtd_folders: allWatch }] });
+    threadKeysInFolders.mockResolvedValueOnce(['thr-first']);
+    const mgr = mgrWithConnection('acct-tick-first', {
+      _gtdFolderFingerprint: vi.fn()
+        .mockResolvedValueOnce('0:0:0:0')
+        .mockResolvedValueOnce('1:1:5:5'),
+    });
+    const account = { id: 'acct-tick-first', user_id: 'user-1' };
+    await runGtdSyncTick(mgr, account);
+    expect(runGtdTransitions).toHaveBeenCalledWith(mgr, account, ['thr-first']);
+    expect(mgr.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'acct-tick-first' }, 'user-1');
   });
 
   it('keeps processing remaining folders when one folder sync throws', async () => {
@@ -939,6 +955,45 @@ describe('connectStaggerFor', () => {
 // ── planModseqSync — CONDSTORE delta-sync strategy decision ────────────────────
 
 describe('planModseqSync', () => {
+  it('forces a full sync when the local cache is empty but a nonempty server has an equal modseq', () => {
+    expect(planModseqSync({
+      storedModseq: '100',
+      serverModseq: '100',
+      uidValidityChanged: false,
+      maxKnownUid: 0,
+      serverExists: 1,
+    })).toBe('full');
+  });
+
+  it('forces a full sync when the local cache is empty and the server modseq advanced', () => {
+    expect(planModseqSync({
+      storedModseq: '100',
+      serverModseq: '101',
+      uidValidityChanged: false,
+      maxKnownUid: 0,
+      serverExists: 1,
+    })).toBe('full');
+  });
+
+  it('leaves an empty local cache and empty server unchanged when the modseqs match', () => {
+    expect(planModseqSync({
+      storedModseq: '100',
+      serverModseq: '100',
+      uidValidityChanged: false,
+      maxKnownUid: 0,
+      serverExists: 0,
+    })).toBe('unchanged');
+  });
+
+  it('retains the existing CONDSTORE plans when the local cache has a UID watermark', () => {
+    const localState = { maxKnownUid: 50, serverExists: 50 };
+    expect(planModseqSync({ ...localState, storedModseq: '100', serverModseq: '100', uidValidityChanged: false })).toBe('unchanged');
+    expect(planModseqSync({ ...localState, storedModseq: '100', serverModseq: '101', uidValidityChanged: false })).toBe('delta');
+    expect(planModseqSync({ ...localState, storedModseq: '100', serverModseq: '100', uidValidityChanged: true })).toBe('full');
+    expect(planModseqSync({ ...localState, storedModseq: null, serverModseq: '100', uidValidityChanged: false })).toBe('full');
+    expect(planModseqSync({ ...localState, storedModseq: '100', serverModseq: null, uidValidityChanged: false })).toBe('full');
+  });
+
   it('falls back to full sync when there is no stored baseline (first sync / seed)', () => {
     expect(planModseqSync({ storedModseq: null, serverModseq: '42', uidValidityChanged: false })).toBe('full');
   });
@@ -975,5 +1030,123 @@ describe('planModseqSync', () => {
     expect(Number(a) === Number(b)).toBe(true);            // the trap we must avoid
     expect(planModseqSync({ storedModseq: a, serverModseq: b, uidValidityChanged: false })).toBe('delta');
     expect(planModseqSync({ storedModseq: b, serverModseq: b, uidValidityChanged: false })).toBe('unchanged');
+  });
+});
+
+// ── syncMessages — empty-cache/modseq wiring ─────────────────────────────────
+
+describe('syncMessages — empty local cache vs nonempty server (wiring)', () => {
+  beforeEach(() => {
+    query.mockReset();
+    parseMessage.mockReset();
+    ['acct-sync-empty-cache', 'acct-sync-watermark'].forEach(invalidateGtdConfigCache);
+  });
+
+  it('empty cache forces the full metadata scan', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache',
+      user_id: 'user-1',
+      email_address: 'me@example.com',
+      gtd_enabled: false,
+      categorization_enabled: false,
+      imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 1, uidValidity: 100, highestModseq: 500n },
+      fetch: vi.fn(async function* () { yield { uid: 501 }; }),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: '500' }] });
+      }
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false)')) return Promise.resolve({ rows: [{ n: 0 }] });
+      if (sql.includes('INSERT INTO folders')) return Promise.resolve({ rows: [] });
+      if (sql.includes('COALESCE(MAX(uid), 0)')) return Promise.resolve({ rows: [{ max_uid: 0 }] });
+      if (sql.includes('SELECT gtd_enabled, gtd_folders FROM email_accounts')) {
+        return Promise.resolve({ rows: [{ gtd_enabled: false, gtd_folders: {} }] });
+      }
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'msg-1', is_new: true }] });
+      if (sql.includes('UPDATE folders SET highest_modseq')) return Promise.resolve({ rows: [] });
+      if (sql.includes('UPDATE email_accounts SET last_sync')) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockResolvedValue({
+      uid: 501,
+      messageId: null,
+      subject: 'Watch first message',
+      fromName: 'External',
+      fromEmail: 'them@example.com',
+      to: [],
+      cc: [],
+      replyTo: [],
+      inReplyTo: null,
+      references: null,
+      date: new Date('2026-07-17T10:00:00Z'),
+      snippet: 'hi',
+      isRead: true,
+      isStarred: false,
+      hasAttachments: false,
+      flags: ['\\Seen'],
+      isBulk: false,
+      parsedHeaders: {},
+    });
+
+    const result = await ImapManager.prototype.syncMessages.call({}, account, client, 'Watch', 50, false, true);
+
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+    expect(client.fetch.mock.calls[0][0]).toBe('1:*');
+    expect(client.fetch.mock.calls[0][1]).toEqual(expect.objectContaining({
+      envelope: true,
+      bodyStructure: true,
+      flags: true,
+      uid: true,
+    }));
+    expect(client.fetch.mock.calls[0][2]).toBeUndefined();
+    const insertIndex = query.mock.calls.findIndex(([sql]) => sql.includes('INSERT INTO messages'));
+    const modseqUpdateIndex = query.mock.calls.findIndex(([sql]) => sql.includes('UPDATE folders SET highest_modseq'));
+    expect(insertIndex).toBeGreaterThanOrEqual(0);
+    expect(modseqUpdateIndex).toBeGreaterThan(insertIndex);
+    expect(result).toEqual(expect.objectContaining({ insertedCount: 1 }));
+  });
+
+  it('populated cache keeps the old UID-watermark behavior', async () => {
+    const account = {
+      id: 'acct-sync-watermark',
+      user_id: 'user-1',
+      email_address: 'me@example.com',
+      gtd_enabled: false,
+      categorization_enabled: false,
+      imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 50, uidValidity: 100, highestModseq: 500n },
+      fetch: vi.fn(async function* () {}),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: '500' }] });
+      }
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false)')) return Promise.resolve({ rows: [{ n: 0 }] });
+      if (sql.includes('INSERT INTO folders')) return Promise.resolve({ rows: [] });
+      if (sql.includes('COALESCE(MAX(uid), 0)')) return Promise.resolve({ rows: [{ max_uid: 50 }] });
+      if (sql.includes('SELECT gtd_enabled, gtd_folders FROM email_accounts')) {
+        return Promise.resolve({ rows: [{ gtd_enabled: false, gtd_folders: {} }] });
+      }
+      if (sql.includes('UPDATE email_accounts SET last_sync')) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    await ImapManager.prototype.syncMessages.call({}, account, client, 'Watch', 50, false, true);
+
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+    expect(client.fetch).toHaveBeenCalledWith(
+      '51:*',
+      expect.objectContaining({ envelope: true, bodyStructure: true }),
+      { uid: true }
+    );
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

A folder that seeds its CONDSTORE baseline while empty can never ingest its first message: with no local UID the new-mail phase is skipped, the delta path only updates flags, and the watermark still advances — so the miss becomes permanent. Hit in production on a GTD Watch folder (server count 1, zero cached rows). Separately, alias changes took up to the owner-cache TTL to count as "me", long enough for the GTD engine to strip Watch from a just-ingested self-sent message.

## Changes

- `planModseqSync` treats an empty local cache with a nonempty server mailbox as an incomplete cache and forces the metadata-capable full scan, regardless of modseq. The scan stays bounded; historical gaps remain backfill's job.
- Alias create/update/delete invalidate the GTD owner-address cache immediately.
- Corrected sync comments that claimed the UID phase "ALWAYS runs".

## Testing

- Unit tests pin the new `planModseqSync` states; an integration test drives the real `syncMessages` through the exact production state and fails pre-fix.
- Route tests cover invalidation on success/404/failure; GTD tests cover masked-alias sender keeping Watch vs external sender clearing it.
- Full backend suite + lint green on Node 22.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
