### PR TITLE
fix: linear-time tag stripping so bare-'<' bodies can't stall snippet ingest

### DIFF
--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -73,6 +73,10 @@ function snippetIsGarbled(s) {
     /&[a-z][a-z0-9]*;/i.test(s) ||   // undecoded HTML entity
     /##[^#]*##/.test(s) ||             // unexpanded template placeholder
     /-->/.test(s) ||                   // dangling HTML comment fragment
+    /\{[^}]*[:;][^}]*\}/.test(s) ||   // stored CSS rule block
+    /<[a-z][^>]*>/i.test(s) ||         // raw HTML tag
+    /<\/[a-z][a-z0-9:-]*\s*>/i.test(s) || // stray closing HTML tag
+    /([=_*#~-])\1{3,}/.test(s) ||      // decorative divider run
     /\[[^\]]+\]\(https?:\/\//.test(s)  // Markdown link syntax from ESP text/plain generators
   );
 }

--- a/backend/src/services/messageParser.js
+++ b/backend/src/services/messageParser.js
@@ -44,15 +44,26 @@ export function decodeNamedEntity(_, name) {
 }
 
 // Detect a text/plain part that is actually a raw HTML document — some senders
-// put the full HTML body in the text/plain alternative. A document-level opener
-// is definitive; otherwise require several closing tags near the start so prose
-// that merely mentions a tag ("use the <b> element") is not misrouted. Only the
-// head of the body is scanned to keep this cheap on large messages.
+// put the full HTML body in the text/plain alternative. A document-level opener,
+// attribute-bearing tag, or style/script block is definitive; otherwise require
+// several closing tags near the start so prose that merely mentions an
+// attribute-less tag ("use the <b> element") is not misrouted. Only the head is
+// scanned to keep this cheap on large messages.
 function looksLikeHtml(text) {
   const head = text.slice(0, 2048);
   if (/^\s*<(?:!doctype|html|head|body)[\s>]/i.test(head)) return true;
+  if (/<[a-z][a-z0-9]*\s[^>]*=[^>]*>/i.test(head)) return true;
+  if (/<(?:style|script)[\s>]/i.test(head)) return true;
   const closingTags = head.match(/<\/[a-z][a-z0-9]*\s*>/gi);
   return closingTags !== null && closingTags.length >= 3;
+}
+
+// Lossy text/plain conversions can retain markup while omitting text that is
+// still present in the sibling HTML part.
+function isDegenerateText(text) {
+  return /<!--/.test(text)
+    || /<\/[a-z][a-z0-9:-]*\s*>/i.test(text)
+    || /^\s*(?:\(\s*\)|\[\s*\]|<\s*>)/.test(text);
 }
 
 // Build a plain-text snippet from either a decoded text/plain or text/html body.
@@ -66,12 +77,32 @@ export function snippetFromBody(text, html) {
     if (stripped) return stripped;
     text = '';
   }
+  if (html && text && isDegenerateText(text)) {
+    const stripped = buildSnippetFromHtml(html);
+    if (stripped) return stripped;
+  }
   if (text) {
-    const cleaned = text
+    let cleaned = text
       // Strip [image: alt text] placeholders produced by Google's HTML-to-text converter
       // and some ESPs. These appear at the top of text/plain alternatives for image-heavy
       // marketing emails and produce useless "[image: Banner]" previews.
-      .replace(/\[image:[^\]]*\]/gi, '')
+      .replace(/\[image:[^\]]*\]/gi, '');
+    // A declaration separator distinguishes CSS blocks from prose braces. Body
+    // text is attacker-controlled and this runs synchronously at ingest, so the
+    // pattern must stay linear: the includes() gate skips brace-free bodies
+    // outright; the lookbehind only attempts runs from their first character
+    // (where the leftmost match always starts, so behavior is unchanged)
+    // instead of re-scanning from every position; the selector scan is capped
+    // at 160 characters; and the lookahead finds the separator in one forward
+    // pass rather than a backtracking [^{}]*[:;][^{}]* split.
+    if (cleaned.includes('{')) {
+      cleaned = cleaned.replace(/(?<=^|[\s{}<>])[^\s{}<>][^{}<>]{0,160}\{(?=[^{}]*[:;])[^{}]*\}/g, ' ');
+    }
+    cleaned = cleaned
+      // Converted plain-text parts can retain comments or closing markup even
+      // when no HTML sibling is available for a cleaner fallback.
+      .replace(/<!--[\s\S]*?(?:-->|$)/gi, ' ')
+      .replace(/<\/[a-z][a-z0-9:-]*\s*>/gi, ' ')
       // Strip Markdown-style [label](url) links — ESPs like Klaviyo generate text/plain
       // by converting HTML anchors to Markdown, so the entire body can be link syntax.
       // Must run before the bare-URL pass below: stripping the URL first would leave
