### PR TITLE
feat: add declarative command engine

### DIFF
--- a/frontend/src/commands/contracts.js
+++ b/frontend/src/commands/contracts.js
@@ -1,0 +1,126 @@
+export const TARGET_MODES = Object.freeze({
+  GLOBAL: 'global',
+  ACCOUNT: 'account',
+  DRAFT: 'draft',
+  SINGLE_CONVERSATION: 'single_conversation',
+  BULK_SAFE: 'bulk_safe',
+});
+
+export const SURFACES = Object.freeze(['list', 'conversation', 'compose', 'settings', 'picker']);
+export const PLATFORMS = Object.freeze(['mac', 'windows', 'linux']);
+
+/** @typedef {string | {default?: string, mac?: string, windows?: string, linux?: string}} KeySpec */
+
+/**
+ * @typedef {object} CommandDefinition
+ * @property {string} id
+ * @property {string} titleKey
+ * @property {string[]} aliasKeys
+ * @property {string} icon
+ * @property {string} group
+ * @property {{primary: KeySpec | null, secondary: KeySpec[]}} defaultKeys
+ * @property {{base: number, boost?: (context: CommandContext) => number}} rank
+ * @property {(context: CommandContext) => boolean} isAvailable
+ * @property {'global'|'account'|'draft'|'single_conversation'|'bulk_safe'} targetMode
+ * @property {string} executorId
+ * @property {Readonly<Record<string, unknown>>} [params]
+ */
+
+/**
+ * @typedef {object} CommandContext
+ * @property {'list'|'conversation'|'compose'|'settings'|'picker'} surface
+ * @property {string | null} activeConversationId
+ * @property {object | null} activeMessage
+ * @property {readonly string[]} selectedConversationIds
+ * @property {readonly string[]} visibleConversationIds
+ * @property {Readonly<Record<string, {id: string, rowId: string, accountId: string | null, message: object}>>} conversationsById
+ * @property {string | null} accountId
+ * @property {string | null} folder
+ * @property {object | null} draft
+ * @property {boolean} gtdAvailable
+ * @property {boolean} cardDavConnected
+ * @property {object | null} modal
+ * @property {boolean} editing
+ * @property {boolean} undoAvailable
+ * @property {'mac'|'windows'|'linux'} platform
+ * @property {Readonly<Record<string, string | null>>} shortcutOverrides
+ * @property {(key: string, values?: object) => string} translate
+ */
+
+function freezeKeySpec(spec) {
+  return spec && typeof spec === 'object' ? Object.freeze({ ...spec }) : spec;
+}
+
+export function stableConversationId(message) {
+  const accountId = message?.account_id;
+  const withinAccountId = message?.message_id || message?.id;
+  return accountId && withinAccountId ? `${accountId}:${withinAccountId}` : null;
+}
+
+export function validateCommandDefinition(input) {
+  if (!input?.id?.includes('.')) throw new TypeError('command id must be namespaced');
+  for (const key of ['titleKey', 'icon', 'group']) {
+    if (typeof input[key] !== 'string' || !input[key]) throw new TypeError(`${key} must be a non-empty string`);
+  }
+  if (!Array.isArray(input.aliasKeys) || input.aliasKeys.some(key => typeof key !== 'string')) {
+    throw new TypeError('aliasKeys must be an array of localization keys');
+  }
+  if (!Object.values(TARGET_MODES).includes(input.targetMode)) {
+    throw new TypeError(`unsupported targetMode "${input.targetMode}"`);
+  }
+  if (typeof input.executorId !== 'string' || !input.executorId) {
+    throw new TypeError('executorId must be a non-empty string');
+  }
+  if (typeof input.isAvailable !== 'function') throw new TypeError('isAvailable must be a function');
+  if (!Number.isFinite(input.rank?.base)) throw new TypeError('rank.base must be a finite number');
+  if (input.rank.boost != null && typeof input.rank.boost !== 'function') {
+    throw new TypeError('rank.boost must be a function');
+  }
+  const primary = freezeKeySpec(input.defaultKeys?.primary ?? null);
+  const secondary = Object.freeze((input.defaultKeys?.secondary || []).map(freezeKeySpec));
+  return Object.freeze({
+    ...input,
+    aliasKeys: Object.freeze([...input.aliasKeys]),
+    defaultKeys: Object.freeze({ primary, secondary }),
+    rank: Object.freeze({ ...input.rank }),
+    params: Object.freeze({ ...(input.params || {}) }),
+  });
+}
+
+export function createCommandContext(input) {
+  if (!SURFACES.includes(input.surface)) throw new TypeError(`unsupported surface "${input.surface}"`);
+  if (!PLATFORMS.includes(input.platform)) throw new TypeError(`unsupported platform "${input.platform}"`);
+  if (typeof input.translate !== 'function') throw new TypeError('translate must be a function');
+
+  const conversationsById = {};
+  for (const message of input.conversations || []) {
+    const id = stableConversationId(message);
+    if (!id || conversationsById[id]) continue;
+    conversationsById[id] = Object.freeze({
+      id,
+      rowId: message.id,
+      accountId: message.account_id ?? null,
+      message,
+    });
+  }
+  const selectedConversationIds = [...new Set(input.selectedConversationIds || [])];
+  return Object.freeze({
+    surface: input.surface,
+    activeConversationId: input.activeConversationId || null,
+    activeMessage: input.activeMessage || null,
+    selectedConversationIds: Object.freeze(selectedConversationIds),
+    visibleConversationIds: Object.freeze([...new Set(input.visibleConversationIds || [])]),
+    conversationsById: Object.freeze(conversationsById),
+    accountId: input.accountId || null,
+    folder: input.folder || null,
+    draft: input.draft || null,
+    gtdAvailable: Boolean(input.gtdAvailable),
+    cardDavConnected: Boolean(input.cardDavConnected),
+    modal: input.modal || null,
+    editing: Boolean(input.editing),
+    undoAvailable: Boolean(input.undoAvailable),
+    platform: input.platform,
+    shortcutOverrides: Object.freeze({ ...(input.shortcutOverrides || {}) }),
+    translate: input.translate,
+  });
+}

