### PR TITLE
fix: fail over mail server addresses

### DIFF
--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,10 +1,10 @@
 import { Router } from 'express';
 import crypto from 'crypto';
-import nodemailer from 'nodemailer';
 import { query } from '../services/db.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { decrypt, encrypt } from '../services/encryption.js';
 import { validateHost, resolveForConnection } from '../services/hostValidation.js';
+import { createSmtpTransport } from '../services/smtpTransport.js';
 import { getConnectionPolicy, invalidateConnectionPolicyCache } from '../services/connectionPolicy.js';
 import { reloadAuthSettings } from '../services/authLimiter.js';
 import { imapManager } from '../index.js';
@@ -291,8 +291,7 @@ router.post('/invites', async (req, res) => {
           const sysResolved = await resolveForConnection(cfg.host);
           const sysTls = { rejectUnauthorized: true };
           if (sysResolved.servername) sysTls.servername = sysResolved.servername;
-          transport = nodemailer.createTransport({
-            host: sysResolved.host,
+          transport = createSmtpTransport(sysResolved, {
             port: cfg.port || 587,
             secure: (cfg.port || 587) === 465,
             auth: { user: cfg.user, pass },
@@ -328,8 +327,7 @@ router.post('/invites', async (req, res) => {
         const acctResolved = await resolveForConnection(account.smtp_host, { allowPrivate: policy.allowPrivateHosts });
         const acctTls = { rejectUnauthorized: policy.allowInsecureTls ? !account.imap_skip_tls_verify : true };
         if (acctResolved.servername) acctTls.servername = acctResolved.servername;
-        transport = nodemailer.createTransport({
-          host: acctResolved.host,
+        transport = createSmtpTransport(acctResolved, {
           port: account.smtp_port,
           secure: account.smtp_port === 465,
           auth: smtpAuth,
@@ -463,8 +461,7 @@ router.post('/system-email/test', async (req, res) => {
     const testResolved = await resolveForConnection(cfg.host);
     const testTls = { rejectUnauthorized: true };
     if (testResolved.servername) testTls.servername = testResolved.servername;
-    const transport = nodemailer.createTransport({
-      host: testResolved.host,
+    const transport = createSmtpTransport(testResolved, {
       port: cfg.port,
       secure: cfg.port === 465,
       auth: { user: cfg.user, pass },

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -7,8 +7,8 @@ import { query, pool } from '../services/db.js';
 import { imapManager } from '../index.js';
 import { decrypt, encrypt } from '../services/encryption.js';
 import { pushConfigured } from '../services/pushNotifications.js';
-import nodemailer from 'nodemailer';
 import { validateHost, resolveForConnection } from '../services/hostValidation.js';
+import { createSmtpTransport } from '../services/smtpTransport.js';
 import { getConnectionPolicy } from '../services/connectionPolicy.js';
 import { authLimiterConfig } from '../services/authLimiter.js';
 import { logAuthEvent } from '../services/authEvents.js';
@@ -995,8 +995,8 @@ router.post('/forgot-password', authLimiter, async (req, res) => {
             const sysResolved = await resolveForConnection(cfg.host);
             const sysTls = { rejectUnauthorized: true };
             if (sysResolved.servername) sysTls.servername = sysResolved.servername;
-            transport = nodemailer.createTransport({
-              host: sysResolved.host, port: cfg.port || 587,
+            transport = createSmtpTransport(sysResolved, {
+              port: cfg.port || 587,
               secure: (cfg.port || 587) === 465,
               auth: { user: cfg.user, pass }, tls: sysTls,
             });
@@ -1029,8 +1029,8 @@ router.post('/forgot-password', authLimiter, async (req, res) => {
           const acctResolved = await resolveForConnection(acct.smtp_host, { allowPrivate: policy.allowPrivateHosts });
           const acctTls = { rejectUnauthorized: policy.allowInsecureTls ? !acct.imap_skip_tls_verify : true };
           if (acctResolved.servername) acctTls.servername = acctResolved.servername;
-          transport = nodemailer.createTransport({
-            host: acctResolved.host, port: acct.smtp_port,
+          transport = createSmtpTransport(acctResolved, {
+            port: acct.smtp_port,
             secure: acct.smtp_port === 465,
             auth: smtpAuth, tls: acctTls,
           });

--- a/backend/src/routes/send.js
+++ b/backend/src/routes/send.js
@@ -15,6 +15,7 @@ import { resolveForConnection } from '../services/hostValidation.js';
 import { getConnectionPolicy } from '../services/connectionPolicy.js';
 import { imapManager } from '../index.js';
 import { runTransitionsForSentMessage } from '../services/gtdTransitions.js';
+import { createSmtpTransport } from '../services/smtpTransport.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -304,8 +305,7 @@ router.post('/send', async (req, res) => {
     // For 'STARTTLS' (or any other/legacy value): fall back to port-based detection
     // so existing accounts stored with the default 'STARTTLS' on port 465 keep working.
     const smtpSecure = account.smtp_tls === 'SSL' || (account.smtp_tls !== 'none' && account.smtp_port === 465);
-    const transport = nodemailer.createTransport({
-      host: smtpResolved.host,
+    const transport = createSmtpTransport(smtpResolved, {
       port: account.smtp_port,
       secure: smtpSecure,
       ...(account.smtp_tls === 'none' ? { ignoreTLS: true } : {}),

--- a/backend/src/services/hostValidation.js
+++ b/backend/src/services/hostValidation.js
@@ -95,13 +95,35 @@ export async function validateHost(host, { allowPrivate = false } = {}) {
   return null;
 }
 
-// Resolves a hostname to a specific public IP for use as the actual connection target,
-// closing the DNS rebinding TOCTOU window between validateHost() and the real connect.
+export function createPinnedLookup(addresses) {
+  const candidates = addresses.map(address => ({
+    address,
+    family: isIPv4(address) ? 4 : 6,
+  }));
+
+  return (_hostname, options, callback) => {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
+    const family = Number(options?.family) || 0;
+    const eligible = family ? candidates.filter(candidate => candidate.family === family) : candidates;
+    if (!eligible.length) {
+      const err = new Error('No validated address matches the requested family');
+      err.code = 'ENOTFOUND';
+      return callback(err);
+    }
+    if (options?.all) return callback(null, eligible.map(candidate => ({ ...candidate })));
+    callback(null, eligible[0].address, eligible[0].family);
+  };
+}
+
+// Resolves a hostname to public IPs for use as the only permitted connection targets,
+// closing the DNS rebinding TOCTOU window between validation and the real connect.
 //
-// Returns { host, servername } where:
-//   host       — the IP to connect to (or original value if already literal / unresolvable)
-//   servername — original hostname for TLS SNI and cert verification (null if host was
-//                already a literal IP, since SNI override is not needed in that case)
+// `host` remains the first IP for callers that cannot use multi-address fallback. `lookup`
+// exposes the complete validated set without performing DNS again, while `servername`
+// preserves the original hostname for TLS SNI and certificate verification.
 //
 // Throws if the host is a reserved/private literal or if DNS resolves to a private range.
 // Pass { allowPrivate: true } to skip all private/local checks (for self-hosted servers).
@@ -127,11 +149,16 @@ export async function resolveForConnection(hostname, { allowPrivate = false } = 
     }
   }
 
-  const all = [...v4, ...v6];
+  const all = [...new Set([...v4, ...v6])];
   // DNS failed — let the connection attempt fail naturally (NXDOMAIN etc.).
   if (!all.length) return { host: h, servername: null };
 
-  // Pin to first validated IP. Pass servername so TLS SNI and cert verification
-  // still use the hostname even though the socket connects directly to the IP.
-  return { host: all[0], servername: h };
+  // Expose only prevalidated addresses to the connection layer. No later DNS query can
+  // substitute an unvalidated target, and TLS still authenticates the original hostname.
+  return {
+    host: all[0],
+    servername: h,
+    addresses: all,
+    lookup: createPinnedLookup(all),
+  };
 }

--- a/backend/src/services/hostValidation.test.js
+++ b/backend/src/services/hostValidation.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { validateHostLiteral, validateHost, resolveForConnection } from './hostValidation.js';
+import { connect, createServer } from 'net';
+import { createPinnedLookup, validateHostLiteral, validateHost, resolveForConnection } from './hostValidation.js';
 
 // Mock the dns module so tests never make real network calls.
 vi.mock('dns', () => ({
@@ -154,10 +155,17 @@ describe('resolveForConnection', () => {
   });
 
   it('pins the resolved IP and sets servername for a public hostname', async () => {
-    dns.resolve4.mockResolvedValue(['142.250.80.46']);
+    dns.resolve4.mockResolvedValue(['142.250.80.46', '142.250.80.47']);
     const result = await resolveForConnection('imap.gmail.com');
     expect(result.host).toBe('142.250.80.46');
     expect(result.servername).toBe('imap.gmail.com');
+    expect(result.addresses).toEqual(['142.250.80.46', '142.250.80.47']);
+  });
+
+  it('deduplicates resolved addresses before exposing connection candidates', async () => {
+    dns.resolve4.mockResolvedValue(['142.250.80.46', '142.250.80.46']);
+    const result = await resolveForConnection('imap.gmail.com');
+    expect(result.addresses).toEqual(['142.250.80.46']);
   });
 
   it('throws for a hostname that resolves to a private IP', async () => {
@@ -192,6 +200,54 @@ describe('resolveForConnection', () => {
     dns.resolve4.mockResolvedValue(['142.250.80.46']);
     const result = await resolveForConnection('  imap.gmail.com  ');
     expect(result.servername).toBe('imap.gmail.com');
+  });
+});
+
+describe('createPinnedLookup', () => {
+  it('returns every prevalidated address when Node requests all candidates', async () => {
+    const lookup = createPinnedLookup(['203.0.113.1', '2001:db8::1']);
+    const result = await new Promise((resolve, reject) => {
+      lookup('mail.example.com', { all: true }, (err, addresses) => err ? reject(err) : resolve(addresses));
+    });
+    expect(result).toEqual([
+      { address: '203.0.113.1', family: 4 },
+      { address: '2001:db8::1', family: 6 },
+    ]);
+  });
+
+  it('never performs another DNS lookup and respects a requested family', async () => {
+    const lookup = createPinnedLookup(['203.0.113.1', '2001:db8::1']);
+    const result = await new Promise((resolve, reject) => {
+      lookup('changed.example.com', { family: 6 }, (err, address, family) => {
+        if (err) reject(err); else resolve({ address, family });
+      });
+    });
+    expect(result).toEqual({ address: '2001:db8::1', family: 6 });
+  });
+
+  it('lets Node connect to the next same-family candidate', async () => {
+    const server = createServer(socket => socket.end());
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const socket = await new Promise((resolve, reject) => {
+        const candidate = connect({
+          host: 'mail.example.com',
+          port: server.address().port,
+          lookup: createPinnedLookup(['127.0.0.2', '127.0.0.1']),
+          autoSelectFamily: true,
+          autoSelectFamilyAttemptTimeout: 10,
+        }, () => resolve(candidate));
+        candidate.setTimeout(2000, () => {
+          candidate.destroy();
+          reject(new Error('Multi-address connection timed out'));
+        });
+        candidate.once('error', reject);
+      });
+      expect(socket.remoteAddress).toBe('127.0.0.1');
+      socket.destroy();
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
   });
 });
 

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -947,8 +947,8 @@ async function ensureFreshToken(account) {
   return account;
 }
 
-// resolved: { host, servername } from resolveForConnection() — pins the IP so the
-// actual TCP connection uses the address we validated, not a later DNS lookup.
+// resolved comes from resolveForConnection(), which limits sockets to the validated
+// address set so DNS rebinding cannot change the target between validation and connect.
 // policy: result of getConnectionPolicy() — gates TLS verification override.
 export function makeClientCfg(account, resolved, { enableIdle = false, policy = {}, idleKeepaliveMs } = {}) {
   if (!policy.allowInsecureTls && !account.imap_tls) {
@@ -956,11 +956,16 @@ export function makeClientCfg(account, resolved, { enableIdle = false, policy = 
   }
   const skipTls = policy.allowInsecureTls && !!account.imap_skip_tls_verify;
   const tlsOpts = { rejectUnauthorized: !skipTls };
-  // Set servername so TLS SNI and cert verification use the original hostname even
-  // though the socket connects directly to the pinned IP address.
+  // Keep the original hostname for TLS authentication while Node connects only to the
+  // prevalidated addresses and moves to the next candidate when one is unreachable.
   if (resolved.servername) tlsOpts.servername = resolved.servername;
+  if (resolved.lookup && resolved.servername) {
+    tlsOpts.lookup = resolved.lookup;
+    tlsOpts.autoSelectFamily = true;
+    tlsOpts.autoSelectFamilyAttemptTimeout = 1000;
+  }
   const cfg = {
-    host: resolved.host,
+    host: resolved.lookup && resolved.servername ? resolved.servername : resolved.host,
     port: account.imap_port,
     secure: account.imap_tls,
     auth: { user: account.auth_user, pass: decrypt(account.auth_pass) },

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -258,6 +258,20 @@ describe('makeClientCfg — rejectUnauthorized', () => {
     const cfg = makeClientCfg(baseAccount, resolved);
     expect(cfg.tls.servername).toBeUndefined();
   });
+
+  it('uses the original hostname with a pinned multi-address lookup', () => {
+    const lookup = vi.fn();
+    const cfg = makeClientCfg(baseAccount, {
+      host: '203.0.113.1',
+      servername: 'imap.example.com',
+      addresses: ['203.0.113.1', '203.0.113.2'],
+      lookup,
+    });
+    expect(cfg.host).toBe('imap.example.com');
+    expect(cfg.tls.lookup).toBe(lookup);
+    expect(cfg.tls.autoSelectFamily).toBe(true);
+    expect(cfg.tls.autoSelectFamilyAttemptTimeout).toBe(1000);
+  });
 });
 
 // ── copyMessage DB side — insertCopiedSibling ────────────────────────────────

--- a/backend/src/services/mailer.js
+++ b/backend/src/services/mailer.js
@@ -1,7 +1,7 @@
-import nodemailer from 'nodemailer';
 import { query } from './db.js';
 import { decrypt } from './encryption.js';
 import { resolveForConnection } from './hostValidation.js';
+import { createSmtpTransport } from './smtpTransport.js';
 
 export async function sendSystemEmail({ to, subject, text, html }) {
   const sysResult = await query(
@@ -14,8 +14,7 @@ export async function sendSystemEmail({ to, subject, text, html }) {
   const resolved = await resolveForConnection(cfg.host);
   const tls = { rejectUnauthorized: true };
   if (resolved.servername) tls.servername = resolved.servername;
-  const transport = nodemailer.createTransport({
-    host: resolved.host,
+  const transport = createSmtpTransport(resolved, {
     port: cfg.port || 587,
     secure: (cfg.port || 587) === 465,
     auth: { user: cfg.user, pass },

--- a/backend/src/services/smtpTransport.js
+++ b/backend/src/services/smtpTransport.js
@@ -1,0 +1,63 @@
+import nodemailer from 'nodemailer';
+
+const SMTP_ATTEMPT_TIMEOUT_MS = 10_000;
+const SMTP_FAILOVER_BUDGET_MS = 45_000;
+
+export function isPreDeliveryConnectionError(err) {
+  return err?.command === 'CONN';
+}
+
+async function runWithAddressFallback({
+  resolved,
+  transportOptions,
+  operation,
+  createTransport = nodemailer.createTransport,
+  now = Date.now,
+}) {
+  const candidates = [...new Set(
+    resolved.addresses?.length ? resolved.addresses : [resolved.host]
+  )];
+  const startedAt = now();
+  let lastError;
+
+  for (let i = 0; i < candidates.length; i++) {
+    const remaining = SMTP_FAILOVER_BUDGET_MS - (now() - startedAt);
+    if (remaining < 2000 && lastError) throw lastError;
+    const attemptTimeout = Math.max(1000, Math.min(SMTP_ATTEMPT_TIMEOUT_MS, Math.floor(remaining / 2)));
+    const transport = createTransport({
+      ...transportOptions,
+      host: candidates[i],
+      connectionTimeout: attemptTimeout,
+      greetingTimeout: attemptTimeout,
+    });
+
+    try {
+      return await operation(transport);
+    } catch (err) {
+      lastError = err;
+      if (!isPreDeliveryConnectionError(err) || i === candidates.length - 1) throw err;
+      console.warn('SMTP connection failed; retrying another validated address:', err.message);
+    } finally {
+      transport.close?.();
+    }
+  }
+
+  throw lastError;
+}
+
+export function createSmtpTransport(resolved, transportOptions, createTransport = nodemailer.createTransport) {
+  return {
+    sendMail: mailOptions => runWithAddressFallback({
+      resolved,
+      transportOptions,
+      operation: transport => transport.sendMail(mailOptions),
+      createTransport,
+    }),
+    verify: () => runWithAddressFallback({
+      resolved,
+      transportOptions,
+      operation: transport => transport.verify(),
+      createTransport,
+    }),
+  };
+}

--- a/backend/src/services/smtpTransport.test.js
+++ b/backend/src/services/smtpTransport.test.js
@@ -1,0 +1,70 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { createSmtpTransport, isPreDeliveryConnectionError } from './smtpTransport.js';
+
+const resolved = {
+  host: '203.0.113.10',
+  servername: 'smtp.example.com',
+  addresses: ['203.0.113.10', '203.0.113.11'],
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('createSmtpTransport', () => {
+  it('tries the next validated address after a connection-stage failure', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const firstError = Object.assign(new Error('Connection timeout'), { code: 'ETIMEDOUT', command: 'CONN' });
+    const sendMail = vi.fn()
+      .mockRejectedValueOnce(firstError)
+      .mockResolvedValueOnce({ accepted: ['user@example.com'] });
+    const close = vi.fn();
+    const createTransport = vi.fn(() => ({ sendMail, close }));
+
+    const transport = createSmtpTransport(
+      resolved,
+      { port: 465, secure: true, tls: { servername: resolved.servername } },
+      createTransport,
+    );
+    const result = await transport.sendMail({ to: 'user@example.com' });
+
+    expect(result.accepted).toEqual(['user@example.com']);
+    expect(createTransport).toHaveBeenCalledTimes(2);
+    expect(createTransport.mock.calls.map(([options]) => options.host)).toEqual(resolved.addresses);
+    expect(createTransport.mock.calls[0][0].connectionTimeout).toBeLessThanOrEqual(10_000);
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ['AUTH', 'EAUTH'],
+    ['MAIL FROM', 'EENVELOPE'],
+    ['DATA', 'ETIMEDOUT'],
+  ])('does not retry an ambiguous or post-connect %s failure', async (command, code) => {
+    const error = Object.assign(new Error(`${command} failed`), { code, command });
+    const createTransport = vi.fn(() => ({ sendMail: vi.fn().mockRejectedValue(error), close: vi.fn() }));
+
+    const transport = createSmtpTransport(
+      resolved,
+      { port: 587, secure: false },
+      createTransport,
+    );
+    await expect(transport.sendMail({ to: 'user@example.com' })).rejects.toBe(error);
+
+    expect(createTransport).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the same address fallback to SMTP verification', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const firstError = Object.assign(new Error('Connection refused'), { command: 'CONN' });
+    const verify = vi.fn().mockRejectedValueOnce(firstError).mockResolvedValueOnce(true);
+    const createTransport = vi.fn(() => ({ verify, close: vi.fn() }));
+    const transport = createSmtpTransport(resolved, { port: 587, secure: false }, createTransport);
+
+    await expect(transport.verify()).resolves.toBe(true);
+    expect(createTransport.mock.calls.map(([options]) => options.host)).toEqual(resolved.addresses);
+  });
+
+  it('recognizes only CONN errors as unambiguously pre-delivery', () => {
+    expect(isPreDeliveryConnectionError({ command: 'CONN' })).toBe(true);
+    expect(isPreDeliveryConnectionError({ command: 'AUTH' })).toBe(false);
+    expect(isPreDeliveryConnectionError(new Error('timeout'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #318.

Mail server hostnames can resolve to several valid addresses, but MailFlow previously pinned every connection to the first one. An unreachable first address therefore blocked IMAP and SMTP even when another validated address was healthy. SMTP's default connection timeout could also outlive the frontend proxy timeout.

## Changes

- Preserve every validated A/AAAA address while keeping DNS rebinding protection: connection code receives only the addresses validated up front.
- Let Node try the remaining validated IMAP addresses while retaining the original hostname for TLS SNI and certificate verification.
- Add one SMTP transport wrapper for user mail, system mail, invite/password-reset mail, and SMTP verification.
- Limit each SMTP connection and greeting stage to 10 seconds and the failover sequence to a 45-second budget.
- Retry SMTP only for Nodemailer `CONN` failures, before authentication or envelope/data commands, so failover cannot duplicate delivered messages.

## Testing

- Backend lint: `npm run lint`
- Backend syntax: `node --check src/index.js`
- Backend tests: `710` passed across `35` files
- Backend production audit: `0` vulnerabilities
- Frontend lint: `npm run lint`
- Frontend build: `npm run build`
- Frontend tests: `1401` passed across `48` suites
- Frontend production audit at `audit-level=high`: passed (two existing moderate React Router advisories have no available fix)
- Added a local socket test proving same-family IPv4 fallback reaches the second candidate without another DNS lookup
- `git diff --check`

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