@@ -96,6 +127,10 @@ export function snippetFromBody(text, html) {
       .replace(/\(\s*\)|\[\s*\]|<\s*>/g, ' ')
       // Drop standalone runs of Markdown emphasis/divider chars ("**", "____").
       .replace(/(?<=^|\s)[*_]{2,}(?=\s|$)/g, '')
+      .replace(/\s+/g, ' ').trim()
+      // Whitespace boundaries keep short or inline Markdown and signature
+      // syntax intact while removing long runs used only as decoration.
+      .replace(/(?<=^|\s)([=_*#~-])\1{3,}(?=\s|$)/g, '')
       .replace(/\s+/g, ' ').trim();
     if (cleaned) return cleaned.substring(0, 200);
     // Text body was entirely image placeholders — fall through to HTML.
@@ -111,17 +146,23 @@ export function snippetFromBody(text, html) {
 // pre-fetched raw HTML bodies (avoiding duplicated, inconsistent entity handling).
 export function buildSnippetFromHtml(html) {
   return html
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
+    // Strip the enclosing head first so an unclosed nested style cannot consume
+    // visible body content while falling back to the end of the document.
+    .replace(/<head\b[^>]*>[\s\S]*?(?:<\/head\s*>|$)/gi, '')
+    .replace(/<style\b[^>]*>[\s\S]*?(?:<\/style\s*>|$)/gi, '')
+    .replace(/<script\b[^>]*>[\s\S]*?(?:<\/script\s*>|$)/gi, '')
     // Strip HTML comments (including MSO conditional comments) before tag
     // stripping — otherwise dangling --> fragments and comment content leak
     // into the snippet text (e.g. UPS ##varLangText1## template markers sit
     // inside comments and survive tag-only regex stripping).
-    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<!--[\s\S]*?(?:-->|$)/gi, '')
     // Strip ##marker## template placeholders emitted by some marketing tools
     // (UPS, Epsilon) that don't fully render before sending.
     .replace(/##[^#]*##/g, '')
-    .replace(/<[^>]+>/g, ' ')
+    .replace(/<(?:[^>"']|"[^"]*"|'[^']*')+>/g, ' ')
+    // A tag with no closing angle bracket bypasses the tag matcher and would
+    // otherwise become literal preview text through the end of the body.
+    .replace(/<\/?[a-z][a-z0-9:-]*(?:\s+[\s\S]*)?$/gi, ' ')
     .replace(/&nbsp;/gi, ' ')
     .replace(/&amp;/gi, '&')
     .replace(/&lt;/gi, '<')
@@ -132,6 +173,7 @@ export function buildSnippetFromHtml(html) {
     .replace(/&#([0-9]+);/g, (_, d) => String.fromCodePoint(parseInt(d, 10)))
     .replace(/&([a-z][a-z0-9]*);/gi, decodeNamedEntity)
     .replace(INVISIBLE_CHARS_RE, '')
+    .replace(/(?<=^|\s)([=_*#~-])\1{3,}(?=\s|$)/g, '')
     .replace(/\s+/g, ' ').trim().substring(0, 200);
 }
 
@@ -142,14 +184,26 @@ function findSnippetPart(structure) {
   const type = (structure.type || '').toLowerCase();
 
   if (structure.childNodes?.length) {
-    let htmlFallback = null;
+    let plainPart = null;
+    let htmlPart = null;
     for (const child of structure.childNodes) {
       const found = findSnippetPart(child);
       if (!found) continue;
-      if (found.type === 'text/plain') return found;
-      if (!htmlFallback) htmlFallback = found;
+      if (found.type === 'text/plain') {
+        if (!plainPart) plainPart = found;
+      } else if (!htmlPart) {
+        htmlPart = found;
+      }
     }
-    return htmlFallback;
+    if (plainPart) {
+      return {
+        ...plainPart,
+        // A nested multipart/alternative owns the most relevant fallback;
+        // otherwise use the HTML sibling discovered at this level.
+        htmlFallback: plainPart.htmlFallback || htmlPart || undefined,
+      };
+    }
+    return htmlPart;
   }
 
   const disposition = (structure.disposition || '').toLowerCase();
@@ -161,6 +215,7 @@ function findSnippetPart(structure) {
       type,
       encoding: (structure.encoding || '').toLowerCase(),
       charset: structure.parameters?.charset || 'utf-8',
+      htmlFallback: undefined,
     };
   }
   return null;
@@ -506,9 +561,18 @@ export async function parseMessage(msg) {
     if (rawBuf) {
       try {
         const text = decodeBodyPart(rawBuf, encoding, charset);
+        let htmlFallbackText;
+        if (!isHtml && partInfo?.htmlFallback && msg.bodyParts.has(partInfo.htmlFallback.part)) {
+          const fallback = partInfo.htmlFallback;
+          htmlFallbackText = decodeBodyPart(
+            msg.bodyParts.get(fallback.part),
+            fallback.encoding,
+            fallback.charset || 'utf-8'
+          );
+        }
         // Route through the canonical snippet builders so sync-time snippets get
         // the same link/markup/entity cleanup as body prefetch and backfill.
-        snippet = isHtml ? buildSnippetFromHtml(text) : snippetFromBody(text);
+        snippet = isHtml ? buildSnippetFromHtml(text) : snippetFromBody(text, htmlFallbackText);
       } catch { /* leave snippet empty on parse failure */ }
     }
   }

--- a/backend/src/services/messageParser.js
+++ b/backend/src/services/messageParser.js
@@ -141,11 +141,55 @@ export function snippetFromBody(text, html) {
   return '';
 }
 
+// Remove tags the way /<(?:[^>"']|"[^"]*"|'[^']*')+>/g did, but in linear
+// time. That regex admits exactly one parse at every character — a quote can
+// only open a quoted attribute value, whose contents run to the next same
+// quote, and any other character is a single content unit — so a tag's
+// closing '>' depends only on the position the scan is at, never on how it
+// got there. close[q] memoizes that walk right-to-left; the regex's repeated
+// left-to-right rescans made bodies full of bare '<' with no '>' quadratic
+// (minutes of ingest stall on crafted or merely unlucky large messages).
+function stripTags(html) {
+  let lt = html.indexOf('<');
+  if (lt === -1) return html;
+  const n = html.length;
+  // close[q]: index of the '>' that ends a tag whose content scan reached q,
+  // or -1 when the scan would run off the end of the string.
+  const close = new Int32Array(n + 1);
+  close[n] = -1;
+  let nextDouble = -1;
+  let nextSingle = -1;
+  for (let q = n - 1; q >= 0; q--) {
+    const c = html.charCodeAt(q);
+    if (c === 62 /* > */) close[q] = q;
+    else if (c === 34 /* " */) close[q] = nextDouble === -1 ? -1 : close[nextDouble + 1];
+    else if (c === 39 /* ' */) close[q] = nextSingle === -1 ? -1 : close[nextSingle + 1];
+    else close[q] = close[q + 1];
+    if (c === 34) nextDouble = q;
+    else if (c === 39) nextSingle = q;
+  }
+  let out = '';
+  let copied = 0;
+  while (lt !== -1) {
+    const end = close[lt + 1];
+    // end === lt + 1 is '<>', which the regex left alone (it required at
+    // least one content character); the bracket collapse sweeps those up.
+    if (end !== -1 && end > lt + 1) {
+      out += html.slice(copied, lt) + ' ';
+      copied = end + 1;
+      lt = html.indexOf('<', copied);
+    } else {
+      lt = html.indexOf('<', lt + 1);
+    }
+  }
+  return out + html.slice(copied);
+}
+
 // Strip HTML markup and decode all entities to produce a plain-text snippet.
 // Exported so imapManager can use the same logic when building snippets from
 // pre-fetched raw HTML bodies (avoiding duplicated, inconsistent entity handling).
 export function buildSnippetFromHtml(html) {
-  return html
+  const untagged = stripTags(html
     // Strip the enclosing head first so an unclosed nested style cannot consume
     // visible body content while falling back to the end of the document.
     .replace(/<head\b[^>]*>[\s\S]*?(?:<\/head\s*>|$)/gi, '')
@@ -158,8 +202,8 @@ export function buildSnippetFromHtml(html) {
     .replace(/<!--[\s\S]*?(?:-->|$)/gi, '')
     // Strip ##marker## template placeholders emitted by some marketing tools
     // (UPS, Epsilon) that don't fully render before sending.
-    .replace(/##[^#]*##/g, '')
-    .replace(/<(?:[^>"']|"[^"]*"|'[^']*')+>/g, ' ')
+    .replace(/##[^#]*##/g, ''));
+  return untagged
     // A tag with no closing angle bracket bypasses the tag matcher and would
     // otherwise become literal preview text through the end of the body.
     .replace(/<\/?[a-z][a-z0-9:-]*(?:\s+[\s\S]*)?$/gi, ' ')

--- a/backend/src/services/messageParser.snippet.test.js
+++ b/backend/src/services/messageParser.snippet.test.js
@@ -1,6 +1,19 @@
 import { describe, it, expect } from 'vitest';
 import { buildSnippetFromHtml, parseMessage, snippetFromBody } from './messageParser.js';
 
+// Timing assertions use the fastest of a few runs so GC pauses and cold-JIT
+// noise cannot flake CI; an accidental return to quadratic scanning is
+// orders of magnitude over these thresholds (minutes, not milliseconds).
+function fastestRunMs(fn, runs) {
+  let fastest = Infinity;
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    fn();
+    fastest = Math.min(fastest, performance.now() - start);
+  }
+  return fastest;
+}
+
 describe('buildSnippetFromHtml', () => {
   it('drops CSS from an unclosed style block inside the document head', () => {
     const html = '<html><head><style>body{max-width:740px}h1{font-size:30px;color:#000}<title>Newsletter</head><body><p>Hello</p></body></html>';
@@ -45,6 +58,30 @@ describe('buildSnippetFromHtml', () => {
   it('drops a decorative divider run from visible HTML text', () => {
     const html = '<p>========================================</p><p>Visible content</p>';
     expect(buildSnippetFromHtml(html)).toBe('Visible content');
+  });
+
+  it('keeps a bare less-than sign in prose that never closes as a tag', () => {
+    const html = 'checking that 5 < 10 still reads as prose';
+    expect(buildSnippetFromHtml(html)).toBe(html);
+  });
+
+  it('finishes a ~300KB body full of bare less-than signs well under 50ms', () => {
+    const html = 'a < b and c '.repeat(25000);
+    expect(buildSnippetFromHtml(html)).toContain('a < b and c');
+    expect(fastestRunMs(() => buildSnippetFromHtml(html), 3)).toBeLessThan(50);
+  });
+
+  it('stays linear on crafted ~300KB tag-heavy bodies', () => {
+    // Dangling opens, unpaired quotes, and quoted '>' runs are the shapes
+    // that force a backtracking tag matcher to rescan the whole tail.
+    const danglingOpens = '<a '.repeat(100000);
+    const unpairedQuotes = ('<a"x ').repeat(60000);
+    const quotedGtRuns = ('<"' + '>'.repeat(10) + '"').repeat(23000);
+    expect(fastestRunMs(() => {
+      buildSnippetFromHtml(danglingOpens);
+      buildSnippetFromHtml(unpairedQuotes);
+      buildSnippetFromHtml(quotedGtRuns);
+    }, 2)).toBeLessThan(500);
   });
 });
 
@@ -103,19 +140,6 @@ describe('snippetFromBody', () => {
     const text = 'Trouble viewing this email? .preheader { display: none; } Read the highlights below.';
     expect(snippetFromBody(text)).toBe('Read the highlights below.');
   });
-
-  // Timing assertions use the fastest of a few runs so GC pauses and cold-JIT
-  // noise cannot flake CI; an accidental return to quadratic scanning is
-  // orders of magnitude over these thresholds (minutes, not milliseconds).
-  function fastestRunMs(fn, runs) {
-    let fastest = Infinity;
-    for (let i = 0; i < runs; i++) {
-      const start = performance.now();
-      fn();
-      fastest = Math.min(fastest, performance.now() - start);
-    }
-    return fastest;
-  }
 
   it('finishes a ~200KB brace-free body well under 50ms', () => {
     const text = 'newsletter content with plenty of ordinary prose words here '.repeat(3400);

--- a/backend/src/services/messageParser.snippet.test.js
+++ b/backend/src/services/messageParser.snippet.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { buildSnippetFromHtml, parseMessage, snippetFromBody } from './messageParser.js';
+
+describe('buildSnippetFromHtml', () => {
+  it('drops CSS from an unclosed style block inside the document head', () => {
+    const html = '<html><head><style>body{max-width:740px}h1{font-size:30px;color:#000}<title>Newsletter</head><body><p>Hello</p></body></html>';
+    expect(buildSnippetFromHtml(html)).toBe('Hello');
+  });
+
+  it('strips a tag when an attribute contains a greater-than sign', () => {
+    const html = '<p style="height:0;margin:0;"><img alt=\'Track Resource\' src="https://example.com/track?a=1>2" /></p><p>Real content here</p>';
+    expect(buildSnippetFromHtml(html)).toBe('Real content here');
+  });
+
+  it('drops script contents when the block never closes', () => {
+    const html = '<p>Visible content</p><script>window.track("<p>hidden marker</p>");';
+    expect(buildSnippetFromHtml(html)).toBe('Visible content');
+  });
+
+  it('drops HTML comment contents when the comment never closes', () => {
+    const html = '<p>Visible content</p><!-- hidden <b>comment marker</b>';
+    expect(buildSnippetFromHtml(html)).toBe('Visible content');
+  });
+
+  it('drops a dangling tag-open fragment', () => {
+    const html = '<p>Visible content</p><img alt="tracking pixel"';
+    expect(buildSnippetFromHtml(html)).toBe('Visible content');
+  });
+
+  it('strips ordinary HTML tags', () => {
+    const html = '<section><p>Hello <strong>ordinary</strong> markup</p><br></section>';
+    expect(buildSnippetFromHtml(html)).toBe('Hello ordinary markup');
+  });
+
+  it('decodes HTML entities after stripping markup', () => {
+    const html = '<p>Fish &amp; chips&nbsp;&hellip; &#x2014; &#169; &quot;yes&quot; &apos;ok&apos; &lt;done&gt;</p>';
+    expect(buildSnippetFromHtml(html)).toBe('Fish & chips … — © "yes" \'ok\' <done>');
+  });
+
+  it('drops closed HTML comments with their contents', () => {
+    const html = '<p>Before</p><!-- hidden production marker --><p>After</p>';
+    expect(buildSnippetFromHtml(html)).toBe('Before After');
+  });
+
+  it('drops a decorative divider run from visible HTML text', () => {
+    const html = '<p>========================================</p><p>Visible content</p>';
+    expect(buildSnippetFromHtml(html)).toBe('Visible content');
+  });
+});
+
+describe('snippetFromBody', () => {
+  it('keeps a plain-text digest with divider rule lines clean', () => {
+    const text = '***************\r\nWeekly Digest\r\n***************\r\n\r\n-----\r\nPosts\r\n-----\r\n\r\nWhat it takes to launch a new product this year\r\n\r\nWe were just about...';
+    expect(snippetFromBody(text)).toBe("Weekly Digest Posts What it takes to launch a new product this year We were just about...");
+  });
+
+  it('drops bare CSS rule blocks while keeping the visible text', () => {
+    const text = 'body{max-width:740px}h1{font-size:30px;color:#000}\n\nWelcome to our newsletter, here is what is new this week.';
+    expect(snippetFromBody(text)).toBe('Welcome to our newsletter, here is what is new this week.');
+  });
+
+  it('routes an attribute-carrying HTML fragment through the HTML stripper', () => {
+    const text = '<p style="height:0;margin:0;"><img alt="Track" src="https://example.com/pixel.gif"></p>\nThanks for your order, it is on its way.';
+    expect(snippetFromBody(text)).toBe('Thanks for your order, it is on its way.');
+  });
+
+  it('routes a standalone style block through the HTML stripper', () => {
+    const text = '<style>body{max-width:740px}</style>Actual content here';
+    expect(snippetFromBody(text)).toBe('Actual content here');
+  });
+
+  it('keeps prose braces without CSS declaration separators byte-identical', () => {
+    const text = 'The set is defined as {1, 2, 3} for this example.';
+    expect(snippetFromBody(text)).toBe(text);
+  });
+
+  it('keeps an attribute-less HTML tag mentioned in prose byte-identical', () => {
+    const text = 'Use the <b> tag for bold; multiply with 2 * 3 and keep snake_case names';
+    expect(snippetFromBody(text)).toBe(text);
+  });
+
+  it('strips stray closing tags and HTML comments without an HTML fallback', () => {
+    const text = 'Before</b> middle <!-- hidden marker -->after';
+    expect(snippetFromBody(text)).toBe('Before middle after');
+  });
+
+  it('drops a leading decorative divider run', () => {
+    const text = '======================================== Learn more about our product and how it can help you save time.';
+    expect(snippetFromBody(text)).toBe('Learn more about our product and how it can help you save time.');
+  });
+
+  it('keeps two-character signature delimiters and three-character Markdown rules', () => {
+    const text = 'Message complete -- Signature follows --- Markdown rule';
+    expect(snippetFromBody(text)).toBe(text);
+  });
+
+  it('keeps ordinary plain text byte-identical', () => {
+    const text = 'Your report is ready for review at 3:00 PM.';
+    expect(snippetFromBody(text)).toBe(text);
+  });
+
+  it('strips a mid-prose CSS block together with its preceding selector run', () => {
+    const text = 'Trouble viewing this email? .preheader { display: none; } Read the highlights below.';
+    expect(snippetFromBody(text)).toBe('Read the highlights below.');
+  });
+
+  // Timing assertions use the fastest of a few runs so GC pauses and cold-JIT
+  // noise cannot flake CI; an accidental return to quadratic scanning is
+  // orders of magnitude over these thresholds (minutes, not milliseconds).
+  function fastestRunMs(fn, runs) {
+    let fastest = Infinity;
+    for (let i = 0; i < runs; i++) {
+      const start = performance.now();
+      fn();
+      fastest = Math.min(fastest, performance.now() - start);
+    }
+    return fastest;
+  }
+
+  it('finishes a ~200KB brace-free body well under 50ms', () => {
+    const text = 'newsletter content with plenty of ordinary prose words here '.repeat(3400);
+    const snippet = snippetFromBody(text);
+    expect(snippet).toHaveLength(200);
+    expect(text.startsWith(snippet)).toBe(true);
+    expect(fastestRunMs(() => snippetFromBody(text), 3)).toBeLessThan(50);
+  });
+
+  it('stays linear on crafted ~300KB brace-bearing bodies', () => {
+    // A lone brace defeats a bare includes() gate; separator runs defeat a
+    // bounded scan that still backtracks through the declaration content.
+    const loneBrace = 'x{' + 'ordinary prose words here '.repeat(12000);
+    const separatorRuns = ('a{' + ';'.repeat(6000)).repeat(50);
+    expect(fastestRunMs(() => {
+      snippetFromBody(loneBrace);
+      snippetFromBody(separatorRuns);
+    }, 2)).toBeLessThan(500);
+  });
+});
+
+describe('parseMessage', () => {
+  it('prefers the HTML sibling when a text/plain part is degenerate', async () => {
+    const text = ' ()\r\n\r\nRelink to \r\n\r\nWe stopped importing transactions from  because we lost connection! To fix this we need you to go through the process of relinking to ?</b> Simply reply...\r\n\r\n<!-- Action -->\r\nGo to my accounts';
+    const html = '<html><body><h1>Relink to Examplebank (Canada)</h1><p>Reconnect your account.</p></body></html>';
+    const parsed = await parseMessage({
+      uid: 1,
+      envelope: { subject: 'Relink account', from: [{ name: 'Budget App', address: 'support@budget.example' }] },
+      flags: new Set(),
+      bodyStructure: {
+        type: 'multipart/alternative',
+        childNodes: [
+          { type: 'text/plain', part: '1.1', encoding: '7bit', parameters: { charset: 'utf-8' } },
+          { type: 'text/html', part: '1.2', encoding: '7bit', parameters: { charset: 'utf-8' } },
+        ],
+      },
+      bodyParts: new Map([
+        ['1.1', Buffer.from(text)],
+        ['1.2', Buffer.from(html)],
+      ]),
+    });
+
+    expect(parsed.snippet).toContain('Relink to Examplebank (Canada)');
+    expect(parsed.snippet).not.toContain('</b>');
+    expect(parsed.snippet).not.toContain('<!--');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #285, fixing the pre-existing quadratic flagged there while profiling: the tag-strip scan in `buildSnippetFromHtml` rescanned from every `<` toward a closing `>`, so a body with many bare less-than signs and none after them — crafted, or just unlucky prose in an HTML part — cost O(n²). A 300KB body took ~60s, synchronously, at ingest. This predates #285: `main`'s `<[^>]+>` measures the same ~61s on the same input.

## Changes

- The quote-aware tag regex admits exactly one parse at every character (a quote can only open an attribute value that runs to its matching quote), so where a tag closes is a pure function of the scan position. `stripTags` memoizes that walk in one right-to-left pass, then strips tags left-to-right with the regex's leftmost-match semantics.
- No caps or heuristics, so long-but-legitimate tags (inline styles, data-URI images) still strip instead of leaking into previews.

## Testing

- Byte-identical output to the old regex on 50k fuzzed markup samples over a `<>"'`-heavy alphabet, plus all existing fixtures.
- The crafted shapes (dangling opens, unpaired quotes, quoted-`>` runs) finish in single-digit milliseconds at 300KB; timing regression tests pin the envelopes using fastest-of-N runs so CI GC pauses can't flake them.
- Full backend suite green on Node 22 (655 tests).

> **Note:** stacked on #285 (both PRs edit the same function) — this PR shows two commits until #285 merges, after which only `b8ccbf9` remains to review.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)