--- a/frontend/src/commands/contracts.test.js
+++ b/frontend/src/commands/contracts.test.js
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  TARGET_MODES,
+  createCommandContext,
+  stableConversationId,
+  validateCommandDefinition,
+} from './contracts.js';
+
+const validDefinition = {
+  id: 'mail.archive',
+  titleKey: 'commands.mail.archive.title',
+  aliasKeys: ['commands.mail.archive.alias.done'],
+  icon: 'archive',
+  group: 'mail',
+  defaultKeys: { primary: 'e', secondary: ['o'] },
+  rank: { base: 100, boost: context => context.selectedConversationIds.length ? 25 : 0 },
+  isAvailable: context => context.surface !== 'settings',
+  targetMode: 'bulk_safe',
+  executorId: 'mail.archive',
+};
+
+describe('command contracts', () => {
+  it('uses the five approved target-mode values', () => {
+    assert.deepEqual(Object.values(TARGET_MODES), [
+      'global', 'account', 'draft', 'single_conversation', 'bulk_safe',
+    ]);
+  });
+
+  it('validates and deeply freezes a complete definition', () => {
+    const definition = validateCommandDefinition(validDefinition);
+    assert.equal(definition.id, 'mail.archive');
+    assert.ok(Object.isFrozen(definition));
+    assert.ok(Object.isFrozen(definition.aliasKeys));
+    assert.ok(Object.isFrozen(definition.defaultKeys.secondary));
+    assert.throws(() => definition.aliasKeys.push('commands.other'));
+  });
+
+  it('rejects missing, unnamespaced, and unsupported fields with exact errors', () => {
+    assert.throws(
+      () => validateCommandDefinition({ ...validDefinition, id: 'archive' }),
+      /command id must be namespaced/,
+    );
+    assert.throws(
+      () => validateCommandDefinition({ ...validDefinition, targetMode: 'message' }),
+      /unsupported targetMode "message"/,
+    );
+    assert.throws(
+      () => validateCommandDefinition({ ...validDefinition, executorId: '' }),
+      /executorId must be a non-empty string/,
+    );
+  });
+
+  it('scopes RFC Message-ID and row-id fallback identities by account', () => {
+    assert.equal(stableConversationId({ account_id: 'acct-1', id: 'row-1', message_id: '<same@example.test>' }), 'acct-1:<same@example.test>');
+    assert.equal(stableConversationId({ account_id: 'acct-2', id: 'row-1', message_id: '<same@example.test>' }), 'acct-2:<same@example.test>');
+    assert.equal(stableConversationId({ account_id: 'acct-1', id: 'row-2' }), 'acct-1:row-2');
+    assert.equal(stableConversationId({ id: 'row-2' }), null);
+    assert.equal(stableConversationId({}), null);
+  });
+
+  it('normalizes and freezes a complete command context snapshot', () => {
+    const context = createCommandContext({
+      surface: 'list',
+      activeConversationId: 'acct-1:<active@example.test>',
+      activeMessage: { id: 'row-a', message_id: '<active@example.test>', account_id: 'acct-1' },
+      selectedConversationIds: ['acct-1:<bulk@example.test>', 'acct-1:<bulk@example.test>'],
+      visibleConversationIds: ['acct-1:<active@example.test>', 'acct-1:<bulk@example.test>'],
+      conversations: [
+        { id: 'row-a', message_id: '<active@example.test>', account_id: 'acct-1' },
+        { id: 'row-b', message_id: '<bulk@example.test>', account_id: 'acct-1' },
+      ],
+      accountId: 'acct-1',
+      folder: 'INBOX',
+      draft: null,
+      gtdAvailable: true,
+      cardDavConnected: false,
+      modal: null,
+      editing: false,
+      undoAvailable: true,
+      platform: 'mac',
+      shortcutOverrides: { 'mail.archive': 'x' },
+      translate: key => ({ 'commands.mail.archive.title': 'Archive' })[key] || key,
+    });
+
+    assert.deepEqual(context.selectedConversationIds, ['acct-1:<bulk@example.test>']);
+    assert.deepEqual(context.visibleConversationIds, ['acct-1:<active@example.test>', 'acct-1:<bulk@example.test>']);
+    assert.equal(context.conversationsById['acct-1:<active@example.test>'].rowId, 'row-a');
+    assert.equal(context.activeMessage.id, 'row-a');
+    assert.equal(context.undoAvailable, true);
+    assert.equal(context.translate('commands.mail.archive.title'), 'Archive');
+    assert.ok(Object.isFrozen(context));
+    assert.ok(Object.isFrozen(context.selectedConversationIds));
+  });
+});

