### PR TITLE
fix: prevent GTD done rows from resurfacing

### DIFF
--- a/frontend/src/hooks/useGtdTriage.js
+++ b/frontend/src/hooks/useGtdTriage.js
@@ -8,6 +8,7 @@ import {
 } from '../utils/gtd.js';
 import { openReplyFromMessage, openForwardFromMessage } from '../utils/composeFromMessage.js';
 import { resolveContextMenuMessage } from '../utils/contextMenuPolicy.js';
+import { doneGtdRow } from '../utils/gtdDone.js';
 
 // One pending delayed auto-read across ALL GTD surfaces (module scope, not per hook
 // instance): the sidebar and the tab browse list are mounted together in desktop row
@@ -55,6 +56,7 @@ export function useGtdTriage() {
   const setSelectedMessage = useStore(s => s.setSelectedMessage);
   const scheduleGtdSectionsFetch = useStore(s => s.scheduleGtdSectionsFetch);
   const removeGtdThread = useStore(s => s.removeGtdThread);
+  const restoreGtdThread = useStore(s => s.restoreGtdThread);
   const markGtdThreadRead = useStore(s => s.markGtdThreadRead);
   const markGtdThreadStarred = useStore(s => s.markGtdThreadStarred);
   const addNotification = useStore(s => s.addNotification);
@@ -77,25 +79,18 @@ export function useGtdTriage() {
   }, []);
 
   // The GTD "done" action: strip this row's label(s) (`states`), mark read, archive.
