### PR TITLE
fix: attached HTML/text files vanish from the attachment list

### DIFF
--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -335,7 +335,7 @@ function decodeAttachmentBuffer(buf, encoding) {
   return Buffer.isBuffer(buf) ? buf : Buffer.from(buf);
 }
 
-function walkStructure(node, results) {
+export function walkStructure(node, results) {
   if (!node) return;
   const type = (node.type || '').toLowerCase();
   if (node.childNodes && node.childNodes.length > 0) {
@@ -345,7 +345,22 @@ function walkStructure(node, results) {
   const disposition = (node.disposition || '').toLowerCase();
   const rawFilename = node.dispositionParameters?.filename || node.parameters?.name || null;
   const filename = rawFilename ? rawFilename.replace(BIDI_OVERRIDE_RE, '').trim() || 'attachment' : null;
-  if (type === 'text/html') {
+  // A part explicitly marked Content-Disposition: attachment is an attachment
+  // no matter its MIME type. Checking the text/* types first used to absorb
+  // attached .html/.txt files into the message body: the paperclip showed
+  // (detectAttachments keys on disposition) but the file never appeared in
+  // the attachment list — and an attached HTML file could even replace the
+  // real message body.
+  if (disposition === 'attachment') {
+    results.attachments.push({
+      part: node.part || '1',
+      filename: filename || 'attachment',
+      type: node.type || 'application/octet-stream',
+      encoding: node.encoding || 'base64',
+      size: node.dispositionParameters?.size ? parseInt(node.dispositionParameters.size) : node.size || 0,
+      disposition,
+    });
+  } else if (type === 'text/html') {
     results.textParts.push({
       part: node.part || '1', type,
       encoding: node.encoding || '',
@@ -373,10 +388,11 @@ function walkStructure(node, results) {
       // Content-ID header value is wrapped in angle brackets — strip them
       cid: (node.id || '').replace(/^<|>$/g, ''),
     });
-  } else if (disposition === 'attachment' || filename) {
+  } else if (filename) {
+    // Named non-text part without an explicit disposition — still an attachment.
     results.attachments.push({
       part: node.part || '1',
-      filename: filename || 'attachment',
+      filename,
       type: node.type || 'application/octet-stream',
       encoding: node.encoding || 'base64',
       size: node.dispositionParameters?.size ? parseInt(node.dispositionParameters.size) : node.size || 0,

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -11,7 +11,7 @@ vi.mock('../utils/redact.js', () => ({ redactEmail: vi.fn() }));
 vi.mock('./hostValidation.js', () => ({ resolveForConnection: vi.fn() }));
 vi.mock('./gtdTransitions.js', () => ({ runGtdTransitions: vi.fn(), threadKeysForMessageIds: vi.fn(), threadKeysInFolders: vi.fn() }));
 
-import { ImapManager, providerProfile, makeClientCfg, gtdRelocateGuard, insertCopiedSibling, deleteMessageCopyRow, emitAfterDeferredCopySync, emitGtdSectionsRefreshOnDelete, emitGtdSectionsRefreshIfEnabled, selectGtdReevalIds, ensureMailbox, runGtdSyncTick, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, planModseqSync, connectStaggerFor } from './imapManager.js';
+import { ImapManager, providerProfile, makeClientCfg, gtdRelocateGuard, insertCopiedSibling, deleteMessageCopyRow, emitAfterDeferredCopySync, emitGtdSectionsRefreshOnDelete, emitGtdSectionsRefreshIfEnabled, selectGtdReevalIds, ensureMailbox, runGtdSyncTick, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, planModseqSync, connectStaggerFor, walkStructure } from './imapManager.js';
 import { query } from './db.js';
 import { invalidateGtdConfigCache } from './gtdConfig.js';
 import { runGtdTransitions, threadKeysInFolders } from './gtdTransitions.js';
@@ -1152,5 +1152,84 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
       { uid: true }
     );
     expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+  });
+});
+
+describe('walkStructure attachment classification', () => {
+  const walk = (node) => {
+    const results = { textParts: [], attachments: [] };
+    walkStructure(node, results);
+    return results;
+  };
+
+  it('treats an attached HTML file as an attachment, not body text', () => {
+    const results = walk({
+      type: 'multipart/mixed',
+      childNodes: [
+        { part: '1', type: 'text/plain', encoding: 'quoted-printable', parameters: { charset: 'utf-8' } },
+        {
+          part: '2', type: 'text/html', encoding: 'base64',
+          disposition: 'attachment',
+          dispositionParameters: { filename: 'report.html' },
+          size: 2048,
+        },
+      ],
+    });
+    expect(results.textParts).toHaveLength(1);
+    expect(results.textParts[0].type).toBe('text/plain');
+    expect(results.attachments).toHaveLength(1);
+    expect(results.attachments[0]).toMatchObject({
+      part: '2', filename: 'report.html', type: 'text/html', encoding: 'base64',
+    });
+  });
+
+  it('treats an attached text file as an attachment', () => {
+    const results = walk({
+      part: '2', type: 'text/plain', encoding: 'base64',
+      disposition: 'attachment',
+      dispositionParameters: { filename: 'server.log' },
+    });
+    expect(results.textParts).toHaveLength(0);
+    expect(results.attachments).toHaveLength(1);
+    expect(results.attachments[0].filename).toBe('server.log');
+  });
+
+  it('still treats undisposed HTML parts as the message body', () => {
+    const results = walk({
+      type: 'multipart/alternative',
+      childNodes: [
+        { part: '1', type: 'text/plain', encoding: '7bit' },
+        { part: '2', type: 'text/html', encoding: 'quoted-printable' },
+      ],
+    });
+    expect(results.textParts.map(p => p.type)).toEqual(['text/plain', 'text/html']);
+    expect(results.attachments).toHaveLength(0);
+  });
+
+  it('attachment-disposed images are attachments; cid images stay inline', () => {
+    const results = walk({
+      type: 'multipart/related',
+      childNodes: [
+        { part: '1', type: 'text/html', encoding: '7bit' },
+        { part: '2', type: 'image/png', encoding: 'base64', id: '<logo@x>' },
+        {
+          part: '3', type: 'image/jpeg', encoding: 'base64',
+          disposition: 'attachment', dispositionParameters: { filename: 'photo.jpg' },
+        },
+      ],
+    });
+    expect(results.inlineImages).toHaveLength(1);
+    expect(results.inlineImages[0].cid).toBe('logo@x');
+    expect(results.attachments).toHaveLength(1);
+    expect(results.attachments[0].filename).toBe('photo.jpg');
+  });
+
+  it('named non-text parts without a disposition are still attachments', () => {
+    const results = walk({
+      part: '2', type: 'application/pdf', encoding: 'base64',
+      parameters: { name: 'invoice.pdf' },
+    });
+    expect(results.attachments).toHaveLength(1);
+    expect(results.attachments[0].filename).toBe('invoice.pdf');
   });
 });


### PR DESCRIPTION
## Problem

Emails with an attached `.html` (or `.txt`) file show the paperclip indicator, but the attachment never appears in the attachment list — there is nothing to view or download. Worse, an attached HTML file can end up rendered as the message body, shadowing the real content.

## Root cause

`walkStructure` in `backend/src/services/imapManager.js` classifies MIME parts by **type before disposition**. An attached HTML file is `Content-Type: text/html` + `Content-Disposition: attachment; filename="..."`, so it hits the `text/html` branch and is pushed into `textParts` (message body) — it never reaches the attachment branch. The same happens to attached `text/plain` files.

Meanwhile `detectAttachments` in `messageParser.js` (which drives `has_attachments` / the 📎 indicator) keys on `disposition === 'attachment'` — so the indicator and the attachment list disagree for exactly these parts.

## Fix

Route any part with `Content-Disposition: attachment` to the attachment list **before** the text-type branches, mirroring `detectAttachments` so the two can never disagree. Behavior is otherwise unchanged:

- undisposed `text/html` / `text/plain` parts still flow to the message body (`multipart/alternative` untouched)
- `cid:`-referenced images stay inline
- named non-text parts without a disposition are still collected as attachments

## Tests

New `walkStructure` describe block in `imapManager.test.js`:
- attached HTML file → attachment list, not body
- attached text file → attachment list
- undisposed HTML in `multipart/alternative` → still body
- attachment-disposed image → attachment; `cid:` image → inline
- named PDF without disposition → attachment

Full backend suite passes (691 tests) and eslint is clean.

---

Written with AI assistance (Claude); I have reviewed and tested the changes and am authorized to submit them under the project's CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)