--- a/frontend/src/commands/controller.js
+++ b/frontend/src/commands/controller.js
@@ -1,0 +1,84 @@
+import { hasTargets, resolveTargetIds } from './targets.js';
+
+function failed(commandId, error, targetIds = []) {
+  return { status: 'failed', commandId, targetIds, error: error instanceof Error ? error : new Error(String(error)) };
+}
+
+function terminalOutcome(commandId, targetIds, result) {
+  if (!['success', 'cancelled', 'partial', 'failed'].includes(result?.status)) {
+    return failed(commandId, new Error(`Invalid executor outcome for "${commandId}"`), targetIds);
+  }
+  return { commandId, targetIds, ...result };
+}
+
+export function createCommandController({
+  registry,
+  getContext,
+  executors,
+  onContinuation = () => {},
+  onOutcome = () => {},
+}) {
+  const inFlight = new Map();
+
+  function execute(commandId, { source = 'unknown', input, frozenTargetIds } = {}) {
+    const initialContext = getContext();
+    const command = registry.get(commandId);
+    if (!command) {
+      const outcome = failed(commandId, new Error(`Unknown command "${commandId}"`));
+      onOutcome(outcome);
+      return Promise.resolve(outcome);
+    }
+    if (!command.isAvailable(initialContext) || (!frozenTargetIds && !hasTargets(command, initialContext))) {
+      const outcome = failed(commandId, new Error(`Command "${commandId}" is not available`));
+      onOutcome(outcome);
+      return Promise.resolve(outcome);
+    }
+
+    const frozen = frozenTargetIds == null
+      ? resolveTargetIds(command, initialContext).targetIds
+      : [...new Set(frozenTargetIds)];
+    const dedupeKey = `${commandId}:${[...frozen].sort().join('|')}`;
+    if (inFlight.has(dedupeKey)) return inFlight.get(dedupeKey);
+
+    const promise = (async () => {
+      const context = getContext();
+      const { targetIds, missingTargetIds } = resolveTargetIds(command, context, frozen);
+      const executor = executors[command.executorId];
+      if (!executor) return failed(commandId, new Error(`Missing executor "${command.executorId}"`), targetIds);
+      if (frozen.length && !targetIds.length) {
+        return { status: 'partial', commandId, targetIds, missingTargetIds, succeededIds: [], failed: [] };
+      }
+      try {
+        const result = await executor({ command, context, source, input, targetIds });
+        if (result?.status === 'needs_input') {
+          const continuation = Object.freeze({
+            commandId,
+            kind: result.continuation.kind,
+            targetIds: Object.freeze([...frozen]),
+            props: Object.freeze({ ...(result.continuation.props || {}) }),
+          });
+          onContinuation(continuation);
+          return { status: 'needs_input', continuation };
+        }
+        const outcome = terminalOutcome(commandId, targetIds, result);
+        if (missingTargetIds.length && outcome.status === 'success') {
+          return {
+            status: 'partial', commandId, targetIds, missingTargetIds,
+            succeededIds: [...targetIds], failed: [], value: outcome.value,
+          };
+        }
+        return missingTargetIds.length ? { ...outcome, missingTargetIds } : outcome;
+      } catch (error) {
+        return failed(commandId, error, targetIds);
+      }
+    })().then(outcome => {
+      if (outcome.status !== 'needs_input') onOutcome(outcome);
+      return outcome;
+    }).finally(() => inFlight.delete(dedupeKey));
+
+    inFlight.set(dedupeKey, promise);
+    return promise;
+  }
+
+  return Object.freeze({ execute });
+}

