### PR TITLE
fix: honor user language for AI responses

### DIFF
--- a/backend/src/routes/ai.js
+++ b/backend/src/routes/ai.js
@@ -7,6 +7,23 @@ import { getConnectionPolicy } from '../services/connectionPolicy.js';
 
 const router = Router();
 
+const AI_LANGUAGE_NAMES = {
+  en: 'English',
+  ru: 'Russian',
+  de: 'German',
+  es: 'Spanish',
+  fr: 'French',
+  it: 'Italian',
+  zhCN: 'Simplified Chinese',
+};
+
+export function aiLanguageInstruction(language) {
+  const name = Object.hasOwn(AI_LANGUAGE_NAMES, language)
+    ? AI_LANGUAGE_NAMES[language]
+    : 'the user interface language';
+  return `Always respond in ${name}, unless the user explicitly asks for another language. For email drafting and rewriting, preserve the original email language when it differs from ${name}.`;
+}
+
 // ── Admin: AI provider configuration ──────────────────────────────────────────
 
 router.get('/admin/ai', requireAdmin, async (req, res) => {
@@ -163,6 +180,13 @@ router.post('/ai/chat', requireAuth, async (req, res) => {
     }
   }
 
+  const prefResult = await query('SELECT preferences FROM users WHERE id = $1', [req.session.userId]);
+  const language = prefResult.rows[0]?.preferences?.language || 'en';
+  const providerMessages = [
+    { role: 'system', content: aiLanguageInstruction(language) },
+    ...messages,
+  ];
+
   const apiKey = cfg.apiKey ? decrypt(cfg.apiKey) : null;
   const headers = { 'Content-Type': 'application/json' };
   if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
@@ -173,7 +197,7 @@ router.post('/ai/chat', requireAuth, async (req, res) => {
     const aiRes = await fetch(`${cfg.baseUrl}/chat/completions`, {
       method: 'POST',
       headers,
-      body: JSON.stringify({ model: cfg.model, messages, stream: true }),
+      body: JSON.stringify({ model: cfg.model, messages: providerMessages, stream: true }),
       signal: AbortSignal.timeout(120000),
     });
 

--- a/backend/src/routes/ai.test.js
+++ b/backend/src/routes/ai.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: vi.fn(),
+  requireAdmin: vi.fn(),
+}));
+vi.mock('../services/encryption.js', () => ({
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+}));
+vi.mock('../services/hostValidation.js', () => ({ validateHost: vi.fn() }));
+vi.mock('../services/connectionPolicy.js', () => ({ getConnectionPolicy: vi.fn() }));
+
+import { aiLanguageInstruction } from './ai.js';
+
+describe('aiLanguageInstruction', () => {
+  it.each([
+    ['en', 'English'],
+    ['ru', 'Russian'],
+    ['de', 'German'],
+    ['es', 'Spanish'],
+    ['fr', 'French'],
+    ['it', 'Italian'],
+    ['zhCN', 'Simplified Chinese'],
+  ])('maps %s to %s', (language, name) => {
+    expect(aiLanguageInstruction(language)).toBe(
+      `Always respond in ${name}, unless the user explicitly asks for another language. For email drafting and rewriting, preserve the original email language when it differs from ${name}.`,
+    );
+  });
+
+  it.each([undefined, null, '', 'pt', 'constructor', 'toString'])(
+    'uses a non-interpolating fallback for unsupported value %s',
+    (language) => {
+      expect(aiLanguageInstruction(language)).toBe(
+        'Always respond in the user interface language, unless the user explicitly asks for another language. For email drafting and rewriting, preserve the original email language when it differs from the user interface language.',
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Replacement for #297 after maintainer review. This re-cuts the accepted AI-language change from current `main`, without the unrelated IMAP/MIME commit carried by the original contributor branch.

## Changes

- prepend an allowlisted user-interface language instruction to `/ai/chat` provider messages
- preserve the original email language for drafting and rewriting
- cover all seven supported languages plus missing, unknown, and inherited-object-key fallbacks
- keep GTD waiting gists in the source email language intentionally: they are cached content summaries, not interactive UI responses, and changing them on a locale switch would require separate preference plumbing and cache invalidation

## Testing

- `backend`: 42 Vitest files / 753 tests passed on Node 22
- `backend`: ESLint passed with zero warnings
- `frontend`: 1,451 tests passed on Node 22
- `frontend`: ESLint passed with zero warnings
- `frontend`: production Vite build passed

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.