### PR TITLE
fix: harden native app security boundaries

### DIFF
--- a/frontend/packages/android/app/build.gradle
+++ b/frontend/packages/android/app/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core:$androidxCoreVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "androidx.webkit:webkit:$androidxWebkitVersion"
     implementation "androidx.work:work-runtime:$androidxWorkVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"

--- a/frontend/packages/android/app/src/main/AndroidManifest.xml
+++ b/frontend/packages/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowNativeMessageBridge.java
+++ b/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowNativeMessageBridge.java
@@ -1,0 +1,53 @@
+package sh.mailflow.app;
+
+import android.content.Context;
+import android.webkit.WebView;
+import androidx.webkit.WebViewCompat;
+import androidx.webkit.WebViewFeature;
+import com.getcapacitor.JSObject;
+import java.util.Collections;
+import org.json.JSONObject;
+
+final class MailFlowNativeMessageBridge {
+    private static final String BRIDGE_NAME = "MailFlowAndroid";
+
+    private MailFlowNativeMessageBridge() {}
+
+    static void configure(WebView webView, Context context, String configuredHost) {
+        if (webView == null || context == null) return;
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)) return;
+
+        try {
+            WebViewCompat.removeWebMessageListener(webView, BRIDGE_NAME);
+        } catch (Exception ignored) {}
+
+        if (configuredHost == null) return;
+
+        WebViewCompat.addWebMessageListener(
+            webView,
+            BRIDGE_NAME,
+            Collections.singleton(configuredHost),
+            (view, message, sourceOrigin, isMainFrame, replyProxy) -> {
+                if (!isMainFrame || sourceOrigin == null) return;
+                if (!NativeSecurity.isSameOrigin(configuredHost, sourceOrigin.toString())) return;
+
+                JSObject response = new JSObject();
+                try {
+                    JSONObject request = new JSONObject(message.getData());
+                    response.put("id", request.optString("id", ""));
+                    response.put(
+                        "result",
+                        MailFlowNativePlugin.handleNativeBridgeRequest(
+                            context.getApplicationContext(),
+                            request.optString("method", ""),
+                            request.optJSONObject("args")
+                        )
+                    );
+                } catch (Exception error) {
+                    response.put("error", "Native request failed");
+                }
+                replyProxy.postMessage(response.toString());
+            }
+        );
+    }
+}

--- a/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowNativePlugin.java
+++ b/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowNativePlugin.java
@@ -15,7 +15,6 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.Settings;
 import android.util.Log;