--- a/frontend/src/commands/controller.test.js
+++ b/frontend/src/commands/controller.test.js
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCommandContext } from './contracts.js';
+import { createCommandRegistry } from './registry.js';
+import { createCommandController } from './controller.js';
+
+const definition = (overrides = {}) => ({
+  id: 'mail.move', titleKey: 'move', aliasKeys: [], icon: 'move', group: 'mail',
+  defaultKeys: { primary: 'v', secondary: [] }, rank: { base: 1 },
+  isAvailable: () => true, targetMode: 'bulk_safe', executorId: 'mail.move', ...overrides,
+});
+const makeContext = (ids = ['acct:<a>', 'acct:<b>']) => createCommandContext({
+  surface: 'list', activeConversationId: 'acct:<a>', selectedConversationIds: ids,
+  conversations: ids.map((id, index) => ({ id: `row-${index}`, message_id: id.slice('acct:'.length), account_id: 'acct' })),
+  accountId: 'acct', folder: 'INBOX', draft: null, gtdAvailable: false,
+  cardDavConnected: false, modal: null, editing: false, platform: 'mac',
+  shortcutOverrides: {}, translate: key => key,
+});
+
+describe('createCommandController', () => {
+  it('rejects unknown, unavailable, and missing executors as failed outcomes', async () => {
+    const registry = createCommandRegistry([definition({ isAvailable: () => false })]);
+    const controller = createCommandController({ registry, getContext: () => makeContext(), executors: {} });
+    assert.match((await controller.execute('missing.command')).error.message, /Unknown command/);
+    assert.match((await controller.execute('mail.move')).error.message, /not available/);
+
+    const available = createCommandRegistry([definition()]);
+    const noExecutor = createCommandController({ registry: available, getContext: () => makeContext(), executors: {} });
+    assert.match((await noExecutor.execute('mail.move')).error.message, /Missing executor/);
+  });
+
+  it('freezes targets into a continuation and reuses them on resume', async () => {
+    let context = makeContext();
+    const calls = [];
+    const continuations = [];
+    const registry = createCommandRegistry([definition()]);
+    const controller = createCommandController({
+      registry,
+      getContext: () => context,
+      executors: {
+        'mail.move': args => {
+          calls.push(args);
+          return args.input
+            ? { status: 'success', value: { folder: args.input.folder } }
+            : { status: 'needs_input', continuation: { kind: 'move', props: { titleKey: 'move.title' } } };
+        },
+      },
+      onContinuation: value => continuations.push(value),
+    });
+
+    const first = await controller.execute('mail.move', { source: 'palette' });
+    assert.deepEqual(first.continuation, {
+      commandId: 'mail.move', kind: 'move', targetIds: ['acct:<a>', 'acct:<b>'], props: { titleKey: 'move.title' },
+    });
+    assert.deepEqual(continuations, [first.continuation]);
+
+    context = makeContext(['acct:<a>']);
+    const resumed = await controller.execute('mail.move', {
+      source: 'palette', input: { folder: 'Archive' }, frozenTargetIds: first.continuation.targetIds,
+    });
+    assert.equal(resumed.status, 'partial');
+    assert.deepEqual(resumed.targetIds, ['acct:<a>']);
+    assert.deepEqual(resumed.missingTargetIds, ['acct:<b>']);
+    assert.deepEqual(calls[1].targetIds, ['acct:<a>']);
+  });
+
+  it('deduplicates only concurrent execution of the same command and target set', async () => {
+    let release;
+    let callCount = 0;
+    const gate = new Promise(resolve => { release = resolve; });
+    const registry = createCommandRegistry([definition()]);
+    const controller = createCommandController({
+      registry, getContext: () => makeContext(),
+      executors: { 'mail.move': async () => { callCount += 1; await gate; return { status: 'success' }; } },
+    });
+    const one = controller.execute('mail.move');
+    const two = controller.execute('mail.move');
+    assert.strictEqual(one, two);
+    release();
+    await one;
+    await controller.execute('mail.move');
+    assert.equal(callCount, 2);
+  });
+
+  it('normalizes success, cancelled, partial, thrown failures, and callback delivery', async () => {
+    const terminal = [];
+    const outcomes = ['success', 'cancelled', 'partial'];
+    for (const status of outcomes) {
+      const registry = createCommandRegistry([definition()]);
+      const controller = createCommandController({
+        registry, getContext: () => makeContext(['acct:<a>']),
+        executors: { 'mail.move': () => status === 'partial'
+          ? { status, succeededIds: [], failed: [{ targetId: 'acct:<a>', error: new Error('nope') }] }
+          : { status } },
+        onOutcome: outcome => terminal.push(outcome.status),
+      });
+      assert.equal((await controller.execute('mail.move')).status, status);
+    }
+    const registry = createCommandRegistry([definition()]);
+    const failed = createCommandController({
+      registry, getContext: () => makeContext(['acct:<a>']),
+      executors: { 'mail.move': () => { throw new Error('boom'); } },
+      onOutcome: outcome => terminal.push(outcome.status),
+    });
+    assert.equal((await failed.execute('mail.move')).status, 'failed');
+    assert.deepEqual(terminal, ['success', 'cancelled', 'partial', 'failed']);
+  });
+});