-  // Optimistically drop the row so it feels instant; the WS refetch reconciles. On
-  // failure, restore via a refetch and surface a notification (no undo toast).
-  const doneRow = async (thread, states) => {
+  // Optimistically drop and guard the row so stale refetches cannot resurrect it. On
+  // failure, restore its local snapshot and refetch for authoritative reconciliation.
+  const doneRow = (thread, states) => {
     cancelAutoMarkReadFor(thread);
-    removeGtdThread(thread.message_id || thread.id, states);
-    try {
-      const res = await api.gtdDone(thread.id, states);
-      // Labels stripped but the archive step failed: the optimistic removal is still
-      // correct (the row left its GTD sections), yet the email remains in the inbox —
-      // tell the user so the missing archive isn't a silent surprise.
-      if (res?.archiveFailed) {
-        addNotification({ title: t('gtd.doneArchiveFailed'), body: thread.subject || t('common.noSubject') });
-      }
-      scheduleGtdSectionsFetch();
-    } catch (err) {
-      console.error('GTD done failed:', err.message);
-      addNotification({ title: t('gtd.doneFailed'), body: thread.subject || t('common.noSubject') });
-      scheduleGtdSectionsFetch();
-    }
+    return doneGtdRow(thread, states, {
+      gtdDone: api.gtdDone,
+      removeGtdThread,
+      restoreGtdThread,
+      addNotification,
+      scheduleGtdSectionsFetch,
+      t,
+    });
   };
 
   // Read: flip is_read on the section thread instantly. Section rows carry thread-level

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -4,7 +4,13 @@ import { applyTheme, applyCustomCss, getInitialTheme } from '../themes.js';
 import { applyFontSet, applyFontSize } from '../fonts.js';
 import { applyLayout, normalizeLayout } from '../layouts.js';
 import { DEFAULT_AI_ACTIONS } from '../aiActions.js';
-import { removeGtdThreadFromSections, setGtdThreadReadInSections } from '../utils/gtd.js';
+import {
+  removeGtdThreadFromSections,
+  restoreGtdThreadRemoval,
+  setGtdThreadReadInSections,
+  snapshotGtdThreadRemoval,
+} from '../utils/gtd.js';
+import { applyGtdRemovalGuard } from '../utils/pendingGtdRemovals.js';
 import { clampRightSidebarWidth } from '../utils/rightSidebar.js';
 import i18n from '../i18n.js';
 
@@ -559,7 +565,7 @@ export const useStore = create((set, get) => ({
     try {
       const data = await api.getGtdSections({ accountId, limit: 50 });
       if (seq !== _gtdSectionsSeq) return; // superseded by a newer fetch
-      set({ gtdSections: data.sections || {} });
+      set({ gtdSections: applyGtdRemovalGuard(data.sections || {}) });
     } catch {
       // Best-effort; scheduleGtdSectionsFetch/the next context change will retry.
     }
@@ -576,8 +582,17 @@ export const useStore = create((set, get) => ({
   // are the backend section keys whose labels were removed (todo/watch/delegated/…).
   // Delegates to a pure helper (unit-tested in gtd.test.js) that also keeps the deduped
   // Waiting rollup in step so the Waiting badge is correct instantly.
-  removeGtdThread: (identity, states) => set(state => {
-    const next = removeGtdThreadFromSections(state.gtdSections, identity, states);
+  removeGtdThread: (identity, states) => {
+    let snapshot = null;
+    set(state => {
+      snapshot = snapshotGtdThreadRemoval(state.gtdSections, identity, states);
+      const next = removeGtdThreadFromSections(state.gtdSections, identity, states);
+      return next === state.gtdSections ? {} : { gtdSections: next };
+    });
+    return snapshot;
+  },
+  restoreGtdThread: (snapshot) => set(state => {
+    const next = restoreGtdThreadRemoval(state.gtdSections, snapshot);
     return next === state.gtdSections ? {} : { gtdSections: next };
   }),
   // Optimistically flip a section thread's read flag so a rail row's bold/normal styling

--- a/frontend/src/utils/gtd.js
+++ b/frontend/src/utils/gtd.js
@@ -279,6 +279,64 @@ export function removeGtdThreadFromSections(sections, identity, states) {
   return changed ? next : sections;
 }
 
+export function snapshotGtdThreadRemoval(sections, identity, states) {
+  if (!sections || identity == null) return null;
+  const removedByState = {};
+  for (const key of [...new Set(states || [])]) {
+    const sec = sections[key];
+    if (!sec || !Array.isArray(sec.threads)) continue;
+    const rows = [];
+    sec.threads.forEach((thread, index) => {
+      if ((thread.message_id || thread.id) === identity) rows.push({ index, thread });
+    });
+    if (rows.length) removedByState[key] = rows;
+  }
+  return Object.keys(removedByState).length ? { identity, removedByState } : null;
+}
+
+export function restoreGtdThreadRemoval(sections, snapshot) {
+  if (!sections || !snapshot) return sections;
+  const next = { ...sections };
+  let changed = false;
+  let restoredWaiting = false;
+  let restoredWaitingUnread = false;
+
+  for (const [key, rows] of Object.entries(snapshot.removedByState)) {
+    const sec = sections[key];
+    if (!sec || !Array.isArray(sec.threads)) continue;
+    const threads = [...sec.threads];
+    let restored = 0;
+    let restoredUnread = 0;
+    for (const row of rows) {
+      if (threads.some(thread => (thread.message_id || thread.id) === snapshot.identity)) continue;
+      threads.splice(Math.min(row.index, threads.length), 0, row.thread);
+      restored += 1;
+      if (!row.thread.is_read) restoredUnread += 1;
+    }
+    if (!restored) continue;
+    changed = true;
+    if (key === 'watch' || key === 'delegated') {
+      restoredWaiting = true;
+      if (restoredUnread) restoredWaitingUnread = true;
+    }
+    next[key] = {
+      ...sec,
+      total: (Number(sec.total) || 0) + restored,
+      unread: (Number(sec.unread) || 0) + restoredUnread,
+      threads,
+    };
+  }
+
+  if (restoredWaiting && sections.waiting && typeof sections.waiting === 'object') {
+    next.waiting = {
+      ...sections.waiting,
+      total: (Number(sections.waiting.total) || 0) + 1,
+      unread: (Number(sections.waiting.unread) || 0) + (restoredWaitingUnread ? 1 : 0),
+    };
+  }
+  return changed ? next : sections;
+}
+
 // Optimistically flip a section thread's read flag across every state it is labelled with
 // (a merged Waiting row lives in both watch and delegated), so a GTD entry's bold/normal
 // styling updates instantly on a mark-read/unread; the gtd refetch reconciles. Also nudges

--- a/frontend/src/utils/gtd.test.js
+++ b/frontend/src/utils/gtd.test.js
@@ -11,7 +11,9 @@ import {
   mergeWaiting,
   buildGtdDisplaySections,
   removeGtdThreadFromSections,
+  restoreGtdThreadRemoval,
   setGtdThreadReadInSections,
+  snapshotGtdThreadRemoval,
   collectThreadReadIds,
   scheduleGtdThreadAutoRead,
   openGtdThreadWithAutoRead,
@@ -697,6 +699,65 @@ describe('removeGtdThreadFromSections', () => {
     const before = JSON.stringify(sections);
     removeGtdThreadFromSections(sections, 'x', ['watch', 'delegated']);
     assert.equal(JSON.stringify(sections), before);
+  });
+});
+
+describe('GTD row removal rollback', () => {
+  const make = () => ({
+    todo: {
+      total: 3,
+      unread: 2,
+      threads: [
+        { message_id: 'a', is_read: false },
+        { message_id: 'b', is_read: false },
+        { message_id: 'c', is_read: true },
+      ],
+    },
+    watch: {
+      total: 1,
+      unread: 1,
+      threads: [{ message_id: 'b', is_read: false }],
+    },
+    delegated: {
+      total: 1,
+      unread: 1,
+      threads: [{ message_id: 'b', is_read: false }],
+    },
+    waiting: { total: 1, unread: 1 },
+  });
+
+  it('restores the failed row at its original position and restores counts', () => {
+    const sections = make();
+    const snapshot = snapshotGtdThreadRemoval(sections, 'b', ['todo']);
+    const removed = removeGtdThreadFromSections(sections, 'b', ['todo']);
+    const restored = restoreGtdThreadRemoval(removed, snapshot);
+
+    assert.deepEqual(restored.todo.threads.map(row => row.message_id), ['a', 'b', 'c']);
+    assert.equal(restored.todo.total, 3);
+    assert.equal(restored.todo.unread, 2);
+  });
+
+  it('does not resurrect a different row removed by a concurrent action', () => {
+    const sections = make();
+    const failedSnapshot = snapshotGtdThreadRemoval(sections, 'a', ['todo']);
+    const withoutA = removeGtdThreadFromSections(sections, 'a', ['todo']);
+    const withoutAOrB = removeGtdThreadFromSections(withoutA, 'b', ['todo']);
+    const restored = restoreGtdThreadRemoval(withoutAOrB, failedSnapshot);
+
+    assert.deepEqual(restored.todo.threads.map(row => row.message_id), ['a', 'c']);
+    assert.equal(restored.todo.total, 2);
+    assert.equal(restored.todo.unread, 1);
+  });
+
+  it('restores a merged Waiting row and adjusts the deduped rollup once', () => {
+    const sections = make();
+    const snapshot = snapshotGtdThreadRemoval(sections, 'b', ['watch', 'delegated']);
+    const removed = removeGtdThreadFromSections(sections, 'b', ['watch', 'delegated']);
+    const restored = restoreGtdThreadRemoval(removed, snapshot);
+
+    assert.equal(restored.watch.total, 1);
+    assert.equal(restored.delegated.total, 1);
+    assert.deepEqual(restored.waiting, { total: 1, unread: 1 });
   });
 });
 

--- a/frontend/src/utils/gtdDone.js
+++ b/frontend/src/utils/gtdDone.js
@@ -1,0 +1,35 @@
+import {
+  clearGtdRemovalGuard,
+  setCompletedGtdRemoval,
+  setPendingGtdRemoval,
+} from './pendingGtdRemovals.js';
+
+export async function doneGtdRow(thread, states, {
+  gtdDone,
+  removeGtdThread,
+  restoreGtdThread,
+  addNotification,
+  scheduleGtdSectionsFetch,
+  t,
+}) {
+  const identity = thread.message_id || thread.id;
+  setPendingGtdRemoval(identity, states);
+  const snapshot = removeGtdThread(identity, states);
+
+  try {
+    const result = await gtdDone(thread.id, states);
+    setCompletedGtdRemoval(identity, states);
+    if (result?.archiveFailed) {
+      addNotification({ title: t('gtd.doneArchiveFailed'), body: thread.subject || t('common.noSubject') });
+    }
+    scheduleGtdSectionsFetch();
+    return result;
+  } catch (err) {
+    clearGtdRemovalGuard(identity, states);
+    restoreGtdThread(snapshot);
+    console.error('GTD done failed:', err.message);
+    addNotification({ title: t('gtd.doneFailed'), body: thread.subject || t('common.noSubject') });
+    scheduleGtdSectionsFetch();
+    return null;
+  }
+}

--- a/frontend/src/utils/gtdDone.test.js
+++ b/frontend/src/utils/gtdDone.test.js
@@ -1,0 +1,102 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { doneGtdRow } from './gtdDone.js';
+import {
+  clearGtdRemovalGuard,
+  completedGtdRemovalMap,
+  pendingGtdRemovalMap,
+} from './pendingGtdRemovals.js';
+
+const thread = { id: 'row-x', message_id: 'x', subject: 'A subject' };
+const states = ['todo'];
+
+function deps(overrides = {}) {
+  return {
+    gtdDone: async () => ({ ok: true }),
+    removeGtdThread: () => ({ snapshot: true }),
+    restoreGtdThread: () => {},
+    addNotification: () => {},
+    scheduleGtdSectionsFetch: () => {},
+    t: key => key,
+    ...overrides,
+  };
+}
+
+describe('doneGtdRow', () => {
+  afterEach(() => {
+    for (const removal of [...pendingGtdRemovalMap.values(), ...completedGtdRemovalMap.values()]) {
+      clearGtdRemovalGuard(removal.identity, removal.states);
+    }
+  });
+
+  it('guards and removes the row before the request settles, then completes the guard', async () => {
+    const calls = [];
+    let resolveRequest;
+    const request = new Promise(resolve => { resolveRequest = resolve; });
+    const result = doneGtdRow(thread, states, deps({
+      removeGtdThread: (identity, removedStates) => {
+        calls.push(['remove', identity, removedStates]);
+        return { snapshot: true };
+      },
+      gtdDone: async (id, removedStates) => {
+        calls.push(['api', id, removedStates]);
+        return request;
+      },
+      scheduleGtdSectionsFetch: () => calls.push(['schedule']),
+    }));
+
+    assert.deepEqual(calls, [
+      ['remove', 'x', states],
+      ['api', 'row-x', states],
+    ]);
+    assert.equal(pendingGtdRemovalMap.size, 1);
+    assert.equal(completedGtdRemovalMap.size, 0);
+
+    resolveRequest({ ok: true });
+    assert.deepEqual(await result, { ok: true });
+    assert.equal(pendingGtdRemovalMap.size, 0);
+    assert.equal(completedGtdRemovalMap.size, 1);
+    assert.deepEqual(calls.at(-1), ['schedule']);
+  });
+
+  it('clears the guard and restores only the captured row on failure', async () => {
+    const snapshot = { identity: 'x', removedByState: { todo: [] } };
+    const calls = [];
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      const result = await doneGtdRow(thread, states, deps({
+        removeGtdThread: () => snapshot,
+        gtdDone: async () => { throw new Error('network failed'); },
+        restoreGtdThread: value => calls.push(['restore', value]),
+        addNotification: notification => calls.push(['notify', notification]),
+        scheduleGtdSectionsFetch: () => calls.push(['schedule']),
+      }));
+
+      assert.equal(result, null);
+      assert.equal(pendingGtdRemovalMap.size, 0);
+      assert.equal(completedGtdRemovalMap.size, 0);
+      assert.deepEqual(calls, [
+        ['restore', snapshot],
+        ['notify', { title: 'gtd.doneFailed', body: 'A subject' }],
+        ['schedule'],
+      ]);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  it('keeps the row removed but reports a partial archive failure', async () => {
+    const calls = [];
+    await doneGtdRow(thread, states, deps({
+      gtdDone: async () => ({ ok: true, archiveFailed: true }),
+      restoreGtdThread: () => calls.push(['restore']),
+      addNotification: notification => calls.push(['notify', notification]),
+    }));
+
+    assert.deepEqual(calls, [
+      ['notify', { title: 'gtd.doneArchiveFailed', body: 'A subject' }],
+    ]);
+    assert.equal(completedGtdRemovalMap.size, 1);
+  });
+});

--- a/frontend/src/utils/pendingGtdRemovals.js
+++ b/frontend/src/utils/pendingGtdRemovals.js
@@ -1,0 +1,52 @@
+import { removeGtdThreadFromSections } from './gtd.js';
+
+export const pendingGtdRemovalMap = new Map();
+export const completedGtdRemovalMap = new Map();
+
+function normalizeStates(states) {
+  return [...new Set((states || []).filter(Boolean))].sort();
+}
+
+function removalKey(identity, states) {
+  return JSON.stringify([identity, normalizeStates(states)]);
+}
+
+function setExpiring(map, identity, states, ttlMs) {
+  const normalizedStates = normalizeStates(states);
+  const key = removalKey(identity, normalizedStates);
+  const existing = map.get(key);
+  if (existing?.timer) clearTimeout(existing.timer);
+  const timer = setTimeout(() => map.delete(key), ttlMs);
+  map.set(key, { identity, states: normalizedStates, timer });
+}
+
+function clearRemoval(map, identity, states) {
+  const key = removalKey(identity, states);
+  const existing = map.get(key);
+  if (existing?.timer) clearTimeout(existing.timer);
+  map.delete(key);
+}
+
+export function setPendingGtdRemoval(identity, states) {
+  clearRemoval(completedGtdRemovalMap, identity, states);
+  setExpiring(pendingGtdRemovalMap, identity, states, 30000);
+}
+
+export function setCompletedGtdRemoval(identity, states) {
+  clearRemoval(pendingGtdRemovalMap, identity, states);
+  setExpiring(completedGtdRemovalMap, identity, states, 10000);
+}
+
+export function clearGtdRemovalGuard(identity, states) {
+  clearRemoval(pendingGtdRemovalMap, identity, states);
+  clearRemoval(completedGtdRemovalMap, identity, states);
+}
+
+export function applyGtdRemovalGuard(sections) {
+  if (pendingGtdRemovalMap.size === 0 && completedGtdRemovalMap.size === 0) return sections;
+  let guarded = sections;
+  for (const removal of [...pendingGtdRemovalMap.values(), ...completedGtdRemovalMap.values()]) {
+    guarded = removeGtdThreadFromSections(guarded, removal.identity, removal.states);
+  }
+  return guarded;
+}

--- a/frontend/src/utils/pendingGtdRemovals.test.js
+++ b/frontend/src/utils/pendingGtdRemovals.test.js
@@ -1,0 +1,94 @@
+import { afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyGtdRemovalGuard,
+  clearGtdRemovalGuard,
+  completedGtdRemovalMap,
+  pendingGtdRemovalMap,
+  setCompletedGtdRemoval,
+  setPendingGtdRemoval,
+} from './pendingGtdRemovals.js';
+
+const makeSections = () => ({
+  todo: {
+    total: 2,
+    unread: 1,
+    threads: [
+      { id: 'todo-x', message_id: 'x', is_read: false },
+      { id: 'todo-y', message_id: 'y', is_read: true },
+    ],
+  },
+  watch: {
+    total: 1,
+    unread: 1,
+    threads: [{ id: 'watch-x', message_id: 'x', is_read: false }],
+  },
+  delegated: {
+    total: 1,
+    unread: 1,
+    threads: [{ id: 'delegated-x', message_id: 'x', is_read: false }],
+  },
+  waiting: { total: 1, unread: 1 },
+  reference: {
+    total: 1,
+    unread: 1,
+    threads: [{ id: 'reference-x', message_id: 'x', is_read: false }],
+  },
+});
+
+describe('pending GTD removal guard', () => {
+  afterEach(() => {
+    for (const removal of [...pendingGtdRemovalMap.values(), ...completedGtdRemovalMap.values()]) {
+      clearGtdRemovalGuard(removal.identity, removal.states);
+    }
+  });
+
+  it('leaves fetched sections untouched when no row is guarded', () => {
+    const sections = makeSections();
+    assert.equal(applyGtdRemovalGuard(sections), sections);
+  });
+
+  it('keeps a pending Waiting row out of stale refetches with correct rollups', () => {
+    setPendingGtdRemoval('x', ['watch', 'delegated']);
+    const guarded = applyGtdRemovalGuard(makeSections());
+
+    assert.equal(guarded.watch.total, 0);
+    assert.equal(guarded.delegated.total, 0);
+    assert.deepEqual(guarded.watch.threads, []);
+    assert.deepEqual(guarded.delegated.threads, []);
+    assert.deepEqual(guarded.waiting, { total: 0, unread: 0 });
+    assert.equal(guarded.todo.total, 2);
+    assert.equal(guarded.reference.total, 1);
+  });
+
+  it('keeps a completed row hidden during the reconciliation grace window', () => {
+    setPendingGtdRemoval('x', ['todo']);
+    setCompletedGtdRemoval('x', ['todo']);
+
+    assert.equal(pendingGtdRemovalMap.size, 0);
+    assert.equal(completedGtdRemovalMap.size, 1);
+    assert.deepEqual(
+      applyGtdRemovalGuard(makeSections()).todo.threads.map(thread => thread.message_id),
+      ['y'],
+    );
+  });
+
+  it('tracks rapid state-scoped removals independently for the same thread', () => {
+    setPendingGtdRemoval('x', ['todo']);
+    setCompletedGtdRemoval('x', ['reference']);
+    const guarded = applyGtdRemovalGuard(makeSections());
+
+    assert.deepEqual(guarded.todo.threads.map(thread => thread.message_id), ['y']);
+    assert.deepEqual(guarded.reference.threads, []);
+    assert.equal(guarded.watch.threads.length, 1);
+  });
+
+  it('allows a failed row to return after its guard is cleared', () => {
+    const sections = makeSections();
+    setPendingGtdRemoval('x', ['todo']);
+    assert.equal(applyGtdRemovalGuard(sections).todo.total, 1);
+
+    clearGtdRemovalGuard('x', ['todo']);
+    assert.equal(applyGtdRemovalGuard(sections), sections);
+  });
+});


### PR DESCRIPTION
## Summary

Extends the instant, resurrection-proof archive behavior from `f7166e1` to the separate GTD sidebar `useGtdTriage` / `doneRow` path.

This is a follow-up to #304: clicking the GTD sidebar checkmark now removes the row immediately and keeps stale websocket/refetch results from bringing it back.

## Changes

- Guard state-scoped GTD removals while the request is pending and through a short post-success reconciliation window.
- Apply the removal guard at the GTD sections fetch boundary so refreshed data cannot resurrect an archived row.
- Capture a row-level snapshot and restore only that row on failure, preserving other rapid or concurrent triage actions.
- Add focused tests for immediate removal, pending/completed reconciliation, state-scoped rapid actions, partial archive failure, and safe rollback.

## Testing

- `cd frontend && npm test` — 1,414 tests passed
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