-import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
@@ -32,12 +31,13 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URL;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -62,14 +62,17 @@ public class MailFlowNativePlugin extends Plugin {
     static final String ACTION_COMPOSE = "sh.mailflow.app.COMPOSE";
     static final String ACTION_SYNC = "sh.mailflow.app.SYNC";
     static final String ACTION_INSTALL_UPDATE = "sh.mailflow.app.INSTALL_UPDATE";
+    private static final String EXTRA_INTENT_SECRET = "sh.mailflow.app.INTENT_SECRET";
     private static final String TAG = "MailFlowUpdater";
     private static final String CHANNEL_NEW_MAIL = "mailflow_new_mail";
     private static final String CHANNEL_UPDATES = "mailflow_updates";
     private static final String PREFS_NAME = "mailflow-native";
     private static final String PREF_HOST = "host";
+    private static final String PREF_INTENT_SECRET = "intent_secret";
     private static final String PREF_UPDATE_APK_PATH = "update_apk_path";
     private static final String PREF_UPDATE_VERSION = "update_version";
     private static final String PREF_UPDATE_RELEASE_NAME = "update_release_name";
+    private static final String PREF_UPDATE_DIGEST = "update_digest";
     private static final String SETUP_URL = "file:///android_asset/public/index.html";
     private static final String UPDATE_RELEASE_URL = "https://api.github.com/repos/maathimself/mailflow/releases/latest";
     
@@ -108,11 +111,33 @@ public class MailFlowNativePlugin extends Plugin {
         String normalizedHost = normalizeHost(host);
 
         if (normalizedHost == null) {
-            call.reject("Host must start with https:// or http://");
+            call.reject("Public MailFlow hosts must use https://. HTTP is allowed only for localhost and private IP addresses.");
             return;
         }
 
+        if (normalizedHost.startsWith("http://")) {
+            if (getActivity() == null || getActivity().isFinishing()) {
+                call.reject("The unencrypted MailFlow host could not be confirmed.");
+                return;
+            }
+            getActivity().runOnUiThread(() -> new AlertDialog.Builder(getActivity())
+                .setTitle("Unencrypted MailFlow connection")
+                .setMessage("Traffic to this MailFlow server is not encrypted. Your session cookie and email data can be read or changed by anyone who can observe this network. Continue only on a private network you trust.")
+                .setPositiveButton("Use unencrypted connection", (dialog, which) -> persistHost(call, normalizedHost))
+                .setNegativeButton("Cancel", (dialog, which) -> call.reject("The unencrypted MailFlow host was not saved."))
+                .setOnCancelListener((dialog) -> call.reject("The unencrypted MailFlow host was not saved."))
+                .show());
+            return;
+        }
+
+        persistHost(call, normalizedHost);
+    }
+
+    private void persistHost(PluginCall call, String normalizedHost) {
         getPrefs(getContext()).edit().putString(PREF_HOST, normalizedHost).apply();
+        if (getActivity() instanceof MainActivity) {
+            ((MainActivity) getActivity()).configureNativeMessageBridge(normalizedHost);
+        }
         MailFlowBackgroundSync.schedule(getContext());
 
         JSObject result = new JSObject();
@@ -123,6 +148,9 @@ public class MailFlowNativePlugin extends Plugin {
     @PluginMethod
     public void resetHost(PluginCall call) {
         getPrefs(getContext()).edit().remove(PREF_HOST).apply();
+        if (getActivity() instanceof MainActivity) {
+            ((MainActivity) getActivity()).configureNativeMessageBridge(null);
+        }
         getActivity().runOnUiThread(() -> getBridge().getWebView().loadUrl(SETUP_URL));
         call.resolve();
     }
@@ -281,6 +309,7 @@ public class MailFlowNativePlugin extends Plugin {
 
         Intent intent = new Intent(context, MainActivity.class);
         intent.setAction(ACTION_OPEN_MESSAGE);
+        authenticateIntent(context, intent);
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         putExtra(intent, "messageId", messageId);
         putExtra(intent, "accountId", accountId);
@@ -334,7 +363,9 @@ public class MailFlowNativePlugin extends Plugin {
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT);
 
-        NotificationManagerCompat.from(context).notify(notificationId, builder.build());
+        try {
+            NotificationManagerCompat.from(context).notify(notificationId, builder.build());
+        } catch (SecurityException ignored) {}
     }
 
     private static PendingIntent messageActionPendingIntent(Context context, int notificationId, String action, String messageId, String accountId, String folder, JSObject message) {
@@ -344,6 +375,7 @@ public class MailFlowNativePlugin extends Plugin {
             backgroundAction ? MailFlowNotificationActionReceiver.class : MainActivity.class
         );
         intent.setAction(action);
+        authenticateIntent(context, intent);
         if (!backgroundAction) {
             intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         }
@@ -381,7 +413,41 @@ public class MailFlowNativePlugin extends Plugin {
     }
 
     static String getSavedHost(Context context) {
-        return getPrefs(context).getString(PREF_HOST, null);
+        return normalizeHost(getPrefs(context).getString(PREF_HOST, null));
+    }
+
+    static boolean isPrivilegedNativeAction(String action) {
+        return ACTION_OPEN_MESSAGE.equals(action)
+            || ACTION_REPLY_MESSAGE.equals(action)
+            || ACTION_DELETE_MESSAGE.equals(action)
+            || ACTION_STAR_MESSAGE.equals(action)
+            || ACTION_COMPOSE.equals(action)
+            || ACTION_SYNC.equals(action)
+            || ACTION_INSTALL_UPDATE.equals(action);
+    }
+
+    static boolean isTrustedNativeIntent(Context context, Intent intent) {
+        if (context == null || intent == null || !isPrivilegedNativeAction(intent.getAction())) {
+            return false;
+        }
+        return NativeSecurity.secretsMatch(
+            getIntentSecret(context),
+            intent.getStringExtra(EXTRA_INTENT_SECRET)
+        );
+    }
+
+    private static void authenticateIntent(Context context, Intent intent) {
+        intent.putExtra(EXTRA_INTENT_SECRET, getIntentSecret(context));
+    }
+
+    private static String getIntentSecret(Context context) {
+        SharedPreferences prefs = getPrefs(context);
+        String existing = prefs.getString(PREF_INTENT_SECRET, null);
+        if (existing != null && !existing.isEmpty()) return existing;
+
+        String generated = UUID.randomUUID().toString();
+        prefs.edit().putString(PREF_INTENT_SECRET, generated).apply();
+        return generated;
     }
 
     static void injectPendingActions(WebView webView, Context context) {
@@ -406,10 +472,8 @@ public class MailFlowNativePlugin extends Plugin {
             + "delivered=true;"
             + "actions.forEach(function(payload){"
             + "window.dispatchEvent(new CustomEvent('mailflow:native-action',{detail:payload}));"
-            + "window.postMessage({type:'mailflow:native-action',payload:payload},'*');"
             + "});"
             + "window.dispatchEvent(new CustomEvent('mailflow:native-actions-ready'));"
-            + "window.postMessage({type:'mailflow:native-actions-ready'},'*');"
             + "return true;"
             + "};"
             + "if(!deliver(false)){"
@@ -436,19 +500,22 @@ public class MailFlowNativePlugin extends Plugin {
             + "return true;"
             + "};"
             + "}"
-            + "var androidNotifications=window.MailFlowAndroid;"
+            + "var androidBridge=window.MailFlowAndroid;"
+            + "var nativeRequests=window.__mailflowAndroidRequests=window.__mailflowAndroidRequests||{};"
+            + "if(androidBridge&&typeof androidBridge.postMessage==='function'){androidBridge.onmessage=function(event){try{var response=JSON.parse(event.data||'{}');var resolve=nativeRequests[response.id];if(!resolve)return;delete nativeRequests[response.id];resolve(response.result||null);}catch(e){}};}"
+            + "var nativeCall=function(method,args,fallback){if(!androidBridge||typeof androidBridge.postMessage!=='function')return Promise.resolve(fallback||null);return new Promise(function(resolve){var id=String(Date.now())+Math.random();nativeRequests[id]=resolve;androidBridge.postMessage(JSON.stringify({id:id,method:method,args:args||{}}));});};"
             + "var plugin=function(){return window.Capacitor&&window.Capacitor.Plugins&&window.Capacitor.Plugins.MailFlowNative;};"
             + "var call=function(method,args,fallback){var p=plugin();if(!p||typeof p[method]!=='function')return Promise.resolve(fallback||null);return p[method](args||{}).catch(function(){return fallback||null;});};"
             + "window.mailflowNative=window.mailflowNative||{};"
             + "window.mailflowNative.platform='android';"
             + "window.mailflowNative.updates=window.mailflowNative.updates||{};"
             + "window.mailflowNative.updates.check=function(verbose){return call('checkForUpdates',{verbose:!!verbose});};"
-            + "window.mailflowNative.updates.installDownloaded=function(){if(androidNotifications&&typeof androidNotifications.installDownloadedUpdate==='function'){try{return Promise.resolve(JSON.parse(androidNotifications.installDownloadedUpdate()||'{}'));}catch(e){return Promise.resolve({installed:false,reason:'unavailable'});}}return call('installDownloadedUpdate',{}, {installed:false,reason:'unavailable'});};"
+            + "window.mailflowNative.updates.installDownloaded=function(){return nativeCall('installDownloadedUpdate',{},null).then(function(result){return result||call('installDownloadedUpdate',{}, {installed:false,reason:'unavailable'});});};"
             + "window.mailflowNative.updates.installAuto=window.mailflowNative.updates.installDownloaded;"
             + "window.mailflowNative.updates.openDownload=function(){return call('openDownloadedUpdate',{});};"
             + "window.mailflowNative.updates.onStatus=function(callback){if(typeof callback!=='function')return function(){};var handler=function(event){callback(event.detail);};window.addEventListener('mailflow:update-status',handler);return function(){window.removeEventListener('mailflow:update-status',handler);};};"
             + "window.mailflowNative.notifications=window.mailflowNative.notifications||{};"
-            + "window.mailflowNative.notifications.showNewMail=function(notification){if(androidNotifications&&typeof androidNotifications.showNewMail==='function'){androidNotifications.showNewMail(JSON.stringify(notification||{}));return Promise.resolve(null);}return call('showNewMail',notification||{});};"
+            + "window.mailflowNative.notifications.showNewMail=function(notification){return nativeCall('showNewMail',notification||{},null).then(function(result){return result||call('showNewMail',notification||{});});};"
             + "window.mailflowNative.notifications.checkPermission=function(){return call('checkNotificationPermission',{},{}).then(function(result){return result&&result.permission||'default';});};"
             + "window.mailflowNative.notifications.requestPermission=function(){return call('requestNotificationPermission',{},{}).then(function(result){return result&&result.permission||'default';});};"
             + "window.mailflowNative.notifications.openSettings=function(){return call('openNotificationSettings',{});};"
@@ -641,16 +708,7 @@ public class MailFlowNativePlugin extends Plugin {
     }
 
     private static String normalizeHost(String host) {
-        try {
-            URI uri = new URI(host.trim());
-            String scheme = uri.getScheme();
-            if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) return null;
-            if (uri.getHost() == null) return null;
-
-            return new URI(scheme.toLowerCase(), null, uri.getHost(), uri.getPort(), null, null, null).toString();
-        } catch (Exception ignored) {
-            return null;
-        }
+        return NativeSecurity.normalizeHost(host);
     }
 
     private static SharedPreferences getPrefs(Context context) {
@@ -685,19 +743,15 @@ public class MailFlowNativePlugin extends Plugin {
         if (apkAsset != null) {
             info.assetName = apkAsset.optString("name", "MailFlow.apk");
             info.downloadUrl = apkAsset.optString("browser_download_url", null);
+            info.digest = apkAsset.optString("digest", null);
         }
 
         return info;
     }
 
     private JSONObject requestJson(String url) throws Exception {
-        HttpURLConnection connection = openConnection(url);
+        HttpURLConnection connection = openFollowingHttpsRedirects(url);
         int status = connection.getResponseCode();
-        if (status >= 300 && status < 400) {
-            String location = connection.getHeaderField("Location");
-            connection.disconnect();
-            if (location != null) return requestJson(location);
-        }
 
         if (status < 200 || status >= 300) {
             connection.disconnect();
@@ -719,17 +773,12 @@ public class MailFlowNativePlugin extends Plugin {
                 Log.i(TAG, "Downloading update APK from " + release.downloadUrl);
                 File directory = getContext().getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
                 if (directory == null) directory = getContext().getCacheDir();
+                directory = new File(directory, "updates");
                 if (!directory.exists()) directory.mkdirs();
 
                 File output = uniqueFile(directory, sanitizeApkName(release.assetName));
-                HttpURLConnection connection = openConnection(release.downloadUrl);
+                HttpURLConnection connection = openFollowingHttpsRedirects(release.downloadUrl);
                 int status = connection.getResponseCode();
-                if (status >= 300 && status < 400 && connection.getHeaderField("Location") != null) {
-                    release.downloadUrl = connection.getHeaderField("Location");
-                    connection.disconnect();
-                    downloadUpdate(release);
-                    return;
-                }
                 if (status < 200 || status >= 300) {
                     connection.disconnect();
                     throw new Exception("APK download failed with status " + status);
@@ -748,6 +797,7 @@ public class MailFlowNativePlugin extends Plugin {
                     connection.disconnect();
                 }
 
+                verifyReleaseDigest(release, output);
                 downloadedUpdate = output;
                 persistDownloadedUpdateState(release, output);
                 Log.i(TAG, "Downloaded update APK to " + output.getAbsolutePath());
@@ -761,12 +811,33 @@ public class MailFlowNativePlugin extends Plugin {
     }
 
     private HttpURLConnection openConnection(String url) throws Exception {
+        if (!NativeSecurity.isHttpsUrl(url)) {
+            throw new Exception("Update URLs must use HTTPS.");
+        }
         HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setInstanceFollowRedirects(false);
         connection.setConnectTimeout(15000);
         connection.setReadTimeout(30000);
         connection.setRequestProperty("Accept", "application/vnd.github+json");
         connection.setRequestProperty("User-Agent", "MailFlow/" + getInstalledVersion());
         return connection;
+    }
+
+    private HttpURLConnection openFollowingHttpsRedirects(String initialUrl) throws Exception {
+        String url = initialUrl;
+        for (int redirects = 0; redirects <= 5; redirects++) {
+            HttpURLConnection connection = openConnection(url);
+            int status = connection.getResponseCode();
+            if (status < 300 || status >= 400) return connection;
+
+            String location = connection.getHeaderField("Location");
+            connection.disconnect();
+            if (location == null || redirects == 5) {
+                throw new Exception("Update redirect could not be followed safely.");
+            }
+            url = new URL(new URL(url), location).toString();
+        }
+        throw new Exception("Too many update redirects.");
     }
 
     private String getInstalledVersion() {
@@ -801,6 +872,7 @@ public class MailFlowNativePlugin extends Plugin {
         }
 
         try {
+            verifyReleaseDigest(updateInfo, downloadedUpdate);
             installPendingPermission = false;
             Uri uri = FileProvider.getUriForFile(
                 getContext(),
@@ -879,6 +951,7 @@ public class MailFlowNativePlugin extends Plugin {
             .putString(PREF_UPDATE_APK_PATH, file.getAbsolutePath())
             .putString(PREF_UPDATE_VERSION, release.version == null ? "" : release.version)
             .putString(PREF_UPDATE_RELEASE_NAME, release.releaseName == null ? "" : release.releaseName)
+            .putString(PREF_UPDATE_DIGEST, release.digest == null ? "" : release.digest)
             .apply();
     }
 
@@ -901,6 +974,7 @@ public class MailFlowNativePlugin extends Plugin {
             restored.version = prefs.getString(PREF_UPDATE_VERSION, "");
             restored.releaseName = prefs.getString(PREF_UPDATE_RELEASE_NAME, restored.version);
             restored.assetName = file.getName();
+            restored.digest = prefs.getString(PREF_UPDATE_DIGEST, "");
             updateInfo = restored;
         }
     }
@@ -913,6 +987,7 @@ public class MailFlowNativePlugin extends Plugin {
             .remove(PREF_UPDATE_APK_PATH)
             .remove(PREF_UPDATE_VERSION)
             .remove(PREF_UPDATE_RELEASE_NAME)
+            .remove(PREF_UPDATE_DIGEST)
             .apply();
     }
 
@@ -942,6 +1017,7 @@ public class MailFlowNativePlugin extends Plugin {
 
         Intent installIntent = new Intent(getContext(), MainActivity.class);
         installIntent.setAction(ACTION_INSTALL_UPDATE);
+        authenticateIntent(getContext(), installIntent);
         installIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         PendingIntent installPendingIntent = PendingIntent.getActivity(
@@ -963,7 +1039,9 @@ public class MailFlowNativePlugin extends Plugin {
             .setPriority(NotificationCompat.PRIORITY_DEFAULT);
 
         if (hasNotificationPermission(getContext())) {
-            NotificationManagerCompat.from(getContext()).notify(1002, builder.build());
+            try {
+                NotificationManagerCompat.from(getContext()).notify(1002, builder.build());
+            } catch (SecurityException ignored) {}
         }
     }
 
@@ -973,7 +1051,6 @@ public class MailFlowNativePlugin extends Plugin {
         if (getBridge() == null || getBridge().getWebView() == null) return;
         String script = "(function(status){"
             + "window.dispatchEvent(new CustomEvent('mailflow:update-status',{detail:status}));"
-            + "window.postMessage({type:'mailflow:update-status',payload:status},'*');"
             + "})(" + status.toString() + ");";
         getBridge().getWebView().post(() -> getBridge().getWebView().evaluateJavascript(script, null));
     }
@@ -1047,9 +1124,34 @@ public class MailFlowNativePlugin extends Plugin {
         return name;
     }
 
+    private static void verifyReleaseDigest(ReleaseInfo release, File file) throws Exception {
+        String digest = release == null || release.digest == null ? "" : release.digest.trim();
+        if (digest.isEmpty()) return;
+        if (!digest.matches("(?i)^sha256:[a-f0-9]{64}$")) {
+            throw new Exception("The release asset has an unsupported digest.");
+        }
+
+        MessageDigest hasher = MessageDigest.getInstance("SHA-256");
+        try (FileInputStream input = new FileInputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                hasher.update(buffer, 0, read);
+            }
+        }
+
+        StringBuilder actual = new StringBuilder();
+        for (byte value : hasher.digest()) {
+            actual.append(String.format("%02x", value & 0xff));
+        }
+        if (!NativeSecurity.secretsMatch(digest.substring("sha256:".length()).toLowerCase(java.util.Locale.ROOT), actual.toString())) {
+            throw new Exception("The update digest does not match the release asset.");
+        }
+    }
+
     private static boolean isConfiguredHost(Context context, String url) {
         String host = getSavedHost(context);
-        return host != null && url != null && url.startsWith(host);
+        return host != null && NativeSecurity.isSameOrigin(host, url);
     }
 
     private static class ReleaseInfo {
@@ -1059,6 +1161,7 @@ public class MailFlowNativePlugin extends Plugin {
         String releaseDate;
         String assetName;
         String downloadUrl;
+        String digest;
 
         JSObject toStatusData() {
             return toStatusData(null);
@@ -1137,44 +1240,33 @@ public class MailFlowNativePlugin extends Plugin {
         return result;
     }
 
-    public static class NotificationBridge {
-        private final Context context;
-
-        NotificationBridge(Context context) {
-            this.context = context.getApplicationContext();
-            createNotificationChannel(this.context);
+    static JSObject handleNativeBridgeRequest(Context context, String method, JSONObject args) throws JSONException {
+        if ("showNewMail".equals(method)) {
+            JSONObject notification = args == null ? new JSONObject() : args;
+            JSONObject messageObject = notification.optJSONObject("message");
+            JSObject message = messageObject == null ? null : JSObject.fromJSONObject(messageObject);
+            postNewMailNotification(
+                context,
+                notification.optString("title", "New mail"),
+                notification.optString("body", "You have new mail."),
+                notification.optString("messageId", null),
+                notification.optString("accountId", null),
+                notification.optString("folder", "INBOX"),
+                message
+            );
+            JSObject result = new JSObject();
+            result.put("shown", true);
+            return result;
         }
 
-        @JavascriptInterface
-        public void showNewMail(String notificationJson) {
-            try {
-                JSONObject notification = new JSONObject(notificationJson == null ? "{}" : notificationJson);
-                JSONObject messageObject = notification.optJSONObject("message");
-                JSObject message = messageObject == null ? null : JSObject.fromJSONObject(messageObject);
-
-                postNewMailNotification(
-                    context,
-                    notification.optString("title", "New mail"),
-                    notification.optString("body", "You have new mail."),
-                    notification.optString("messageId", null),
-                    notification.optString("accountId", null),
-                    notification.optString("folder", "INBOX"),
-                    message
-                );
-            } catch (JSONException ignored) {}
+        if ("installDownloadedUpdate".equals(method) && instance != null) {
+            return instance.showUpdateReadyDialog();
         }
 
-        @JavascriptInterface
-        public String installDownloadedUpdate() {
-            if (instance == null) {
-                JSObject result = new JSObject();
-                result.put("installed", false);
-                result.put("reason", "unavailable");
-                return result.toString();
-            }
-
-            return instance.showUpdateReadyDialog().toString();
-        }
+        JSObject result = new JSObject();
+        result.put("installed", false);
+        result.put("reason", "unavailable");
+        return result;
     }
 
     private static void putExtra(Intent intent, String key, String value) {

--- a/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowNotificationActionReceiver.java
+++ b/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowNotificationActionReceiver.java
@@ -18,6 +18,7 @@ public class MailFlowNotificationActionReceiver extends BroadcastReceiver {
         String action = intent.getAction();
         String messageId = intent.getStringExtra("messageId");
         if (messageId == null || messageId.isEmpty()) return;
+        if (!MailFlowNativePlugin.isTrustedNativeIntent(context, intent)) return;
         if (!MailFlowNativePlugin.ACTION_DELETE_MESSAGE.equals(action)
             && !MailFlowNativePlugin.ACTION_STAR_MESSAGE.equals(action)) return;
 

--- a/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowWebViewClient.java
+++ b/frontend/packages/android/app/src/main/java/sh/mailflow/app/MailFlowWebViewClient.java
@@ -24,15 +24,19 @@ public class MailFlowWebViewClient extends BridgeWebViewClient {
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
         Uri uri = request == null ? null : request.getUrl();
-        if (request != null && request.isForMainFrame() && uri != null && openExternallyIfNeeded(uri.toString())) {
-            return true;
-        }
+        if (request == null || uri == null) return super.shouldOverrideUrlLoading(view, request);
+
+        String url = uri.toString();
+        if (isConfiguredHost(url) || FALLBACK_URL.equals(url)) return false;
+        if (!request.isForMainFrame()) return isWebUrl(uri);
+        if (openExternallyIfNeeded(url)) return true;
 
         return super.shouldOverrideUrlLoading(view, request);
     }
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        if (isConfiguredHost(url) || FALLBACK_URL.equals(url)) return false;
         if (openExternallyIfNeeded(url)) {
             return true;
         }
@@ -82,7 +86,12 @@ public class MailFlowWebViewClient extends BridgeWebViewClient {
 
     private boolean isConfiguredHost(String url) {
         String host = MailFlowNativePlugin.getSavedHost(context);
-        return host != null && url != null && url.startsWith(host);
+        return host != null && NativeSecurity.isSameOrigin(host, url);
+    }
+
+    private boolean isWebUrl(Uri uri) {
+        String scheme = uri == null ? null : uri.getScheme();
+        return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
     }
 
     private boolean openExternallyIfNeeded(String url) {

--- a/frontend/packages/android/app/src/main/java/sh/mailflow/app/MainActivity.java
+++ b/frontend/packages/android/app/src/main/java/sh/mailflow/app/MainActivity.java
@@ -25,9 +25,9 @@ public class MainActivity extends BridgeActivity {
 
         if (bridge != null) {
             configureCookies();
-            bridge.getWebView().addJavascriptInterface(new MailFlowNativePlugin.NotificationBridge(this), "MailFlowAndroid");
             bridge.setWebViewClient(new MailFlowWebViewClient(bridge, this));
             String savedHost = MailFlowNativePlugin.getSavedHost(this);
+            configureNativeMessageBridge(savedHost);
             if (savedHost != null) {
                 MailFlowBackgroundSync.schedule(this);
                 bridge.getWebView().post(() -> bridge.getWebView().loadUrl(savedHost));
@@ -92,10 +92,12 @@ public class MainActivity extends BridgeActivity {
 
     private void handleNativeIntent(Intent intent) {
         if (intent == null) return;
-        if (!markIntentHandled(intent)) return;
 
         String action = intent.getAction();
         Uri data = intent.getData();
+        if (MailFlowNativePlugin.isPrivilegedNativeAction(action)
+            && !MailFlowNativePlugin.isTrustedNativeIntent(this, intent)) return;
+        if (!markIntentHandled(intent)) return;
 
         if (MailFlowNativePlugin.ACTION_OPEN_MESSAGE.equals(action)) {
             MailFlowNativePlugin.sendOpenMessageAction(intent);
@@ -169,8 +171,13 @@ public class MainActivity extends BridgeActivity {
         CookieManager cookieManager = CookieManager.getInstance();
         cookieManager.setAcceptCookie(true);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && bridge != null && bridge.getWebView() != null) {
-            cookieManager.setAcceptThirdPartyCookies(bridge.getWebView(), true);
+            cookieManager.setAcceptThirdPartyCookies(bridge.getWebView(), false);
         }
+    }
+
+    void configureNativeMessageBridge(String configuredHost) {
+        if (bridge == null || bridge.getWebView() == null) return;
+        MailFlowNativeMessageBridge.configure(bridge.getWebView(), this, configuredHost);
     }
 
     private void flushCookies() {

--- a/frontend/packages/android/app/src/main/java/sh/mailflow/app/NativeSecurity.java
+++ b/frontend/packages/android/app/src/main/java/sh/mailflow/app/NativeSecurity.java
@@ -1,0 +1,94 @@
+package sh.mailflow.app;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Locale;
+
+final class NativeSecurity {
+    private NativeSecurity() {}
+
+    static String normalizeHost(String value) {
+        try {
+            URI uri = new URI(value == null ? "" : value.trim());
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null) return null;
+
+            scheme = scheme.toLowerCase(Locale.ROOT);
+            host = host.toLowerCase(Locale.ROOT);
+            if (!"http".equals(scheme) && !"https".equals(scheme)) return null;
+            if ("http".equals(scheme) && !isAllowedCleartextHost(host)) return null;
+
+            return new URI(scheme, null, host, uri.getPort(), null, null, null).toString();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    static boolean isSameOrigin(String configuredHost, String candidateUrl) {
+        try {
+            URI configured = new URI(configuredHost);
+            URI candidate = new URI(candidateUrl);
+            return configured.getScheme() != null
+                && configured.getHost() != null
+                && configured.getScheme().equalsIgnoreCase(candidate.getScheme())
+                && configured.getHost().equalsIgnoreCase(candidate.getHost())
+                && effectivePort(configured) == effectivePort(candidate);
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    static boolean isHttpsUrl(String value) {
+        try {
+            URI uri = new URI(value);
+            return "https".equalsIgnoreCase(uri.getScheme()) && uri.getHost() != null;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    static boolean secretsMatch(String expected, String supplied) {
+        if (expected == null || supplied == null || expected.isEmpty() || supplied.isEmpty()) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+            expected.getBytes(StandardCharsets.UTF_8),
+            supplied.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+
+    private static int effectivePort(URI uri) {
+        if (uri.getPort() != -1) return uri.getPort();
+        if ("https".equalsIgnoreCase(uri.getScheme())) return 443;
+        if ("http".equalsIgnoreCase(uri.getScheme())) return 80;
+        return -1;
+    }
+
+    private static boolean isAllowedCleartextHost(String host) {
+        String normalized = host == null ? "" : host.toLowerCase(Locale.ROOT);
+        if ("localhost".equals(normalized) || "::1".equals(normalized) || "[::1]".equals(normalized)) {
+            return true;
+        }
+
+        String[] parts = normalized.split("\\.", -1);
+        if (parts.length != 4) return false;
+
+        int[] octets = new int[4];
+        for (int i = 0; i < parts.length; i++) {
+            if (!parts[i].matches("0|[1-9]\\d{0,2}")) return false;
+            try {
+                octets[i] = Integer.parseInt(parts[i]);
+            } catch (NumberFormatException ignored) {
+                return false;
+            }
+            if (octets[i] > 255) return false;
+        }
+
+        return octets[0] == 127
+            || octets[0] == 10
+            || (octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31)
+            || (octets[0] == 192 && octets[1] == 168);
+    }
+}

--- a/frontend/packages/android/app/src/main/res/xml/file_paths.xml
+++ b/frontend/packages/android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="my_images" path="." />
-    <cache-path name="my_cache_images" path="." />
+    <external-files-path name="update_apks" path="Download/updates/" />
+    <cache-path name="cached_update_apks" path="updates/" />
 </paths>

--- a/frontend/packages/android/app/src/test/java/sh/mailflow/app/MailFlowNativePluginSecurityTest.java
+++ b/frontend/packages/android/app/src/test/java/sh/mailflow/app/MailFlowNativePluginSecurityTest.java
@@ -1,0 +1,16 @@
+package sh.mailflow.app;
+
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Method;
+import org.junit.Test;
+
+public class MailFlowNativePluginSecurityTest {
+    @Test
+    public void normalizeHostRejectsCleartextPublicHosts() throws Exception {
+        Method normalizeHost = MailFlowNativePlugin.class.getDeclaredMethod("normalizeHost", String.class);
+        normalizeHost.setAccessible(true);
+
+        assertNull(normalizeHost.invoke(null, "http://mail.example.com"));
+    }
+}

--- a/frontend/packages/android/app/src/test/java/sh/mailflow/app/NativeSecurityTest.java
+++ b/frontend/packages/android/app/src/test/java/sh/mailflow/app/NativeSecurityTest.java
@@ -1,0 +1,85 @@
+package sh.mailflow.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class NativeSecurityTest {
+    @Test
+    public void normalizeHostAllowsHttpsAndStripsNonOriginComponents() {
+        assertEquals(
+            "https://mail.example.com:8443",
+            NativeSecurity.normalizeHost(" https://MAIL.example.com:8443/inbox?q=all#today ")
+        );
+    }
+
+    @Test
+    public void normalizeHostAllowsOnlyLocalAndRfc1918Cleartext() {
+        assertEquals("http://localhost:3000", NativeSecurity.normalizeHost("http://localhost:3000"));
+        assertEquals("http://127.0.0.1", NativeSecurity.normalizeHost("http://127.0.0.1"));
+        assertEquals("http://10.0.0.8", NativeSecurity.normalizeHost("http://10.0.0.8"));
+        assertEquals("http://172.16.0.1", NativeSecurity.normalizeHost("http://172.16.0.1"));
+        assertEquals("http://172.31.255.255", NativeSecurity.normalizeHost("http://172.31.255.255"));
+        assertEquals("http://192.168.1.20", NativeSecurity.normalizeHost("http://192.168.1.20"));
+        assertEquals("http://[::1]:8080", NativeSecurity.normalizeHost("http://[::1]:8080"));
+
+        assertNull(NativeSecurity.normalizeHost("http://mail.example.com"));
+        assertNull(NativeSecurity.normalizeHost("http://localhost.example.com"));
+        assertNull(NativeSecurity.normalizeHost("http://172.32.0.1"));
+        assertNull(NativeSecurity.normalizeHost("http://192.169.0.1"));
+        assertNull(NativeSecurity.normalizeHost("http://169.254.1.1"));
+    }
+
+    @Test
+    public void sameOriginRejectsPrefixLookalikesAndPortChanges() {
+        assertTrue(NativeSecurity.isSameOrigin(
+            "https://mail.example.com",
+            "https://mail.example.com/inbox"
+        ));
+        assertTrue(NativeSecurity.isSameOrigin(
+            "https://mail.example.com",
+            "https://mail.example.com:443/inbox"
+        ));
+        assertFalse(NativeSecurity.isSameOrigin(
+            "https://mail.example.com",
+            "https://mail.example.com.attacker.test"
+        ));
+        assertFalse(NativeSecurity.isSameOrigin(
+            "https://mail.example.com",
+            "https://mail.example.com:444"
+        ));
+    }
+
+    @Test
+    public void updateUrlsMustRemainHttpsAcrossRedirects() {
+        assertTrue(NativeSecurity.isHttpsUrl("https://github.com/release.apk"));
+        assertFalse(NativeSecurity.isHttpsUrl("http://github.com/release.apk"));
+        assertFalse(NativeSecurity.isHttpsUrl("file:///tmp/release.apk"));
+        assertFalse(NativeSecurity.isHttpsUrl("not a url"));
+    }
+
+    @Test
+    public void secretComparisonRejectsMissingAndDifferentValues() {
+        assertTrue(NativeSecurity.secretsMatch("install-secret", "install-secret"));
+        assertFalse(NativeSecurity.secretsMatch("install-secret", "different"));
+        assertFalse(NativeSecurity.secretsMatch("", ""));
+        assertFalse(NativeSecurity.secretsMatch(null, "install-secret"));
+    }
+
+    @Test
+    public void onlyInternalCustomActionsRequireIntentAuthentication() {
+        assertTrue(MailFlowNativePlugin.isPrivilegedNativeAction(
+            MailFlowNativePlugin.ACTION_OPEN_MESSAGE
+        ));
+        assertTrue(MailFlowNativePlugin.isPrivilegedNativeAction(
+            MailFlowNativePlugin.ACTION_INSTALL_UPDATE
+        ));
+        assertFalse(MailFlowNativePlugin.isPrivilegedNativeAction(
+            "android.intent.action.VIEW"
+        ));
+        assertFalse(MailFlowNativePlugin.isPrivilegedNativeAction(null));
+    }
+}

--- a/frontend/packages/capacitor.config.json
+++ b/frontend/packages/capacitor.config.json
@@ -4,10 +4,5 @@
   "webDir": "../dist",
   "android": {
     "path": "android"
-  },
-  "server": {
-    "allowNavigation": [
-      "*"
-    ]
   }
 }

--- a/frontend/packages/electron/main.cjs
+++ b/frontend/packages/electron/main.cjs
@@ -1,9 +1,18 @@
 const { app, BrowserWindow, Menu, Tray, nativeImage, ipcMain, shell, dialog, Notification, session } = require('electron');
-const { execFileSync, spawn } = require('child_process');
+const { execFileSync, spawn, spawnSync } = require('child_process');
+const { createHash } = require('crypto');
 const fs = require('fs');
 const http = require('http');
 const https = require('https');
 const path = require('path');
+const { pathToFileURL } = require('url');
+const {
+  createNavigationPolicy,
+  hasMatchingMacTeam,
+  hasMatchingWindowsPublisher,
+  isSameOrigin,
+  normalizeHost,
+} = require('./security.cjs');
 
 const CONFIG_FILE = 'mailflow-host.json';
 const UPDATE_STATUS_CHANNEL = 'mailflow:updates:status';
@@ -156,23 +165,6 @@ function clearHost() {
   const config = readConfig();
   delete config.host;
   writeConfig(config);
-}
-
-function normalizeHost(value) {
-  const input = String(value || '').trim();
-  const url = new URL(input);
-
-  if (!['https:', 'http:'].includes(url.protocol)) {
-    throw new Error('Host must start with https:// or http://');
-  }
-
-  url.username = '';
-  url.password = '';
-  url.hash = '';
-  url.search = '';
-  url.pathname = '/';
-
-  return url.toString().replace(/\/$/, '');
 }
 
 function requestJson(url) {
@@ -766,35 +758,93 @@ function setDownloadProgress(window, value) {
   }
 }
 
-function getLinuxTerminalCommand() {
-  return getAvailableCommand([
-    'ptyxis',
-    'kgx',
-    'gnome-terminal',
-    'konsole',
-    'xterm',
-    'x-terminal-emulator',
-  ]);
+function hashFile(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
 }
 
-function getTerminalArgs(terminal, command, args = []) {
-  const shellCommand = ['sh', '-lc', 'exec "$@"', 'mailflow-installer', command, ...args];
-  if (['ptyxis', 'kgx', 'gnome-terminal'].includes(terminal)) return ['--', ...shellCommand];
-  return ['-e', ...shellCommand];
+async function verifyExpectedDigest(filePath) {
+  const digest = String(updateInfo?.digest || '').trim();
+  if (!digest) return;
+
+  const match = digest.match(/^sha256:([a-f0-9]{64})$/i);
+  if (!match) throw new Error('The release asset has an unsupported digest.');
+
+  const actual = await hashFile(filePath);
+  if (actual.toLowerCase() !== match[1].toLowerCase()) {
+    throw new Error('The update digest does not match the release asset.');
+  }
 }
 
-function launchTerminalCommand(command, args = []) {
-  const terminal = getLinuxTerminalCommand();
-  if (!terminal) {
-    throw new Error('No supported terminal was found.');
+function readWindowsSignature(filePath) {
+  const script = [
+    '$signature = Get-AuthenticodeSignature -LiteralPath $args[0]',
+    '[pscustomobject]@{',
+    '  status = [string]$signature.Status',
+    '  subject = [string]$signature.SignerCertificate.Subject',
+    '} | ConvertTo-Json -Compress',
+  ].join('\n');
+  const output = execFileSync('powershell.exe', [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    script,
+    filePath,
+  ], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  return JSON.parse(output);
+}
+
+function readMacSignatureDetails(filePath) {
+  const result = spawnSync('codesign', ['--display', '--verbose=4', filePath], {
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || 'Could not read the code signature.');
+  }
+  return `${result.stdout || ''}\n${result.stderr || ''}`;
+}
+
+function verifyPlatformSignature(filePath) {
+  if (process.platform === 'win32') {
+    const installed = readWindowsSignature(process.execPath);
+    const downloaded = readWindowsSignature(filePath);
+    if (!hasMatchingWindowsPublisher(installed, downloaded)) {
+      throw new Error('The update is not signed by the installed MailFlow publisher.');
+    }
+    return;
   }
 
-  const child = spawn(terminal, getTerminalArgs(terminal, command, args), {
-    detached: true,
-    stdio: 'ignore',
-  });
+  if (process.platform === 'darwin') {
+    execFileSync('codesign', ['--verify', '--deep', '--strict', filePath], { stdio: 'ignore' });
+    execFileSync('spctl', [
+      '--assess',
+      '--type',
+      'open',
+      '--context',
+      'context:primary-signature',
+      filePath,
+    ], { stdio: 'ignore' });
 
-  child.unref();
+    const installed = readMacSignatureDetails(process.execPath);
+    const downloaded = readMacSignatureDetails(filePath);
+    if (!hasMatchingMacTeam(installed, downloaded)) {
+      throw new Error('The update is not signed by the installed MailFlow team.');
+    }
+  }
+}
+
+async function verifyDownloadedUpdate(filePath) {
+  await verifyExpectedDigest(filePath);
+  verifyPlatformSignature(filePath);
 }
 
 function isUpdateDownloadItem(item) {
@@ -827,7 +877,7 @@ function initializeUpdateDownloads(window) {
       }
     });
 
-    item.on('done', (_event, state) => {
+    item.on('done', async (_event, state) => {
       setDownloadProgress(window, -1);
 
       if (state === 'interrupted') {
@@ -835,8 +885,16 @@ function initializeUpdateDownloads(window) {
       }
 
       if (state === 'completed') {
-        downloadedUpdate = item.getSavePath();
-        notifyUpdateDownloaded();
+        const updatePath = item.getSavePath();
+        try {
+          await verifyDownloadedUpdate(updatePath);
+          downloadedUpdate = updatePath;
+          notifyUpdateDownloaded();
+        } catch (error) {
+          downloadedUpdate = null;
+          console.error('Downloaded update failed security verification:', error);
+          notifyUpdateError('The downloaded update could not be verified and will not be opened.');
+        }
       }
 
       pendingUpdateDownloadUrl = null;
@@ -871,6 +929,7 @@ async function checkForUpdates(verbose = false) {
     }
 
     updateInfo = {
+      digest: asset.digest || null,
       releaseNotes: release.body || '',
       releaseName: release.name || release.tag_name,
       releaseDate: release.published_at,
@@ -899,21 +958,6 @@ function launchDownloadedUpdate(updatePath) {
     return Promise.resolve();
   }
 
-  if (process.platform === 'linux' && /\.deb$/i.test(updatePath)) {
-    launchTerminalCommand('sudo', ['dpkg', '--install', updatePath]);
-    return Promise.resolve();
-  }
-
-  if (process.platform === 'linux' && /\.rpm$/i.test(updatePath)) {
-    const packageInstaller = getAvailableCommand(['dnf', 'dnf5', 'yum']);
-    if (!packageInstaller) {
-      throw new Error('No RPM package installer was found.');
-    }
-
-    launchTerminalCommand('sudo', [packageInstaller, 'install', updatePath]);
-    return Promise.resolve();
-  }
-
   return shell.openPath(updatePath).then((error) => {
     if (error) throw new Error(error);
   });
@@ -933,6 +977,7 @@ function installDownloadedUpdate() {
       }
 
       try {
+        await verifyDownloadedUpdate(downloadedUpdate);
         await launchDownloadedUpdate(downloadedUpdate);
         isQuitting = true;
         setTimeout(() => app.quit(), 500);
@@ -1049,20 +1094,9 @@ function sendNativeAction(action, data = {}) {
   const payload = createNativeActionPayload(action, data);
   showMainWindow();
 
-  const dispatchScript = `
-    window.dispatchEvent(new CustomEvent('mailflow:native-action', {
-      detail: ${JSON.stringify(payload)}
-    }));
-    window.postMessage({
-      type: 'mailflow:native-action',
-      payload: ${JSON.stringify(payload)}
-    }, '*');
-  `;
-
   const send = () => {
     if (!mainWindow || mainWindow.isDestroyed()) return;
     mainWindow.webContents.send(NATIVE_ACTION_CHANNEL, payload);
-    mainWindow.webContents.executeJavaScript(dispatchScript).catch(() => {});
   };
 
   if (!mainWindow || mainWindow.isDestroyed()) return;
@@ -1434,10 +1468,32 @@ function createWindow() {
     return { action: 'deny' };
   });
 
+  const navigationPolicy = createNavigationPolicy(readHost);
+  const internalPages = new Set([
+    pathToFileURL(path.join(__dirname, '..', 'native-shell', 'index.html')).toString(),
+    pathToFileURL(path.join(__dirname, '..', 'native-shell', 'host-unavailable.html')).toString(),
+  ]);
+  const guardNavigation = (event, url, kind) => {
+    if (internalPages.has(url)) {
+      navigationPolicy.reset();
+      return;
+    }
+    if (navigationPolicy.decide(kind, url) === 'allow') return;
+    event.preventDefault();
+  };
+
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    guardNavigation(event, url, 'navigate');
+  });
+  mainWindow.webContents.on('will-redirect', (event, url, _isInPlace, isMainFrame) => {
+    if (!isMainFrame) return;
+    guardNavigation(event, url, 'redirect');
+  });
+
   mainWindow.webContents.on('did-fail-load', (_event, _errorCode, _errorDescription, validatedURL, isMainFrame) => {
     if (!isMainFrame) return;
     const host = readHost();
-    if (!host || !String(validatedURL || '').startsWith(host)) return;
+    if (!host || !isSameOrigin(host, validatedURL)) return;
     loadHostUnavailable();
   });
 
@@ -1448,7 +1504,7 @@ function createWindow() {
     if (!HOST_UNAVAILABLE_STATUS_CODES.has(details.statusCode)) return;
 
     const host = readHost();
-    if (!host || !String(details.url || '').startsWith(host)) return;
+    if (!host || !isSameOrigin(host, details.url)) return;
 
     setTimeout(() => loadHostUnavailable(), 0);
   });
@@ -1500,7 +1556,7 @@ function detectRewriteErrorPage() {
   if (!mainWindow || mainWindow.isDestroyed()) return;
   const currentUrl = mainWindow.webContents.getURL();
   const host = readHost();
-  if (!host || !currentUrl.startsWith(host)) return;
+  if (!host || !isSameOrigin(host, currentUrl)) return;
 
   mainWindow.webContents.executeJavaScript('document.body ? document.body.innerText : ""', true)
     .then((text) => {
@@ -1532,7 +1588,24 @@ function scheduleStartupUpdateCheck() {
 ipcMain.handle('mailflow:getHost', () => readHost());
 
 ipcMain.handle('mailflow:saveHost', async (_event, host) => {
-  const normalized = writeHost(host);
+  const normalized = normalizeHost(host);
+  if (new URL(normalized).protocol === 'http:') {
+    const result = await dialog.showMessageBox(mainWindow, {
+      type: 'warning',
+      buttons: ['Use unencrypted connection', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      noLink: true,
+      title: 'Unencrypted MailFlow connection',
+      message: 'Traffic to this MailFlow server is not encrypted.',
+      detail: 'Your session cookie and email data can be read or changed by anyone who can observe this network. Continue only on a private network you trust.',
+    });
+    if (result.response !== 0) {
+      throw new Error('The unencrypted MailFlow host was not saved.');
+    }
+  }
+
+  writeHost(normalized);
   return normalized;
 });
 

--- a/frontend/packages/electron/security.cjs
+++ b/frontend/packages/electron/security.cjs
@@ -1,0 +1,143 @@
+function parseIpv4Literal(hostname) {
+  const parts = String(hostname || '').split('.');
+  if (parts.length !== 4) return null;
+
+  const octets = parts.map((part) => {
+    if (!/^(0|[1-9]\d{0,2})$/.test(part)) return null;
+    const value = Number.parseInt(part, 10);
+    return value <= 255 ? value : null;
+  });
+
+  return octets.some((part) => part === null) ? null : octets;
+}
+
+function isAllowedCleartextHostname(hostname) {
+  const normalized = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+  if (normalized === 'localhost' || normalized === '::1') return true;
+
+  const octets = parseIpv4Literal(normalized);
+  if (!octets) return false;
+
+  return octets[0] === 127
+    || octets[0] === 10
+    || (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31)
+    || (octets[0] === 192 && octets[1] === 168);
+}
+
+function normalizeHost(value) {
+  const input = String(value || '').trim();
+  const url = new URL(input);
+
+  if (!['https:', 'http:'].includes(url.protocol)) {
+    throw new Error('Host must start with https:// or http://');
+  }
+  if (url.protocol === 'http:' && !isAllowedCleartextHostname(url.hostname)) {
+    throw new Error('Public MailFlow hosts must use https://');
+  }
+
+  url.username = '';
+  url.password = '';
+  url.hash = '';
+  url.search = '';
+  url.pathname = '/';
+
+  return url.toString().replace(/\/$/, '');
+}
+
+function isSameOrigin(configuredHost, candidateUrl) {
+  try {
+    return new URL(candidateUrl).origin === new URL(configuredHost).origin;
+  } catch {
+    return false;
+  }
+}
+
+function isOidcStart(url) {
+  return /^\/auth\/oidc\/[^/]+\/start\/?$/.test(url.pathname);
+}
+
+function isOidcCallback(url) {
+  return /^\/auth\/oidc\/[^/]+\/callback\/?$/.test(url.pathname);
+}
+
+function isOidcCompletion(url) {
+  return url.searchParams.has('oidc_success') || url.searchParams.has('oidc_error');
+}
+
+function createNavigationPolicy(getConfiguredHost, { oidcTimeoutMs = 10 * 60 * 1000, now = Date.now } = {}) {
+  let oidcExpiresAt = 0;
+  let oidcOrigins = new Set();
+
+  const resetOidc = () => {
+    oidcExpiresAt = 0;
+    oidcOrigins = new Set();
+  };
+
+  const isOidcActive = () => {
+    if (oidcExpiresAt > now()) return true;
+    resetOidc();
+    return false;
+  };
+
+  return {
+    decide(kind, targetUrl) {
+      let target;
+      let configured;
+      try {
+        target = new URL(targetUrl);
+        configured = new URL(getConfiguredHost());
+      } catch {
+        return 'block';
+      }
+
+      if (target.origin === configured.origin) {
+        if (isOidcStart(target)) {
+          oidcExpiresAt = now() + oidcTimeoutMs;
+          oidcOrigins = new Set([configured.origin]);
+        } else if (isOidcCompletion(target)) {
+          resetOidc();
+        } else if (isOidcActive() && !isOidcCallback(target)) {
+          resetOidc();
+        }
+        return 'allow';
+      }
+
+      if (!isOidcActive()) return 'block';
+      if (oidcOrigins.has(target.origin)) return 'allow';
+
+      if (kind === 'redirect') {
+        oidcOrigins.add(target.origin);
+        return 'allow';
+      }
+
+      return 'block';
+    },
+
+    reset: resetOidc,
+  };
+}
+
+function hasMatchingWindowsPublisher(installed, downloaded) {
+  return installed?.status === 'Valid'
+    && downloaded?.status === 'Valid'
+    && Boolean(installed.subject)
+    && installed.subject === downloaded.subject;
+}
+
+function macTeamIdentifier(output) {
+  return String(output || '').match(/^TeamIdentifier=(.+)$/m)?.[1]?.trim() || null;
+}
+
+function hasMatchingMacTeam(installedOutput, downloadedOutput) {
+  const installedTeam = macTeamIdentifier(installedOutput);
+  return Boolean(installedTeam) && installedTeam === macTeamIdentifier(downloadedOutput);
+}
+
+module.exports = {
+  createNavigationPolicy,
+  hasMatchingMacTeam,
+  hasMatchingWindowsPublisher,
+  isAllowedCleartextHostname,
+  isSameOrigin,
+  normalizeHost,
+};

--- a/frontend/packages/electron/security.test.cjs
+++ b/frontend/packages/electron/security.test.cjs
@@ -1,0 +1,109 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const security = require('./security.cjs');
+
+test('normalizes HTTPS hosts to an origin', () => {
+  assert.equal(
+    security.normalizeHost(' https://Mail.Example.com:8443/inbox?view=all#today '),
+    'https://mail.example.com:8443',
+  );
+});
+
+test('allows cleartext only for localhost, loopback, and RFC 1918 literals', () => {
+  for (const host of [
+    'http://localhost:3000',
+    'http://127.0.0.1',
+    'http://10.0.0.8',
+    'http://172.16.0.1',
+    'http://172.31.255.255',
+    'http://192.168.1.20',
+    'http://[::1]:8080',
+  ]) {
+    assert.equal(security.normalizeHost(host), host);
+  }
+});
+
+test('rejects cleartext public, lookalike, and non-RFC 1918 hosts', () => {
+  for (const host of [
+    'http://example.com',
+    'http://localhost.example.com',
+    'http://10.example.com',
+    'http://172.32.0.1',
+    'http://192.169.0.1',
+    'http://169.254.1.1',
+  ]) {
+    assert.throws(() => security.normalizeHost(host), /https/i);
+  }
+});
+
+test('matches configured hosts by exact origin instead of string prefix', () => {
+  assert.equal(security.isSameOrigin('https://mail.example.com', 'https://mail.example.com/inbox'), true);
+  assert.equal(security.isSameOrigin('https://mail.example.com', 'https://mail.example.com:443/inbox'), true);
+  assert.equal(security.isSameOrigin('https://mail.example.com', 'https://mail.example.com.attacker.test'), false);
+  assert.equal(security.isSameOrigin('https://mail.example.com', 'https://mail.example.com:444'), false);
+});
+
+test('navigation policy allows configured-origin pages and a bounded OIDC redirect chain', () => {
+  const policy = security.createNavigationPolicy(() => 'https://mail.example.com', { oidcTimeoutMs: 60_000 });
+
+  assert.equal(policy.decide('navigate', 'https://mail.example.com/inbox'), 'allow');
+  assert.equal(policy.decide('navigate', 'https://idp.example.test/login'), 'block');
+
+  assert.equal(policy.decide('navigate', 'https://mail.example.com/auth/oidc/work/start'), 'allow');
+  assert.equal(policy.decide('redirect', 'https://idp.example.test/authorize'), 'allow');
+  assert.equal(policy.decide('navigate', 'https://idp.example.test/login'), 'allow');
+  assert.equal(policy.decide('redirect', 'https://login.example.test/mfa'), 'allow');
+  assert.equal(policy.decide('redirect', 'https://mail.example.com/auth/oidc/work/callback?code=ok'), 'allow');
+  assert.equal(policy.decide('redirect', 'https://mail.example.com/?oidc_success=login'), 'allow');
+  assert.equal(policy.decide('navigate', 'https://idp.example.test/login'), 'block');
+});
+
+test('navigation policy does not let renderer navigation extend an OIDC origin chain', () => {
+  const policy = security.createNavigationPolicy(() => 'https://mail.example.com', { oidcTimeoutMs: 60_000 });
+
+  policy.decide('navigate', 'https://mail.example.com/auth/oidc/work/start');
+  policy.decide('redirect', 'https://idp.example.test/authorize');
+
+  assert.equal(policy.decide('navigate', 'https://attacker.test/phish'), 'block');
+});
+
+test('Windows signature verification requires a valid matching publisher', () => {
+  assert.equal(
+    security.hasMatchingWindowsPublisher(
+      { status: 'Valid', subject: 'CN=MailFlow LLC' },
+      { status: 'Valid', subject: 'CN=MailFlow LLC' },
+    ),
+    true,
+  );
+  assert.equal(
+    security.hasMatchingWindowsPublisher(
+      { status: 'Valid', subject: 'CN=MailFlow LLC' },
+      { status: 'Valid', subject: 'CN=Other Publisher' },
+    ),
+    false,
+  );
+  assert.equal(
+    security.hasMatchingWindowsPublisher(
+      { status: 'Valid', subject: 'CN=MailFlow LLC' },
+      { status: 'NotSigned', subject: 'CN=MailFlow LLC' },
+    ),
+    false,
+  );
+});
+
+test('macOS signature verification requires a matching TeamIdentifier', () => {
+  assert.equal(
+    security.hasMatchingMacTeam(
+      'Authority=Developer ID Application: MailFlow\nTeamIdentifier=ABC123',
+      'Authority=Developer ID Application: MailFlow\nTeamIdentifier=ABC123',
+    ),
+    true,
+  );
+  assert.equal(
+    security.hasMatchingMacTeam(
+      'TeamIdentifier=ABC123',
+      'TeamIdentifier=EVIL999',
+    ),
+    false,
+  );
+});

--- a/frontend/src/components/ElectronNotificationBridge.jsx
+++ b/frontend/src/components/ElectronNotificationBridge.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useStore } from '../store/index.js';
 import { api } from '../utils/api.js';
 import { installCapacitorNativeBridge } from '../utils/capacitorNativeBridge.js';
+import { createBoundedActionIdTracker, isTrustedNativeMessage } from '../utils/nativeActionSecurity.js';
 
 export default function ElectronNotificationBridge() {
   const addNotification = useStore(state => state.addNotification);
@@ -11,7 +12,7 @@ export default function ElectronNotificationBridge() {
   const setSearchQuery = useStore(state => state.setSearchQuery);
   const totalUnread = useStore(state => state.unreadCounts.total);
   const lastActionRef = useRef({ action: null, time: 0 });
-  const processedActionIdsRef = useRef(new Set());
+  const processedActionIdsRef = useRef(createBoundedActionIdTracker());
   const [nativeBridgeReady, setNativeBridgeReady] = useState(() => Boolean(window.mailflowNative));
 
   useEffect(() => {
@@ -166,8 +167,7 @@ export default function ElectronNotificationBridge() {
       const id = typeof payload === 'object' ? payload?.id : null;
 
       if (!action) return;
-      if (id && processedActionIdsRef.current.has(id)) return;
-      if (id) processedActionIdsRef.current.add(id);
+      if (id && !processedActionIdsRef.current.remember(id)) return;
 
       const now = Date.now();
       const last = lastActionRef.current;
@@ -238,7 +238,7 @@ export default function ElectronNotificationBridge() {
     };
 
     const handleNativeMessage = (event) => {
-      if (event.source !== window) return;
+      if (!isTrustedNativeMessage(event)) return;
       if (event.data?.type === 'mailflow:native-action') {
         runNativeAction(event.data.payload);
       } else if (event.data?.type === 'mailflow:native-actions-ready') {

--- a/frontend/src/utils/nativeActionSecurity.js
+++ b/frontend/src/utils/nativeActionSecurity.js
@@ -1,0 +1,24 @@
+export function isTrustedNativeMessage(event, expectedWindow = window) {
+  return event.source === expectedWindow && event.origin === expectedWindow.location.origin;
+}
+
+export function createBoundedActionIdTracker(limit = 1000) {
+  const ids = new Set();
+
+  return {
+    has(id) {
+      return ids.has(id);
+    },
+
+    remember(id) {
+      if (ids.has(id)) return false;
+      ids.add(id);
+
+      while (ids.size > limit) {
+        ids.delete(ids.values().next().value);
+      }
+
+      return true;
+    },
+  };
+}

--- a/frontend/src/utils/nativeActionSecurity.test.js
+++ b/frontend/src/utils/nativeActionSecurity.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createBoundedActionIdTracker, isTrustedNativeMessage } from './nativeActionSecurity.js';
+
+test('accepts native window messages only from the same window and origin', () => {
+  const expectedWindow = { location: { origin: 'https://mail.example.com' } };
+
+  assert.equal(isTrustedNativeMessage({
+    source: expectedWindow,
+    origin: 'https://mail.example.com',
+  }, expectedWindow), true);
+  assert.equal(isTrustedNativeMessage({
+    source: expectedWindow,
+    origin: 'https://attacker.test',
+  }, expectedWindow), false);
+  assert.equal(isTrustedNativeMessage({
+    source: {},
+    origin: 'https://mail.example.com',
+  }, expectedWindow), false);
+});
+
+test('bounded action ID tracker evicts the oldest IDs', () => {
+  const tracker = createBoundedActionIdTracker(2);
+
+  assert.equal(tracker.remember('one'), true);
+  assert.equal(tracker.remember('two'), true);
+  assert.equal(tracker.remember('two'), false);
+  assert.equal(tracker.remember('three'), true);
+  assert.equal(tracker.has('one'), false);
+  assert.equal(tracker.has('two'), true);
+  assert.equal(tracker.has('three'), true);
+});


### PR DESCRIPTION
## Summary

Hardens the Electron and Android wrappers before the first signed native release. This addresses the contributor-owned items in #301; CI least-privilege item 7 remains maintainer-owned as requested in the issue.

## Changes

- verify Electron release digests when GitHub provides them, require the downloaded Windows/macOS artifact to match the installed publisher/team, and hand Linux packages to the system installer without unattended `sudo`
- lock Electron top-frame navigation to the configured origin while allowing a bounded OIDC redirect chain, and require HTTPS except for warned localhost/RFC 1918 connections
- authenticate Android notification/update intents with a per-install secret before privileged dispatch
- replace the all-frame Android JavaScript interface and wildcard navigation rule with an exact-origin, main-frame-only message listener and exact origin matching
- restrict Android cleartext host configuration, redirect update downloads only across HTTPS, verify release digests when available, and scope FileProvider access to the update directory
- disable Android backups and third-party cookies, enforce renderer message origins, remove redundant wildcard message dispatch, and bound processed native action IDs

## Testing

- `frontend: npm test` — 1,413 passed
- `frontend: npm run lint`
- `frontend: npm run build`
- `backend: npx --yes node@22 node_modules/vitest/vitest.mjs run` — 706 passed
- `backend: npm run lint`
- `android: npm run android:sync`
- `android: ./gradlew testDebugUnitTest assembleDebug lintDebug`
- `electron: npm run electron:dist -- --linux dir`
- confirmed the committed Gradle 8.14.3 wrapper JAR SHA-256 against the official checksum
- not run: signed-artifact verification on Windows/macOS or native flows on physical devices

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