--- a/frontend/src/commands/registry.js
+++ b/frontend/src/commands/registry.js
@@ -1,0 +1,34 @@
+import { validateCommandDefinition } from './contracts.js';
+import { hasTargets } from './targets.js';
+import { rankCommands } from './search.js';
+import { effectiveCommandKeys } from './shortcuts.js';
+
+export function createCommandRegistry(definitions) {
+  const ordered = [];
+  const byId = new Map();
+  for (const input of definitions) {
+    const command = validateCommandDefinition(input);
+    if (byId.has(command.id)) throw new TypeError(`duplicate command id "${command.id}"`);
+    ordered.push(command);
+    byId.set(command.id, command);
+  }
+  Object.freeze(ordered);
+
+  const available = context => ordered.filter(command => command.isAvailable(context) && hasTargets(command, context));
+  const decorate = (results, context) => results.map(result => ({
+    ...result,
+    bindings: effectiveCommandKeys(result.command, context).bindings,
+  }));
+
+  return Object.freeze({
+    get(id) {
+      return byId.get(id) || null;
+    },
+    list(context) {
+      return decorate(rankCommands(available(context), '', context), context);
+    },
+    search(query, context) {
+      return decorate(rankCommands(available(context), query, context), context);
+    },
+  });
+}

--- a/frontend/src/commands/registry.test.js
+++ b/frontend/src/commands/registry.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCommandContext } from './contracts.js';
+import { createCommandRegistry } from './registry.js';
+
+const raw = (id, overrides = {}) => ({
+  id, titleKey: `${id}.title`, aliasKeys: [], icon: 'test', group: 'test',
+  defaultKeys: { primary: null, secondary: [] }, rank: { base: 0 },
+  isAvailable: () => true, targetMode: 'global', executorId: id, ...overrides,
+});
+const context = createCommandContext({
+  surface: 'list', activeConversationId: null, selectedConversationIds: [], conversations: [],
+  accountId: null, folder: null, draft: null, gtdAvailable: false, cardDavConnected: false,
+  modal: null, editing: false, platform: 'mac', shortcutOverrides: {}, translate: key => key,
+});
+
+describe('createCommandRegistry', () => {
+  it('rejects duplicate IDs before exposing a partial registry', () => {
+    assert.throws(() => createCommandRegistry([raw('test.one'), raw('test.one')]), /duplicate command id "test.one"/);
+  });
+
+  it('returns definitions by ID without exposing mutation', () => {
+    const registry = createCommandRegistry([raw('test.one')]);
+    assert.equal(registry.get('test.one').executorId, 'test.one');
+    assert.equal(registry.get('test.missing'), null);
+    assert.ok(Object.isFrozen(registry.get('test.one')));
+  });
+
+  it('omits explicit and target-mode-unavailable commands', () => {
+    const registry = createCommandRegistry([
+      raw('global.visible'),
+      raw('global.hidden', { isAvailable: () => false }),
+      raw('mail.archive', { targetMode: 'bulk_safe' }),
+    ]);
+    assert.deepEqual(registry.list(context).map(entry => entry.command.id), ['global.visible']);
+  });
+
+  it('returns effective bindings and localized alias search metadata', () => {
+    const registry = createCommandRegistry([raw('mail.archive', {
+      titleKey: 'archive', aliasKeys: ['done'], defaultKeys: { primary: 'e', secondary: [] },
+    })]);
+    const localized = { ...context, translate: key => ({ archive: 'Archive', done: 'Done' })[key] || key };
+    const [result] = registry.search('done', localized);
+    assert.equal(result.title, 'Archive');
+    assert.equal(result.matchedAlias, 'Done');
+    assert.deepEqual(result.bindings, [{ key: 'e', kind: 'primary' }]);
+  });
+});

--- a/frontend/src/commands/search.js
+++ b/frontend/src/commands/search.js
@@ -1,0 +1,60 @@
+function normalize(value) {
+  return String(value || '').normalize('NFKD').replace(/\p{Diacritic}/gu, '').toLowerCase().trim();
+}
+
+function editDistance(a, b) {
+  const rows = Array.from({ length: a.length + 1 }, (_, i) => [i]);
+  for (let j = 1; j <= b.length; j += 1) rows[0][j] = j;
+  for (let i = 1; i <= a.length; i += 1) {
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      rows[i][j] = Math.min(rows[i - 1][j] + 1, rows[i][j - 1] + 1, rows[i - 1][j - 1] + cost);
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+        rows[i][j] = Math.min(rows[i][j], rows[i - 2][j - 2] + 1);
+      }
+    }
+  }
+  return rows[a.length][b.length];
+}
+
+function fuzzyScore(candidate, query) {
+  const text = normalize(candidate);
+  const needle = normalize(query);
+  if (!needle) return 0;
+  if (text === needle) return 1000;
+  if (text.startsWith(needle)) return 900 - (text.length - needle.length);
+  if (text.includes(needle)) return 800 - text.indexOf(needle);
+  const distance = editDistance(text, needle);
+  const limit = Math.max(1, Math.floor(Math.max(text.length, needle.length) * 0.34));
+  return distance <= limit ? 600 - (distance * 40) - Math.abs(text.length - needle.length) : null;
+}
+
+export function rankCommands(commands, query, context) {
+  return commands.map((command, index) => {
+    const title = context.translate(command.titleKey, command.params);
+    const aliases = command.aliasKeys.map(key => ({ key, value: context.translate(key, command.params) }));
+    const candidates = [{ key: null, value: title }, ...aliases]
+      .map(item => ({ ...item, fuzzy: fuzzyScore(item.value, query) }))
+      .filter(item => item.fuzzy != null)
+      .sort((a, b) => b.fuzzy - a.fuzzy);
+    if (query.trim() && !candidates.length) return null;
+    const match = candidates[0] || { key: null, value: title, fuzzy: 0 };
+    const boost = command.rank.boost ? command.rank.boost(context) : 0;
+    return {
+      command,
+      title,
+      matchedAlias: match.key ? match.value : null,
+      matchedAliasKey: match.key,
+      score: match.fuzzy + command.rank.base + boost,
+      index,
+    };
+  }).filter(Boolean)
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .map(result => ({
+      command: result.command,
+      title: result.title,
+      matchedAlias: result.matchedAlias,
+      matchedAliasKey: result.matchedAliasKey,
+      score: result.score,
+    }));
+}

--- a/frontend/src/commands/search.test.js
+++ b/frontend/src/commands/search.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCommandContext, validateCommandDefinition } from './contracts.js';
+import { rankCommands } from './search.js';
+
+const make = (id, titleKey, aliasKeys, base, boost = () => 0) => validateCommandDefinition({
+  id, titleKey, aliasKeys, icon: 'test', group: 'test',
+  defaultKeys: { primary: null, secondary: [] }, rank: { base, boost },
+  isAvailable: () => true, targetMode: 'global', executorId: id,
+});
+const strings = {
+  archive: 'Archive', done: 'Done', compose: 'Compose', search: 'Search', settings: 'Settings',
+};
+const context = createCommandContext({
+  surface: 'list', activeConversationId: null, selectedConversationIds: [], conversations: [],
+  accountId: null, folder: null, draft: null, gtdAvailable: false, cardDavConnected: false,
+  modal: null, editing: false, platform: 'mac', shortcutOverrides: {},
+  translate: key => strings[key] || key,
+});
+const archive = make('mail.archive', 'archive', ['done'], 50, ctx => ctx.selectedConversationIds.length ? 30 : 0);
+const compose = make('compose.new', 'compose', [], 60);
+const settings = make('settings.open', 'settings', [], 10);
+
+describe('rankCommands', () => {
+  it('finds case-insensitive title matches', () => {
+    assert.equal(rankCommands([archive, compose], 'ARCHIVE', context)[0].command.id, 'mail.archive');
+  });
+
+  it('keeps the Mailflow title and discloses the matching alias', () => {
+    const [result] = rankCommands([archive, compose], 'done', context);
+    assert.equal(result.title, 'Archive');
+    assert.equal(result.matchedAlias, 'Done');
+    assert.equal(result.matchedAliasKey, 'done');
+  });
+
+  it('tolerates a close transposition misspelling', () => {
+    assert.equal(rankCommands([archive, compose], 'arhcive', context)[0].command.id, 'mail.archive');
+  });
+
+  it('uses stable base priority for an empty query', () => {
+    assert.deepEqual(rankCommands([settings, compose, archive], '', context).map(x => x.command.id), [
+      'compose.new', 'mail.archive', 'settings.open',
+    ]);
+  });
+
+  it('adds contextual boost and preserves definition order for exact ties', () => {
+    const selected = { ...context, selectedConversationIds: ['acct:<a>'] };
+    const equalA = make('navigation.a', 'search', [], 1);
+    const equalB = make('navigation.b', 'search', [], 1);
+    assert.equal(rankCommands([compose, archive], '', selected)[0].command.id, 'mail.archive');
+    assert.deepEqual(rankCommands([equalA, equalB], 'search', context).map(x => x.command.id), [
+      'navigation.a', 'navigation.b',
+    ]);
+  });
+});

--- a/frontend/src/commands/shortcuts.js
+++ b/frontend/src/commands/shortcuts.js
@@ -1,0 +1,43 @@
+function selectKey(spec, platform) {
+  if (!spec) return null;
+  if (typeof spec === 'string') return spec;
+  return spec[platform] || spec.default || null;
+}
+
+export function effectiveCommandKeys(command, context) {
+  const hasOverride = Object.hasOwn(context.shortcutOverrides, command.id);
+  const override = hasOverride ? context.shortcutOverrides[command.id] : undefined;
+  const bindings = [];
+  const primary = hasOverride ? override : selectKey(command.defaultKeys.primary, context.platform);
+  if (primary) bindings.push({ key: primary, kind: hasOverride ? 'user' : 'primary' });
+  for (const spec of command.defaultKeys.secondary) {
+    const key = selectKey(spec, context.platform);
+    if (key && !bindings.some(binding => binding.key === key)) bindings.push({ key, kind: 'secondary' });
+  }
+  return { bindings, conflicts: [] };
+}
+
+export function formatCommandKey(key, platform) {
+  const mac = platform === 'mac';
+  const labels = mac
+    ? { meta: '⌘', ctrl: '⌃', alt: '⌥', shift: '⇧', enter: '↵' }
+    : { meta: 'Win+', ctrl: 'Ctrl+', alt: 'Alt+', shift: 'Shift+', enter: 'Enter' };
+  return key.split('+').map((part, index, all) => {
+    const normalized = part.toLowerCase();
+    const label = labels[normalized] || (part.length === 1 ? part.toUpperCase() : part);
+    return mac || index === all.length - 1 ? label : label;
+  }).join(mac ? '' : '');
+}
+
+export function findBindingConflicts(commands, context) {
+  const owners = new Map();
+  for (const command of commands) {
+    for (const { key } of effectiveCommandKeys(command, context).bindings) {
+      if (!owners.has(key)) owners.set(key, []);
+      owners.get(key).push(command.id);
+    }
+  }
+  return [...owners.entries()]
+    .filter(([, commandIds]) => commandIds.length > 1)
+    .map(([key, commandIds]) => ({ key, commandIds }));
+}

--- a/frontend/src/commands/shortcuts.test.js
+++ b/frontend/src/commands/shortcuts.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { effectiveCommandKeys, findBindingConflicts, formatCommandKey } from './shortcuts.js';
+
+const command = {
+  id: 'palette.toggle',
+  defaultKeys: {
+    primary: { mac: 'meta+k', windows: 'ctrl+k', linux: 'ctrl+k' },
+    secondary: ['alt+k'],
+  },
+};
+
+describe('command shortcut metadata', () => {
+  it('selects the platform primary and retains secondary bindings', () => {
+    assert.deepEqual(effectiveCommandKeys(command, { platform: 'mac', shortcutOverrides: {} }).bindings, [
+      { key: 'meta+k', kind: 'primary' }, { key: 'alt+k', kind: 'secondary' },
+    ]);
+    assert.equal(effectiveCommandKeys(command, { platform: 'linux', shortcutOverrides: {} }).bindings[0].key, 'ctrl+k');
+  });
+
+  it('uses the unchanged user override as primary without deleting secondary keys', () => {
+    assert.deepEqual(effectiveCommandKeys(command, {
+      platform: 'windows', shortcutOverrides: { 'palette.toggle': 'ctrl+shift+k' },
+    }).bindings, [
+      { key: 'ctrl+shift+k', kind: 'user' }, { key: 'alt+k', kind: 'secondary' },
+    ]);
+  });
+
+  it('supports explicit primary unbinding and formats platform labels', () => {
+    assert.deepEqual(effectiveCommandKeys(command, {
+      platform: 'mac', shortcutOverrides: { 'palette.toggle': null },
+    }).bindings, [{ key: 'alt+k', kind: 'secondary' }]);
+    assert.equal(formatCommandKey('meta+shift+k', 'mac'), '⌘⇧K');
+    assert.equal(formatCommandKey('ctrl+shift+k', 'windows'), 'Ctrl+Shift+K');
+  });
+
+  it('reports conflicts instead of silently dropping either command', () => {
+    const commands = [command, { ...command, id: 'navigation.search', defaultKeys: { primary: 'alt+k', secondary: [] } }];
+    assert.deepEqual(findBindingConflicts(commands, { platform: 'linux', shortcutOverrides: {} }), [
+      { key: 'alt+k', commandIds: ['palette.toggle', 'navigation.search'] },
+    ]);
+  });
+});

--- a/frontend/src/commands/targets.js
+++ b/frontend/src/commands/targets.js
@@ -1,0 +1,28 @@
+import { TARGET_MODES } from './contracts.js';
+
+function contextualIds(context) {
+  return context.selectedConversationIds.length
+    ? context.selectedConversationIds
+    : context.activeConversationId ? [context.activeConversationId] : [];
+}
+
+export function hasTargets(command, context) {
+  switch (command.targetMode) {
+    case TARGET_MODES.GLOBAL: return true;
+    case TARGET_MODES.ACCOUNT: return Boolean(context.accountId);
+    case TARGET_MODES.DRAFT: return Boolean(context.draft?.id);
+    case TARGET_MODES.SINGLE_CONVERSATION: return contextualIds(context).length === 1;
+    case TARGET_MODES.BULK_SAFE: return contextualIds(context).length > 0;
+    default: return false;
+  }
+}
+
+export function resolveTargetIds(command, context, frozenTargetIds) {
+  if (![TARGET_MODES.SINGLE_CONVERSATION, TARGET_MODES.BULK_SAFE].includes(command.targetMode)) {
+    return { targetIds: [], missingTargetIds: [] };
+  }
+  const requested = frozenTargetIds == null ? contextualIds(context) : [...new Set(frozenTargetIds)];
+  const targetIds = requested.filter(id => context.conversationsById[id]);
+  const missingTargetIds = requested.filter(id => !context.conversationsById[id]);
+  return { targetIds, missingTargetIds };
+}

--- a/frontend/src/commands/targets.test.js
+++ b/frontend/src/commands/targets.test.js
@@ -1,0 +1,55 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createCommandContext, validateCommandDefinition } from './contracts.js';
+import { hasTargets, resolveTargetIds } from './targets.js';
+
+const command = targetMode => validateCommandDefinition({
+  id: `test.${targetMode}`,
+  titleKey: 'test.title', aliasKeys: [], icon: 'test', group: 'test',
+  defaultKeys: { primary: null, secondary: [] }, rank: { base: 0 },
+  isAvailable: () => true, targetMode, executorId: 'test.execute',
+});
+const context = overrides => createCommandContext({
+  surface: 'list', activeConversationId: null, selectedConversationIds: [],
+  conversations: [
+    { id: 'row-a', message_id: '<a>', account_id: 'acct' },
+    { id: 'row-b', message_id: '<b>', account_id: 'acct' },
+  ],
+  accountId: 'acct', folder: 'INBOX', draft: null, gtdAvailable: false,
+  cardDavConnected: false, modal: null, editing: false, platform: 'linux',
+  shortcutOverrides: {}, translate: key => key, ...overrides,
+});
+
+describe('command targets', () => {
+  it('omits conversation commands without an active row or checkbox selection', () => {
+    assert.equal(hasTargets(command('single_conversation'), context({})), false);
+    assert.equal(hasTargets(command('bulk_safe'), context({})), false);
+  });
+
+  it('makes single and bulk-safe commands available for one active conversation', () => {
+    const ctx = context({ activeConversationId: 'acct:<a>' });
+    assert.equal(hasTargets(command('single_conversation'), ctx), true);
+    assert.deepEqual(resolveTargetIds(command('bulk_safe'), ctx), {
+      targetIds: ['acct:<a>'], missingTargetIds: [],
+    });
+  });
+
+  it('uses the complete selection and hides single-conversation commands in bulk', () => {
+    const ctx = context({ activeConversationId: 'acct:<a>', selectedConversationIds: ['acct:<a>', 'acct:<b>'] });
+    assert.equal(hasTargets(command('single_conversation'), ctx), false);
+    assert.deepEqual(resolveTargetIds(command('bulk_safe'), ctx).targetIds, ['acct:<a>', 'acct:<b>']);
+  });
+
+  it('re-resolves a frozen continuation target set and reports missing targets', () => {
+    assert.deepEqual(resolveTargetIds(command('bulk_safe'), context({}), ['acct:<a>', 'acct:<gone>']), {
+      targetIds: ['acct:<a>'], missingTargetIds: ['acct:<gone>'],
+    });
+  });
+
+  it('requires current account and draft state for their scoped modes', () => {
+    assert.equal(hasTargets(command('account'), context({ accountId: null })), false);
+    assert.equal(hasTargets(command('account'), context({ accountId: 'acct' })), true);
+    assert.equal(hasTargets(command('draft'), context({ draft: null })), false);
+    assert.equal(hasTargets(command('draft'), context({ draft: { id: 'draft-1' } })), true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a framework-independent command engine for consistent command discovery, targeting, shortcut metadata, continuations, and execution outcomes.

Closes #334.

## Changes

- add validated, immutable command definitions and normalized application context contracts
- scope stable conversation targets by account and re-resolve frozen target sets before execution
- add localized typo-tolerant search, contextual ranking, alias disclosure, and stable ordering
- resolve platform-aware primary, secondary, and user shortcut bindings while reporting conflicts
- expose the shared `createCommandRegistry` and `createCommandController` APIs
- normalize terminal outcomes, freeze continuation envelopes, and deduplicate concurrent repeats
- cover the engine with 27 focused Node tests without adding dependencies or application commands

## Testing

- `cd frontend && fnm exec --using=22 node --test src/commands/*.test.js` (27 passed)
- `cd frontend && fnm exec --using=22 npm test` (1,570 passed)
- `cd frontend && fnm exec --using=22 npm run lint`
- `cd frontend && fnm exec --using=22 npm run build`
- `git diff --check origin/main...HEAD`

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.