### PR TITLE
fix: stabilize threaded inbox triage

### DIFF
--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -21,7 +21,15 @@ import SenderAvatarImage from './SenderAvatarImage.jsx';
 import { shortcutBus } from '../utils/shortcutBus.js';
 import { createLatestRequest } from '../utils/latestRequest.js';
 import { pendingMarkReadMap, completedMarkReadMap, setPending } from '../utils/pendingReads.js';
-import { applyDeleteGuard, clearDeleteGuard, clearPendingDelete, setCompletedDelete, setPendingDelete } from '../utils/pendingDeletes.js';
+import { applyDeleteGuard, clearDeleteGuard, clearPendingDelete, setCompletedDelete, setPendingDelete, threadDeleteGuardKey } from '../utils/pendingDeletes.js';
+import {
+  archiveTargetsForFolder,
+  currentThreadLoadVersion,
+  findVisibleArchiveMessage,
+  invalidateThreadLoad,
+  isCurrentThreadLoad,
+  unreadCountsByAccount,
+} from '../utils/threadedArchive.js';
 
 // Folder icon for move picker
 function FolderIcon({ specialUse, size = 13 }) {
@@ -39,9 +47,9 @@ function FolderIcon({ specialUse, size = 13 }) {
 // or nothing if the list is now empty). Mirrors scheduleDelete's inline advance;
 // call before removeMessage so the outgoing row is still present for the lookup.
 // No-op unless the removed message is the currently selected one.
-function advanceSelectionAfterRemoval(removedId) {
+function advanceSelectionAfterRemoval(removedId, selectedWithinRemovedRow = false) {
   const { messages, searchResults, searchQuery, selectedMessageId, setSelectedMessage } = useStore.getState();
-  if (selectedMessageId !== removedId) return;
+  if (!selectedWithinRemovedRow && selectedMessageId !== removedId) return;
   const displayMsgs = searchQuery.trim() ? searchResults : messages;
   const idx = displayMsgs.findIndex(m => m.id === removedId);
   if (idx === -1) return;
@@ -113,7 +121,7 @@ export default function MessageList() {
     messagesRefreshToken, layout, setLayout, pageSize, setPageSize, scrollMode,
     setMobileSidebarOpen, unreadCounts, showContacts, setShowContacts,
     threadedView, expandedThreadId, setExpandedThreadId,
-    threadMessages, setThreadMessages, loadingThread, setLoadingThread,
+    threadMessages, setThreadMessages, clearThreadMessages, loadingThread, setLoadingThread,
     hoverQuickActions, showMobileAvatars, showMessagePreviews,
     swipeActions,
     folders, favoriteFolders, addFavoriteFolder, removeFavoriteFolder, setSelectedAccount,
@@ -169,6 +177,7 @@ export default function MessageList() {
   const [showScrollTop, setShowScrollTop] = useState(false);
   const [listScrolled, setListScrolled] = useState(false);
   const [fabVisible, setFabVisible] = useState(true);
+  const threadLoadVersionsRef = useRef(new Map());
   const lastScrollTopRef = useRef(0);
   const [pullDistance, setPullDistance] = useState(0);
   const pullStartXRef = useRef(null);
@@ -698,6 +707,12 @@ export default function MessageList() {
     const data = await api.getThread(tid, effectiveFolder, isUnified);
     return data.messages?.length ? data.messages : [message];
   }, [isThreadListRow, threadMessages, selectedAccountId, selectedFolder, isUnified]);
+
+  const invalidateThreadCache = useCallback((threadId) => {
+    invalidateThreadLoad(threadLoadVersionsRef.current, threadId);
+    clearThreadMessages(threadId);
+    if (useStore.getState().loadingThread === threadId) setLoadingThread(null);
+  }, [clearThreadMessages, setLoadingThread]);
 
   const setCachedThreadRead = useCallback((message, read) => {
     const tid = message.thread_id || message.id;
@@ -1588,6 +1603,89 @@ export default function MessageList() {
     });
   }, [removeMessages, decrementUnread, incrementUnread, addNotification, t]);
 
+  const archiveVisibleMessage = useCallback(async (message) => {
+    const threadRow = isThreadListRow(message);
+    const threadId = message.thread_id || message.id;
+    const activeFolder = selectedAccountId ? selectedFolder : 'INBOX';
+    const threadGuard = threadRow
+      ? threadDeleteGuardKey(threadId, activeFolder, selectedAccountId)
+      : null;
+    const initialGuards = [message.id, threadGuard].filter(Boolean);
+
+    refreshRequestRef.current.invalidate();
+    initialGuards.forEach(setPendingDelete);
+    advanceSelectionAfterRemoval(message.id, true);
+    removeMessage(message.id);
+    if (threadRow && expandedThreadId === threadId) setExpandedThreadId(null);
+
+    const aggregateUnread = Number.parseInt(message.unread_count, 10);
+    const optimisticUnread = threadRow && Number.isFinite(aggregateUnread)
+      ? aggregateUnread
+      : (message.is_read ? 0 : 1);
+    let unreadByAccount = new Map();
+    if (optimisticUnread > 0) decrementUnread(message.account_id, optimisticUnread);
+    if (optimisticUnread > 0) unreadByAccount.set(message.account_id, optimisticUnread);
+
+    let targets;
+    try {
+      const resolved = await resolveMessagesForThreadAction(message);
+      targets = archiveTargetsForFolder(message, resolved, activeFolder, threadRow, selectedAccountId);
+
+      const resolvedUnreadByAccount = unreadCountsByAccount(targets);
+      const accounts = new Set([...unreadByAccount.keys(), ...resolvedUnreadByAccount.keys()]);
+      accounts.forEach((accountId) => {
+        const correction = (resolvedUnreadByAccount.get(accountId) || 0) - (unreadByAccount.get(accountId) || 0);
+        if (correction > 0) decrementUnread(accountId, correction);
+        else if (correction < 0) incrementUnread(accountId, -correction);
+      });
+      unreadByAccount = resolvedUnreadByAccount;
+    } catch (err) {
+      initialGuards.forEach(clearDeleteGuard);
+      useStore.getState().restoreMessages([message]);
+      unreadByAccount.forEach((count, accountId) => incrementUnread(accountId, count));
+      addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: 1 }) });
+      console.error('Failed to load thread for archive:', err.message);
+      return;
+    }
+
+    const ids = targets.map(target => target.id);
+    ids.forEach(setPendingDelete);
+    try {
+      const result = await api.bulkArchive(ids);
+      const archived = new Set(result.archived ?? []);
+      ids.forEach(id => (archived.has(id) ? setCompletedDelete(id) : clearDeleteGuard(id)));
+
+      const failed = targets.filter(target => !archived.has(target.id));
+      if (threadRow) invalidateThreadCache(threadId);
+      if (failed.length === 0) {
+        if (threadGuard) setCompletedDelete(threadGuard);
+        return;
+      }
+
+      if (threadGuard) clearDeleteGuard(threadGuard);
+      unreadCountsByAccount(failed).forEach((count, accountId) => incrementUnread(accountId, count));
+      if (!archived.has(message.id)) {
+        useStore.getState().restoreMessages([message]);
+      }
+      window.dispatchEvent(new Event('mailflow:refresh'));
+      const noArchiveFolder = result.noArchiveFolder?.length > 0;
+      addNotification({
+        title: t(noArchiveFolder ? 'messageList.noArchiveFolder.title' : 'messageList.bulkArchived.failTitle'),
+        body: t(noArchiveFolder ? 'messageList.noArchiveFolder.body' : 'messageList.bulkArchived.failBody', { count: failed.length }),
+      });
+    } catch (err) {
+      [...initialGuards, ...ids].forEach(clearDeleteGuard);
+      useStore.getState().restoreMessages([message]);
+      unreadByAccount.forEach((count, accountId) => incrementUnread(accountId, count));
+      addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: ids.length }) });
+      console.error('Archive failed:', err.message);
+    }
+  }, [
+    isThreadListRow, selectedAccountId, selectedFolder, expandedThreadId,
+    resolveMessagesForThreadAction, removeMessage, setExpandedThreadId,
+    decrementUnread, incrementUnread, invalidateThreadCache, addNotification, t,
+  ]);
+
   const handleBulkMarkRead = useCallback(async (ids, msgs) => {
     const markAsRead = msgs.some(m => !m.is_read);
     // Compute per-account and per-category unread deltas before mutating state
@@ -1630,10 +1728,12 @@ export default function MessageList() {
   // Keep refs to bulk handlers so the shortcut effect (registered once) is never stale
   const bulkDeleteRef    = useRef(handleBulkDelete);
   const bulkArchiveRef   = useRef(handleBulkArchive);
+  const archiveVisibleMessageRef = useRef(archiveVisibleMessage);
   const scheduleDeleteRef = useRef(scheduleDelete);
   const handleContextActionRef = useRef(null); // assigned below, once handleContextAction is defined
   useEffect(() => { bulkDeleteRef.current    = handleBulkDelete;  }, [handleBulkDelete]);
   useEffect(() => { bulkArchiveRef.current   = handleBulkArchive; }, [handleBulkArchive]);
+  useEffect(() => { archiveVisibleMessageRef.current = archiveVisibleMessage; }, [archiveVisibleMessage]);
   useEffect(() => { scheduleDeleteRef.current = scheduleDelete;   }, [scheduleDelete]);
 
   // Subscribe to keyboard shortcut actions that belong to the message list.
@@ -1711,26 +1811,16 @@ export default function MessageList() {
     };
 
     const onArchive = () => {
-      const { messages, searchResults, searchQuery, selectedMessageId, removeMessage, decrementUnread, addNotification } = getState();
+      const { messages, searchResults, searchQuery, selectedMessageId, threadMessages } = getState();
       const pool = searchQuery.trim() ? searchResults : messages;
       const ids = [...scRef.current.selectedIds];
       if (ids.length > 0) {
         const msgs = pool.filter(m => ids.includes(m.id));
         bulkArchiveRef.current(ids, msgs);
       } else if (selectedMessageId) {
-        const msg = pool.find(m => m.id === selectedMessageId);
+        const msg = findVisibleArchiveMessage(pool, selectedMessageId, threadMessages);
         if (!msg) return;
-        refreshRequestRef.current.invalidate();
-        setPendingDelete(selectedMessageId);
-        advanceSelectionAfterRemoval(selectedMessageId);
-        removeMessage(selectedMessageId);
-        if (!msg.is_read) decrementUnread(msg.account_id);
-        api.bulkArchive([selectedMessageId]).then(result => {
-          setCompletedDelete(selectedMessageId);
-          if (result.noArchiveFolder?.length) {
-            addNotification({ title: tRef.current('messageList.noArchiveFolder.title'), body: tRef.current('messageList.noArchiveFolder.body') });
-          }
-        }).catch(err => { clearDeleteGuard(selectedMessageId); console.error(err); });
+        archiveVisibleMessageRef.current(msg);
       }
     };
 
@@ -2202,10 +2292,13 @@ export default function MessageList() {
     }
   };
 
-  const handleThreadClick = async (message) => {
+  const handleThreadClick = (message) => {
+    handleSelect(message);
+  };
+
+  const handleThreadToggle = async (message) => {
     const tid = message.thread_id || message.id;
     if (!message.thread_id || (message.message_count || 1) <= 1) {
-      handleSelect(message);
       return;
     }
     if (expandedThreadId === tid) {
@@ -2214,21 +2307,22 @@ export default function MessageList() {
     }
     setExpandedThreadId(tid);
     if (!threadMessages[tid]) {
+      const loadVersion = currentThreadLoadVersion(threadLoadVersionsRef.current, tid);
       setLoadingThread(tid);
       try {
         const effectiveFolder = selectedAccountId ? selectedFolder : 'INBOX';
         const data = await api.getThread(tid, effectiveFolder, isUnified);
         const msgs = data.messages || [];
-        setThreadMessages(tid, msgs);
-        if (!isMobile && msgs.length > 0) handleSelect(msgs[msgs.length - 1]);
+        if (isCurrentThreadLoad(threadLoadVersionsRef.current, tid, loadVersion)) {
+          setThreadMessages(tid, msgs);
+        }
       } catch (err) {
         console.error('Failed to load thread:', err);
       } finally {
-        setLoadingThread(null);
+        if (isCurrentThreadLoad(threadLoadVersionsRef.current, tid, loadVersion)) {
+          setLoadingThread(null);
+        }
       }
-    } else {
-      const msgs = threadMessages[tid];
-      if (!isMobile && msgs.length > 0) handleSelect(msgs[msgs.length - 1]);
     }
   };
 
@@ -3435,6 +3529,7 @@ export default function MessageList() {
                 showAccount={false} /* No per-account dot on unified rows: it added noise beside the unread indicator; the account is visible in the message pane header. */
                 isNarrow={isNarrow}
                 onThreadClick={() => handleThreadClick(message)}
+                onThreadToggle={() => handleThreadToggle(message)}
                 showMobileAvatars={showMobileAvatars}
                 showMessagePreviews={showMessagePreviews}
                 onSelect={handleSelect}
@@ -3914,7 +4009,7 @@ function EmptyState({ folderSyncing, searchQuery, unreadOnly, selectedFolder, ac
   );
 }
 
-function ThreadRow({ message, isExpanded, threadMsgs, isLoadingThread, selectedMessageId, selectedMid, lastViewedMessageId, showAccount, isNarrow, onThreadClick, showMobileAvatars, showMessagePreviews, onSelect, onMarkRead, onStar, onDelete, hoverQuickActions, onContextMenu, onMove, onGtdDone, isMobile, swipeLeftAction, swipeRightAction, onSwipeLeft, onSwipeRight, isChecked, selectionMode, onToggleSelect, onRangeSelect, onLongPress }) {
+function ThreadRow({ message, isExpanded, threadMsgs, isLoadingThread, selectedMessageId, selectedMid, lastViewedMessageId, showAccount, isNarrow, onThreadClick, onThreadToggle, showMobileAvatars, showMessagePreviews, onSelect, onMarkRead, onStar, onDelete, hoverQuickActions, onContextMenu, onMove, onGtdDone, isMobile, swipeLeftAction, swipeRightAction, onSwipeLeft, onSwipeRight, isChecked, selectionMode, onToggleSelect, onRangeSelect, onLongPress }) {
   const { t } = useTranslation();
   const [hovered, setHovered] = useState(false);
   const messageCount = message.message_count || 1;
@@ -4062,19 +4157,25 @@ function ThreadRow({ message, isExpanded, threadMsgs, isLoadingThread, selectedM
                 {message.from_name || message.from_email || t('common.unknown', 'Unknown')}
               </span>
               {messageCount > 1 && (
-                <span style={{
+                <button
+                  type="button"
+                  aria-expanded={isExpanded}
+                  aria-label={`${isExpanded ? t('message.aiCollapse') : t('messageList.showAll')} (${messageCount})`}
+                  onClick={(e) => { e.stopPropagation(); onThreadToggle(); }}
+                  style={{
                   display: 'inline-flex', alignItems: 'center', gap: 3,
                   fontSize: 10, fontWeight: 600, color: 'var(--text-tertiary)',
                   background: 'var(--bg-tertiary)', border: '1px solid var(--border-subtle)',
-                  borderRadius: 10, padding: '1px 6px', flexShrink: 0,
-                }}>
+                  borderRadius: 10, padding: '1px 6px', flexShrink: 0, cursor: 'pointer',
+                }}
+                >
                   <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
                     {isExpanded
                       ? <polyline points="18 15 12 9 6 15" />
                       : <polyline points="6 9 12 15 18 9" />}
                   </svg>
                   {messageCount}
-                </span>
+                </button>
               )}
             </div>
             <div style={{

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -23,13 +23,17 @@ import { createLatestRequest } from '../utils/latestRequest.js';
 import { pendingMarkReadMap, completedMarkReadMap, setPending } from '../utils/pendingReads.js';
 import { applyDeleteGuard, clearDeleteGuard, clearPendingDelete, setCompletedDelete, setPendingDelete, threadDeleteGuardKey } from '../utils/pendingDeletes.js';
 import {
+  archiveInChunks,
+  archiveTargetGroupsForRows,
   archiveTargetsForFolder,
+  archiveViewKey,
   currentThreadLoadVersion,
   findVisibleArchiveMessage,
   invalidateThreadLoad,
   isCurrentThreadLoad,
   unreadCountsByAccount,
 } from '../utils/threadedArchive.js';
+import { createUndoableCommit, UNDO_COMMIT_DELAY_MS, UNDO_WINDOW_MS } from '../utils/undoableAction.js';
 
 // Folder icon for move picker
 function FolderIcon({ specialUse, size = 13 }) {
@@ -55,6 +59,10 @@ function advanceSelectionAfterRemoval(removedId, selectedWithinRemovedRow = fals
   if (idx === -1) return;
   const next = displayMsgs[idx + 1] || displayMsgs[idx - 1] || null;
   setSelectedMessage(next?.id ?? null);
+}
+
+function restoreMessagesIfViewCurrent(viewKey, currentViewKeyRef, messages) {
+  if (currentViewKeyRef.current === viewKey) useStore.getState().restoreMessages(messages);
 }
 
 const SWIPE_ACTIONS = {
@@ -172,12 +180,14 @@ export default function MessageList() {
   const [activeCategory, setActiveCategory] = useState('primary');
   const [currentPage, setCurrentPage] = useState(1);
   const currentPageRef = useRef(1);
+  const archiveViewKeyRef = useRef(null);
   const [syncing, setSyncing] = useState(false);
   const [folderSyncing, setFolderSyncing] = useState(false);
   const [showScrollTop, setShowScrollTop] = useState(false);
   const [listScrolled, setListScrolled] = useState(false);
   const [fabVisible, setFabVisible] = useState(true);
   const threadLoadVersionsRef = useRef(new Map());
+  const archiveVisibleMessageRef = useRef(null);
   const lastScrollTopRef = useRef(0);
   const [pullDistance, setPullDistance] = useState(0);
   const pullStartXRef = useRef(null);
@@ -253,6 +263,23 @@ export default function MessageList() {
   // Fetch unread counts per category for the tab bar badges.
   // Re-fetches whenever the account/folder changes or new mail arrives.
   const categorizationActive = categorizationEnabled || (!isUnified && selectedAccount?.categorization_enabled);
+  archiveViewKeyRef.current = archiveViewKey({
+    selectedAccountId,
+    selectedFolder,
+    searchQuery,
+    threadedView,
+    unreadOnly,
+    activeCategory,
+    currentPage,
+    searchAllFolders,
+    activeGtdTab,
+    pageSize,
+    scrollMode,
+    categorizationEnabled,
+    accountCategorizationEnabled: selectedAccount?.categorization_enabled,
+    unifiedInboxAccountKey,
+    showGtdTab,
+  });
   useEffect(() => {
     if (!categorizationActive || selectedFolder !== 'INBOX') {
       setCategoryCounts({});
@@ -697,10 +724,10 @@ export default function MessageList() {
     return threadedView && !searchQuery.trim() && message.thread_id && messageCount > 1;
   }, [threadedView, searchQuery]);
 
-  const resolveMessagesForThreadAction = useCallback(async (message) => {
+  const resolveMessagesForThreadAction = useCallback(async (message, { forceRefresh = false } = {}) => {
     const tid = message.thread_id || message.id;
     if (!isThreadListRow(message)) return [message];
-    if (Array.isArray(threadMessages[tid]) && threadMessages[tid].length > 0) {
+    if (!forceRefresh && Array.isArray(threadMessages[tid]) && threadMessages[tid].length > 0) {
       return threadMessages[tid];
     }
     const effectiveFolder = selectedAccountId ? selectedFolder : 'INBOX';
@@ -1194,30 +1221,49 @@ export default function MessageList() {
   }, [setMessagesReadState]);
 
   const handleSwipeArchive = useCallback(async (message) => {
+    const archiveMessage = archiveVisibleMessageRef.current;
+    if (!archiveMessage) return;
+    const threadRow = isThreadListRow(message);
+    const threadId = message.thread_id || message.id;
+    const activeFolder = selectedAccountId ? selectedFolder : 'INBOX';
+    const threadGuard = threadRow
+      ? threadDeleteGuardKey(threadId, activeFolder, selectedAccountId)
+      : null;
+    const guards = [message.id, threadGuard].filter(Boolean);
+    const viewKey = archiveViewKeyRef.current;
+
     refreshRequestRef.current.invalidate();
+    guards.forEach(setPendingDelete);
     advanceSelectionAfterRemoval(message.id);
     removeMessage(message.id);
-    if (!message.is_read) decrementUnread(message.account_id);
-    let undone = false;
-    const timer = setTimeout(async () => {
-      if (undone) return;
-      try {
-        await api.bulkArchive([message.id]);
-      } catch (err) {
-        console.error('swipe archive failed:', err.message);
-      }
-    }, 4500);
+    if (threadRow && expandedThreadId === threadId) setExpandedThreadId(null);
+    const aggregateUnread = Number.parseInt(message.unread_count, 10);
+    const optimisticUnread = threadRow && Number.isFinite(aggregateUnread)
+      ? aggregateUnread
+      : (message.is_read ? 0 : 1);
+    if (optimisticUnread > 0) decrementUnread(message.account_id, optimisticUnread);
+    const archiveAction = createUndoableCommit({
+      delayMs: UNDO_COMMIT_DELAY_MS,
+      commit: async () => {
+        guards.forEach(clearDeleteGuard);
+        await archiveMessage(message, { alreadyRemoved: true, viewKey });
+      },
+      undo: () => {
+        guards.forEach(clearDeleteGuard);
+        restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, [message]);
+        if (optimisticUnread > 0) incrementUnread(message.account_id, optimisticUnread);
+      },
+    });
     addNotification({
       title: t('messageList.bulkArchived.title', { count: 1 }),
       body: message.subject || '',
-      onUndo: () => {
-        undone = true;
-        clearTimeout(timer);
-        useStore.getState().restoreMessages([message]);
-        if (!message.is_read) incrementUnread(message.account_id);
-      },
+      onUndo: archiveAction.undo,
     });
-  }, [removeMessage, decrementUnread, incrementUnread, addNotification, t]);
+  }, [
+    isThreadListRow, selectedAccountId, selectedFolder, expandedThreadId,
+    removeMessage, setExpandedThreadId, decrementUnread, incrementUnread,
+    addNotification, t,
+  ]);
 
   const handleSwipeStar = useCallback((message) => {
     setMessagesStarredState(message, !message.is_starred);
@@ -1553,57 +1599,128 @@ export default function MessageList() {
   }, []);
 
   const handleBulkArchive = useCallback((ids, msgs) => {
+    const activeFolder = selectedAccountId ? selectedFolder : 'INBOX';
+    const threadGuardsByRow = new Map(
+      msgs
+        .filter(message => isThreadListRow(message))
+        .map(message => [
+          message.id,
+          threadDeleteGuardKey(message.thread_id || message.id, activeFolder, selectedAccountId),
+        ])
+        .filter(([, guard]) => Boolean(guard)),
+    );
+    const initialGuards = [...new Set([...ids, ...threadGuardsByRow.values()])];
+    const viewKey = archiveViewKeyRef.current;
+
     refreshRequestRef.current.invalidate();
-    // Tombstone the ids so a background refresh/websocket refetch during the undo window
-    // can't resurrect them — applyDeleteGuard filters pending/completed ids out of refetch
-    // results — and drop every row in one batched state update rather than one per id.
-    ids.forEach(id => setPendingDelete(id));
+    initialGuards.forEach(setPendingDelete);
     removeMessages(ids);
-    msgs.forEach(msg => { if (!msg.is_read) decrementUnread(msg.account_id); });
+    let unreadByAccount = new Map();
+    msgs.forEach((message) => {
+      const aggregateUnread = Number.parseInt(message.unread_count, 10);
+      const count = isThreadListRow(message) && Number.isFinite(aggregateUnread)
+        ? aggregateUnread
+        : (message.is_read ? 0 : 1);
+      if (count <= 0) return;
+      decrementUnread(message.account_id, count);
+      unreadByAccount.set(message.account_id, (unreadByAccount.get(message.account_id) || 0) + count);
+    });
     setSelectedIds(new Set());
     setSelectionModeActive(false);
     setShowFolderPicker(false);
-    let undone = false;
-    const timer = setTimeout(async () => {
-      if (undone) return;
-      try {
-        const result = await api.bulkArchive(ids);
-        const archivedSet = new Set(result.archived ?? []);
-        // Archived: keep guarding briefly (completed grace) so an in-flight refetch can't
-        // bring them back; not archived: release the guard so those rows can return.
-        ids.forEach(id => (archivedSet.has(id) ? setCompletedDelete(id) : clearDeleteGuard(id)));
-        const failedMsgs = msgs.filter(msg => !archivedSet.has(msg.id));
-        if (failedMsgs.length > 0) {
-          useStore.getState().restoreMessages(failedMsgs);
-          failedMsgs.forEach(msg => { if (!msg.is_read) incrementUnread(msg.account_id); });
-          if (result.noArchiveFolder?.length) {
-            addNotification({ title: t('messageList.bulkArchived.noFolderTitle'), body: t('messageList.bulkArchived.noFolderBody') });
-          } else {
-            addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: failedMsgs.length }) });
+    const archiveAction = createUndoableCommit({
+      delayMs: UNDO_COMMIT_DELAY_MS,
+      commit: async () => {
+        let groups;
+        let targets;
+        try {
+          groups = await archiveTargetGroupsForRows(
+            msgs,
+            message => resolveMessagesForThreadAction(message, { forceRefresh: true }),
+            activeFolder,
+            isThreadListRow,
+            selectedAccountId,
+          );
+          const seen = new Set();
+          targets = groups.flatMap(group => group.targets).filter((target) => {
+            if (!target?.id || seen.has(target.id)) return false;
+            seen.add(target.id);
+            return true;
+          });
+          const archiveIds = targets.map(target => target.id);
+          archiveIds.forEach(setPendingDelete);
+
+          const resolvedUnreadByAccount = unreadCountsByAccount(targets);
+          const accountIds = new Set([...unreadByAccount.keys(), ...resolvedUnreadByAccount.keys()]);
+          accountIds.forEach((accountId) => {
+            const correction = (resolvedUnreadByAccount.get(accountId) || 0) - (unreadByAccount.get(accountId) || 0);
+            if (correction > 0) decrementUnread(accountId, correction);
+            else if (correction < 0) incrementUnread(accountId, -correction);
+          });
+          unreadByAccount = resolvedUnreadByAccount;
+
+          groups.forEach(({ row }) => {
+            if (isThreadListRow(row)) invalidateThreadCache(row.thread_id || row.id);
+          });
+
+          const result = await archiveInChunks(archiveIds, api.bulkArchive);
+          if (result.error) console.error('Bulk archive chunk failed:', result.error);
+          const archivedSet = new Set(result.archived);
+          archiveIds.forEach(id => (archivedSet.has(id) ? setCompletedDelete(id) : clearDeleteGuard(id)));
+          ids.filter(id => !seen.has(id)).forEach(clearDeleteGuard);
+          groups.forEach(({ row, targets: groupTargets }) => {
+            const threadGuard = threadGuardsByRow.get(row.id);
+            if (!threadGuard) return;
+            if (groupTargets.every(target => archivedSet.has(target.id))) setCompletedDelete(threadGuard);
+            else clearDeleteGuard(threadGuard);
+          });
+
+          const failedTargets = targets.filter(target => !archivedSet.has(target.id));
+          if (failedTargets.length > 0) {
+            const failedVisibleRows = groups
+              .filter(({ row, targets: groupTargets }) => (
+                !archivedSet.has(row.id) && groupTargets.some(target => !archivedSet.has(target.id))
+              ))
+              .map(({ row }) => row);
+            if (failedVisibleRows.length > 0) restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, failedVisibleRows);
+            unreadCountsByAccount(failedTargets).forEach((count, accountId) => incrementUnread(accountId, count));
+            window.dispatchEvent(new Event('mailflow:refresh'));
+            if (!result.error && result.noArchiveFolder.length) {
+              addNotification({ title: t('messageList.bulkArchived.noFolderTitle'), body: t('messageList.bulkArchived.noFolderBody') });
+            } else {
+              addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: failedTargets.length }) });
+            }
           }
+        } catch (err) {
+          console.error('Bulk archive failed:', err);
+          const targetIds = targets?.map(target => target.id) || [];
+          [...new Set([...initialGuards, ...targetIds])].forEach(clearDeleteGuard);
+          restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, msgs);
+          unreadByAccount.forEach((count, accountId) => incrementUnread(accountId, count));
+          addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: targets?.length || ids.length }) });
         }
-      } catch (err) {
-        console.error('Bulk archive failed:', err);
-        ids.forEach(id => clearDeleteGuard(id));
-        useStore.getState().restoreMessages(msgs);
-        msgs.forEach(msg => { if (!msg.is_read) incrementUnread(msg.account_id); });
-        addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: ids.length }) });
-      }
-    }, 4500);
+      },
+      undo: () => {
+        initialGuards.forEach(clearDeleteGuard);
+        restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, msgs);
+        unreadByAccount.forEach((count, accountId) => incrementUnread(accountId, count));
+      },
+    });
     addNotification({
       title: t('messageList.bulkArchived.title', { count: ids.length }),
       body: t('messageList.bulkArchived.body'),
-      onUndo: () => {
-        undone = true;
-        clearTimeout(timer);
-        ids.forEach(id => clearPendingDelete(id));
-        useStore.getState().restoreMessages(msgs);
-        msgs.forEach(msg => { if (!msg.is_read) incrementUnread(msg.account_id); });
-      },
+      onUndo: archiveAction.undo,
     });
-  }, [removeMessages, decrementUnread, incrementUnread, addNotification, t]);
+  }, [
+    selectedAccountId, selectedFolder, isThreadListRow, resolveMessagesForThreadAction,
+    removeMessages, decrementUnread, incrementUnread, invalidateThreadCache,
+    addNotification, t,
+  ]);
 
-  const archiveVisibleMessage = useCallback(async (message) => {
+  const archiveVisibleMessage = useCallback(async (message, {
+    alreadyRemoved = false,
+    viewKey: actionViewKey = archiveViewKeyRef.current,
+  } = {}) => {
     const threadRow = isThreadListRow(message);
     const threadId = message.thread_id || message.id;
     const activeFolder = selectedAccountId ? selectedFolder : 'INBOX';
@@ -1611,24 +1728,27 @@ export default function MessageList() {
       ? threadDeleteGuardKey(threadId, activeFolder, selectedAccountId)
       : null;
     const initialGuards = [message.id, threadGuard].filter(Boolean);
+    const viewKey = actionViewKey;
 
     refreshRequestRef.current.invalidate();
     initialGuards.forEach(setPendingDelete);
-    advanceSelectionAfterRemoval(message.id, true);
-    removeMessage(message.id);
-    if (threadRow && expandedThreadId === threadId) setExpandedThreadId(null);
+    if (!alreadyRemoved) {
+      advanceSelectionAfterRemoval(message.id, true);
+      removeMessage(message.id);
+      if (threadRow && expandedThreadId === threadId) setExpandedThreadId(null);
+    }
 
     const aggregateUnread = Number.parseInt(message.unread_count, 10);
     const optimisticUnread = threadRow && Number.isFinite(aggregateUnread)
       ? aggregateUnread
       : (message.is_read ? 0 : 1);
     let unreadByAccount = new Map();
-    if (optimisticUnread > 0) decrementUnread(message.account_id, optimisticUnread);
+    if (!alreadyRemoved && optimisticUnread > 0) decrementUnread(message.account_id, optimisticUnread);
     if (optimisticUnread > 0) unreadByAccount.set(message.account_id, optimisticUnread);
 
     let targets;
     try {
-      const resolved = await resolveMessagesForThreadAction(message);
+      const resolved = await resolveMessagesForThreadAction(message, { forceRefresh: true });
       targets = archiveTargetsForFolder(message, resolved, activeFolder, threadRow, selectedAccountId);
 
       const resolvedUnreadByAccount = unreadCountsByAccount(targets);
@@ -1641,7 +1761,7 @@ export default function MessageList() {
       unreadByAccount = resolvedUnreadByAccount;
     } catch (err) {
       initialGuards.forEach(clearDeleteGuard);
-      useStore.getState().restoreMessages([message]);
+      restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, [message]);
       unreadByAccount.forEach((count, accountId) => incrementUnread(accountId, count));
       addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: 1 }) });
       console.error('Failed to load thread for archive:', err.message);
@@ -1651,9 +1771,11 @@ export default function MessageList() {
     const ids = targets.map(target => target.id);
     ids.forEach(setPendingDelete);
     try {
-      const result = await api.bulkArchive(ids);
-      const archived = new Set(result.archived ?? []);
+      const result = await archiveInChunks(ids, api.bulkArchive);
+      if (result.error) console.error('Archive chunk failed:', result.error);
+      const archived = new Set(result.archived);
       ids.forEach(id => (archived.has(id) ? setCompletedDelete(id) : clearDeleteGuard(id)));
+      if (!archived.has(message.id)) clearDeleteGuard(message.id);
 
       const failed = targets.filter(target => !archived.has(target.id));
       if (threadRow) invalidateThreadCache(threadId);
@@ -1665,17 +1787,17 @@ export default function MessageList() {
       if (threadGuard) clearDeleteGuard(threadGuard);
       unreadCountsByAccount(failed).forEach((count, accountId) => incrementUnread(accountId, count));
       if (!archived.has(message.id)) {
-        useStore.getState().restoreMessages([message]);
+        restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, [message]);
       }
       window.dispatchEvent(new Event('mailflow:refresh'));
-      const noArchiveFolder = result.noArchiveFolder?.length > 0;
+      const noArchiveFolder = !result.error && result.noArchiveFolder.length > 0;
       addNotification({
         title: t(noArchiveFolder ? 'messageList.noArchiveFolder.title' : 'messageList.bulkArchived.failTitle'),
         body: t(noArchiveFolder ? 'messageList.noArchiveFolder.body' : 'messageList.bulkArchived.failBody', { count: failed.length }),
       });
     } catch (err) {
       [...initialGuards, ...ids].forEach(clearDeleteGuard);
-      useStore.getState().restoreMessages([message]);
+      restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, [message]);
       unreadByAccount.forEach((count, accountId) => incrementUnread(accountId, count));
       addNotification({ title: t('messageList.bulkArchived.failTitle'), body: t('messageList.bulkArchived.failBody', { count: ids.length }) });
       console.error('Archive failed:', err.message);
@@ -1728,7 +1850,6 @@ export default function MessageList() {
   // Keep refs to bulk handlers so the shortcut effect (registered once) is never stale
   const bulkDeleteRef    = useRef(handleBulkDelete);
   const bulkArchiveRef   = useRef(handleBulkArchive);
-  const archiveVisibleMessageRef = useRef(archiveVisibleMessage);
   const scheduleDeleteRef = useRef(scheduleDelete);
   const handleContextActionRef = useRef(null); // assigned below, once handleContextAction is defined
   useEffect(() => { bulkDeleteRef.current    = handleBulkDelete;  }, [handleBulkDelete]);
@@ -1988,32 +2109,43 @@ export default function MessageList() {
         break;
       case 'archive': {
         const archived = message;
+        const archiveMessage = archiveVisibleMessageRef.current;
+        if (!archiveMessage) break;
+        const threadRow = isThreadListRow(archived);
+        const threadId = archived.thread_id || archived.id;
+        const activeFolder = selectedAccountId ? selectedFolder : 'INBOX';
+        const threadGuard = threadRow
+          ? threadDeleteGuardKey(threadId, activeFolder, selectedAccountId)
+          : null;
+        const guards = [archived.id, threadGuard].filter(Boolean);
+        const viewKey = archiveViewKeyRef.current;
+
         refreshRequestRef.current.invalidate();
+        guards.forEach(setPendingDelete);
         advanceSelectionAfterRemoval(archived.id);
         removeMessage(archived.id);
-        if (!archived.is_read) decrementUnread(archived.account_id);
-        let archiveUndone = false;
-        const archiveTimer = setTimeout(async () => {
-          if (archiveUndone) return;
-          try {
-            const result = await api.bulkArchive([archived.id]);
-            if (result.noArchiveFolder?.length) {
-              addNotification({ title: t('message.archived.noFolderTitle'), body: t('message.archived.noFolderBody') });
-            }
-          } catch (err) {
-            console.error('Archive failed:', err.message);
-            addNotification({ title: t('message.archived.failTitle'), body: t('message.archived.failBody') });
-          }
-        }, 4500);
+        if (threadRow && expandedThreadId === threadId) setExpandedThreadId(null);
+        const aggregateUnread = Number.parseInt(archived.unread_count, 10);
+        const optimisticUnread = threadRow && Number.isFinite(aggregateUnread)
+          ? aggregateUnread
+          : (archived.is_read ? 0 : 1);
+        if (optimisticUnread > 0) decrementUnread(archived.account_id, optimisticUnread);
+        const archiveAction = createUndoableCommit({
+          delayMs: UNDO_COMMIT_DELAY_MS,
+          commit: async () => {
+            guards.forEach(clearDeleteGuard);
+            await archiveMessage(archived, { alreadyRemoved: true, viewKey });
+          },
+          undo: () => {
+            guards.forEach(clearDeleteGuard);
+            restoreMessagesIfViewCurrent(viewKey, archiveViewKeyRef, [archived]);
+            if (optimisticUnread > 0) incrementUnread(archived.account_id, optimisticUnread);
+          },
+        });
         addNotification({
           title: t('message.archived.title'),
           body: archived.subject || t('common.noSubject'),
-          onUndo: () => {
-            archiveUndone = true;
-            clearTimeout(archiveTimer);
-            useStore.getState().restoreMessages([archived]);
-            if (!archived.is_read) incrementUnread(archived.account_id);
-          },
+          onUndo: archiveAction.undo,
         });
         break;
       }
@@ -3832,7 +3964,7 @@ function UndoBar({ notification, onDismiss, showTopBorder }) {
   };
 
   useEffect(() => {
-    const timer = setTimeout(dismiss, 6000);
+    const timer = setTimeout(dismiss, UNDO_WINDOW_MS);
     return () => clearTimeout(timer);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -3852,7 +3984,7 @@ function UndoBar({ notification, onDismiss, showTopBorder }) {
       <div style={{
         position: 'absolute', bottom: 0, left: 0,
         height: 2, background: 'var(--accent)',
-        animation: 'action-bar-progress 4.5s linear forwards',
+        animation: `action-bar-progress ${UNDO_WINDOW_MS}ms linear forwards`,
       }} />
       <span style={{
         flex: 1, minWidth: 0,

--- a/frontend/src/components/NotificationToasts.jsx
+++ b/frontend/src/components/NotificationToasts.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../store/index.js';
 import { useMobile } from '../hooks/useMobile.js';
+import { UNDO_WINDOW_MS } from '../utils/undoableAction.js';
 
 export default function NotificationToasts() {
   const { notifications, removeNotification } = useStore();
@@ -61,7 +62,7 @@ function ActionBar({ notification, onDismiss, isMobile }) {
   };
 
   useEffect(() => {
-    const timer = setTimeout(dismiss, 6000);
+    const timer = setTimeout(dismiss, UNDO_WINDOW_MS);
     return () => clearTimeout(timer);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -88,7 +89,7 @@ function ActionBar({ notification, onDismiss, isMobile }) {
         bottom: 0, left: 0,
         height: 2,
         background: 'var(--accent)',
-        animation: 'action-bar-progress 4.5s linear forwards',
+        animation: `action-bar-progress ${UNDO_WINDOW_MS}ms linear forwards`,
       }} />
 
       <span style={{
@@ -151,7 +152,7 @@ function Toast({ notification, onDismiss, isMobile }) {
   useEffect(() => {
     if (notification.persistent) return undefined;
 
-    const duration = notification.onUndo ? 6000 : 5000;
+    const duration = notification.onUndo ? UNDO_WINDOW_MS : 5000;
     const timer = setTimeout(dismiss, duration);
     return () => clearTimeout(timer);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/hooks/useSwipeRow.js
+++ b/frontend/src/hooks/useSwipeRow.js
@@ -2,11 +2,15 @@ import { useRef, useEffect, useCallback } from 'react';
 
 const SWIPE_THRESHOLD = 72;
 
+export function isInteractiveSwipeTarget(target) {
+  return Boolean(target?.closest?.('button, input, select, textarea, a, [role="button"]'));
+}
+
 export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLongPress, onTap }) {
   const contentRef = useRef(null);
   const swipeBgLeftRef = useRef(null);
   const swipeBgRightRef = useRef(null);
-  const swipeRef = useRef({ active: false, startX: 0, startY: 0, dir: null, x: 0 });
+  const swipeRef = useRef({ active: false, startX: 0, startY: 0, dir: null, x: 0, interactive: false });
   const longPressTimerRef = useRef(null);
   const springBackTimerRef = useRef(null);
   const longPressActivatedRef = useRef(false);
@@ -51,7 +55,7 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
       }
     };
     const resetSwipeState = () => {
-      swipeRef.current = { active: false, startX: 0, startY: 0, dir: null, x: 0 };
+      swipeRef.current = { active: false, startX: 0, startY: 0, dir: null, x: 0, interactive: false };
     };
     const suppressNextClick = () => {
       if (tapSuppressTimerRef.current) clearTimeout(tapSuppressTimerRef.current);
@@ -69,9 +73,10 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
         springBackTimerRef.current = null;
       }
       longPressActivatedRef.current = false;
-      swipeRef.current = { active: false, startX: t.clientX, startY: t.clientY, dir: null, x: 0 };
+      const interactive = isInteractiveSwipeTarget(e.target);
+      swipeRef.current = { active: false, startX: t.clientX, startY: t.clientY, dir: null, x: 0, interactive };
       showBgs();
-      if (latestRef.current.onLongPress) {
+      if (!interactive && latestRef.current.onLongPress) {
         longPressTimerRef.current = setTimeout(() => {
           longPressTimerRef.current = null;
           longPressActivatedRef.current = true;
@@ -83,6 +88,7 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
 
     const onMove = (e) => {
       const s = swipeRef.current;
+      if (s.interactive) return;
       const t = e.touches[0];
       const dx = t.clientX - s.startX;
       const dy = t.clientY - s.startY;
@@ -116,7 +122,7 @@ export function useSwipeRow({ isMobile, message, onSwipeLeft, onSwipeRight, onLo
       cancelLongPress();
       const s = swipeRef.current;
       if (!s.active) {
-        const wasTap = !s.dir;
+        const wasTap = !s.dir && !s.interactive;
         resetSwipeState();
         hideBgs();
         // Fire onTap immediately on touchend instead of waiting for the synthesized

--- a/frontend/src/hooks/useSwipeRow.test.js
+++ b/frontend/src/hooks/useSwipeRow.test.js
@@ -1,0 +1,19 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isInteractiveSwipeTarget } from './useSwipeRow.js';
+
+describe('isInteractiveSwipeTarget', () => {
+  it('suppresses row taps that start on an interactive descendant', () => {
+    const buttonChild = { closest: selector => selector.includes('button') ? {} : null };
+    assert.equal(isInteractiveSwipeTarget(buttonChild), true);
+  });
+
+  it('allows row taps that start on ordinary row content', () => {
+    const rowText = { closest: () => null };
+    assert.equal(isInteractiveSwipeTarget(rowText), false);
+  });
+
+  it('handles non-element targets defensively', () => {
+    assert.equal(isInteractiveSwipeTarget(null), false);
+  });
+});

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -18,6 +18,7 @@ import {
   mergeFolderOrder,
   readFolderOrder,
 } from './folderOrder.js';
+import { removeThreadCacheEntry } from '../utils/threadedArchive.js';
 import i18n from '../i18n.js';
 
 // Accumulate rapid preference changes and flush at most once per second.
@@ -490,6 +491,9 @@ export const useStore = create((set, get) => ({
   threadMessages: {},
   setThreadMessages: (threadId, msgs) => set(state => ({
     threadMessages: { ...state.threadMessages, [threadId]: msgs },
+  })),
+  clearThreadMessages: (threadId) => set(state => ({
+    threadMessages: removeThreadCacheEntry(state.threadMessages, threadId),
   })),
   loadingThread: null,
   setLoadingThread: (id) => set({ loadingThread: id }),

--- a/frontend/src/utils/pendingDeletes.js
+++ b/frontend/src/utils/pendingDeletes.js
@@ -37,7 +37,23 @@ export function clearDeleteGuard(messageId) {
   clearCompletedDelete(messageId);
 }
 
+export function threadDeleteGuardKey(threadId, folder, accountId = null) {
+  if (!threadId || !folder) return null;
+  const accountScope = accountId ? `:account:${accountId}` : '';
+  return `thread:${threadId}${accountScope}:folder:${folder}`;
+}
+
 export function applyDeleteGuard(messages) {
   if (pendingDeleteMap.size === 0 && completedDeleteMap.size === 0) return messages;
-  return messages.filter(m => !pendingDeleteMap.has(m.id) && !completedDeleteMap.has(m.id));
+  return messages.filter((m) => {
+    const guarded = key => key && (pendingDeleteMap.has(key) || completedDeleteMap.has(key));
+    const threadKey = m.thread_id ? `thread:${m.thread_id}` : null;
+    const folderThreadKey = threadDeleteGuardKey(m.thread_id, m.folder);
+    const accountThreadKey = threadDeleteGuardKey(m.thread_id, m.folder, m.account_id);
+    return !pendingDeleteMap.has(m.id)
+      && !completedDeleteMap.has(m.id)
+      && !guarded(threadKey)
+      && !guarded(folderThreadKey)
+      && !guarded(accountThreadKey);
+  });
 }

--- a/frontend/src/utils/pendingDeletes.test.js
+++ b/frontend/src/utils/pendingDeletes.test.js
@@ -16,7 +16,11 @@ import {
 // setCompletedDelete / clearDeleteGuard; the three list-refetch paths run results through
 // applyDeleteGuard. These tests cover that reconciliation.
 describe('pendingDeletes guard', () => {
-  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  const list = [
+    { id: 'a', thread_id: 'thread-a', account_id: 'account-1', folder: 'INBOX' },
+    { id: 'b', thread_id: 'thread-b', account_id: 'account-1', folder: 'INBOX' },
+    { id: 'c', thread_id: 'thread-c', account_id: 'account-1', folder: 'INBOX' },
+  ];
   const guarded = () => applyDeleteGuard(list).map(m => m.id);
 
   // Clear timers/state so tests don't leak into each other or keep the process alive.
@@ -53,5 +57,37 @@ describe('pendingDeletes guard', () => {
     clearDeleteGuard('a');
     assert.ok(!pendingDeleteMap.has('a') && !completedDeleteMap.has('a'));
     assert.deepEqual(guarded(), ['a', 'b', 'c']);
+  });
+
+  it('hides a replacement head while its stable account-folder thread id is pending', () => {
+    setPendingDelete('thread:thread-b:account:account-1:folder:INBOX');
+    assert.deepEqual(guarded(), ['a', 'c']);
+    clearDeleteGuard('thread:thread-b:account:account-1:folder:INBOX');
+  });
+
+  it('keeps a replacement head hidden during the completed folder thread grace window', () => {
+    setCompletedDelete('thread:thread-b:folder:INBOX');
+    assert.deepEqual(guarded(), ['a', 'c']);
+    clearDeleteGuard('thread:thread-b:folder:INBOX');
+  });
+
+  it('does not hide a preserved-folder copy of a guarded thread', () => {
+    setPendingDelete('thread:thread-b:folder:INBOX');
+    const copies = [
+      { id: 'inbox', thread_id: 'thread-b', account_id: 'account-1', folder: 'INBOX' },
+      { id: 'sent', thread_id: 'thread-b', account_id: 'account-1', folder: 'Sent' },
+    ];
+    assert.deepEqual(applyDeleteGuard(copies).map(message => message.id), ['sent']);
+    clearDeleteGuard('thread:thread-b:folder:INBOX');
+  });
+
+  it('does not hide the same Inbox thread in another account for an account-scoped guard', () => {
+    setPendingDelete('thread:thread-b:account:account-1:folder:INBOX');
+    const copies = [
+      { id: 'first', thread_id: 'thread-b', account_id: 'account-1', folder: 'INBOX' },
+      { id: 'second', thread_id: 'thread-b', account_id: 'account-2', folder: 'INBOX' },
+    ];
+    assert.deepEqual(applyDeleteGuard(copies).map(message => message.id), ['second']);
+    clearDeleteGuard('thread:thread-b:account:account-1:folder:INBOX');
   });
 });

--- a/frontend/src/utils/pendingDeletes.test.js
+++ b/frontend/src/utils/pendingDeletes.test.js
@@ -6,6 +6,7 @@ import {
   clearPendingDelete,
   setCompletedDelete,
   setPendingDelete,
+  threadDeleteGuardKey,
   pendingDeleteMap,
   completedDeleteMap,
 } from './pendingDeletes.js';
@@ -24,7 +25,13 @@ describe('pendingDeletes guard', () => {
   const guarded = () => applyDeleteGuard(list).map(m => m.id);
 
   // Clear timers/state so tests don't leak into each other or keep the process alive.
-  afterEach(() => ['a', 'b', 'c'].forEach(clearDeleteGuard));
+  afterEach(() => [
+    'a',
+    'b',
+    'c',
+    'head',
+    threadDeleteGuardKey('t1', 'INBOX', 'acct-1'),
+  ].forEach(clearDeleteGuard));
 
   it('returns the input untouched when nothing is guarded', () => {
     assert.equal(applyDeleteGuard(list), list);
@@ -89,5 +96,26 @@ describe('pendingDeletes guard', () => {
     ];
     assert.deepEqual(applyDeleteGuard(copies).map(message => message.id), ['second']);
     clearDeleteGuard('thread:thread-b:account:account-1:folder:INBOX');
+  });
+
+  it('suppresses a replacement head from the same thread, folder and account', () => {
+    const sibling = { id: 'older-sibling', thread_id: 't1', account_id: 'acct-1', folder: 'INBOX' };
+    const threadGuard = threadDeleteGuardKey('t1', 'INBOX', 'acct-1');
+
+    setPendingDelete('head');
+    setPendingDelete(threadGuard);
+    assert.deepEqual(applyDeleteGuard([sibling]).map(message => message.id), []);
+
+    clearDeleteGuard('head');
+    clearDeleteGuard(threadGuard);
+  });
+
+  it('does not suppress the same thread id in a different folder', () => {
+    const sent = { id: 'sent-copy', thread_id: 't1', account_id: 'acct-1', folder: 'Sent' };
+    const threadGuard = threadDeleteGuardKey('t1', 'INBOX', 'acct-1');
+
+    setPendingDelete(threadGuard);
+    assert.deepEqual(applyDeleteGuard([sent]).map(message => message.id), ['sent-copy']);
+    clearDeleteGuard(threadGuard);
   });
 });

--- a/frontend/src/utils/threadedArchive.js
+++ b/frontend/src/utils/threadedArchive.js
@@ -1,0 +1,54 @@
+export function findVisibleArchiveMessage(messages, selectedMessageId, threadMessages = {}) {
+  if (!selectedMessageId || !Array.isArray(messages)) return null;
+  const direct = messages.find(message => message?.id === selectedMessageId);
+  if (direct) return direct;
+
+  return messages.find((message) => {
+    const threadId = message?.thread_id || message?.id;
+    const children = threadMessages?.[threadId];
+    return Array.isArray(children) && children.some(child => child?.id === selectedMessageId);
+  }) || null;
+}
+
+export function archiveTargetsForFolder(message, resolvedMessages, folder, isThreadRow, accountId = null) {
+  if (!message) return [];
+  if (!isThreadRow) return [message];
+
+  const seen = new Set();
+  const targets = (Array.isArray(resolvedMessages) ? resolvedMessages : []).filter((candidate) => {
+    if (!candidate?.id || candidate.folder !== folder || seen.has(candidate.id)) return false;
+    if (accountId && candidate.account_id !== accountId) return false;
+    seen.add(candidate.id);
+    return true;
+  });
+  return targets.length > 0 ? targets : [message];
+}
+
+export function unreadCountsByAccount(messages) {
+  const counts = new Map();
+  for (const message of Array.isArray(messages) ? messages : []) {
+    if (!message?.account_id || message.is_read) continue;
+    counts.set(message.account_id, (counts.get(message.account_id) || 0) + 1);
+  }
+  return counts;
+}
+
+export function currentThreadLoadVersion(versions, threadId) {
+  return versions.get(threadId) || 0;
+}
+
+export function invalidateThreadLoad(versions, threadId) {
+  const next = currentThreadLoadVersion(versions, threadId) + 1;
+  versions.set(threadId, next);
+  return next;
+}
+
+export function isCurrentThreadLoad(versions, threadId, version) {
+  return currentThreadLoadVersion(versions, threadId) === version;
+}
+
+export function removeThreadCacheEntry(cache, threadId) {
+  const next = { ...(cache || {}) };
+  delete next[threadId];
+  return next;
+}

--- a/frontend/src/utils/threadedArchive.js
+++ b/frontend/src/utils/threadedArchive.js
@@ -10,6 +10,42 @@ export function findVisibleArchiveMessage(messages, selectedMessageId, threadMes
   }) || null;
 }
 
+export function archiveViewKey({
+  selectedAccountId,
+  selectedFolder,
+  searchQuery,
+  threadedView,
+  unreadOnly,
+  activeCategory,
+  currentPage,
+  searchAllFolders,
+  activeGtdTab,
+  pageSize,
+  scrollMode,
+  categorizationEnabled,
+  accountCategorizationEnabled,
+  unifiedInboxAccountKey,
+  showGtdTab,
+}) {
+  return JSON.stringify([
+    selectedAccountId ?? null,
+    selectedFolder ?? null,
+    String(searchQuery || '').trim(),
+    Boolean(threadedView),
+    Boolean(unreadOnly),
+    activeCategory ?? null,
+    Number(currentPage) || 1,
+    Boolean(searchAllFolders),
+    activeGtdTab ?? null,
+    Number(pageSize) || null,
+    scrollMode ?? null,
+    Boolean(categorizationEnabled),
+    Boolean(accountCategorizationEnabled),
+    unifiedInboxAccountKey ?? null,
+    Boolean(showGtdTab),
+  ]);
+}
+
 export function archiveTargetsForFolder(message, resolvedMessages, folder, isThreadRow, accountId = null) {
   if (!message) return [];
   if (!isThreadRow) return [message];
@@ -21,7 +57,49 @@ export function archiveTargetsForFolder(message, resolvedMessages, folder, isThr
     seen.add(candidate.id);
     return true;
   });
+  const visibleRowMatchesScope = message.id
+    && message.folder === folder
+    && (!accountId || message.account_id === accountId);
+  if (visibleRowMatchesScope && !seen.has(message.id)) targets.push(message);
   return targets.length > 0 ? targets : [message];
+}
+
+export async function archiveTargetGroupsForRows(
+  messages,
+  resolveMessages,
+  folder,
+  isThreadRow,
+  accountId = null,
+  concurrency = 8,
+) {
+  const rows = Array.isArray(messages) ? messages : [];
+  const groups = [];
+  for (let offset = 0; offset < rows.length; offset += concurrency) {
+    const batch = await Promise.all(rows.slice(offset, offset + concurrency).map(async (row) => {
+      const resolved = await resolveMessages(row);
+      return {
+        row,
+        targets: archiveTargetsForFolder(row, resolved, folder, isThreadRow(row), accountId),
+      };
+    }));
+    groups.push(...batch);
+  }
+  return groups;
+}
+
+export async function archiveInChunks(ids, archive, chunkSize = 500) {
+  const archived = [];
+  const noArchiveFolder = [];
+  for (let offset = 0; offset < ids.length; offset += chunkSize) {
+    try {
+      const result = await archive(ids.slice(offset, offset + chunkSize));
+      archived.push(...(result?.archived || []));
+      noArchiveFolder.push(...(result?.noArchiveFolder || []));
+    } catch (error) {
+      return { archived, noArchiveFolder, unconfirmed: ids.slice(offset), error };
+    }
+  }
+  return { archived, noArchiveFolder, unconfirmed: [], error: null };
 }
 
 export function unreadCountsByAccount(messages) {

--- a/frontend/src/utils/threadedArchive.test.js
+++ b/frontend/src/utils/threadedArchive.test.js
@@ -1,0 +1,100 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  archiveTargetsForFolder,
+  currentThreadLoadVersion,
+  findVisibleArchiveMessage,
+  invalidateThreadLoad,
+  isCurrentThreadLoad,
+  removeThreadCacheEntry,
+  unreadCountsByAccount,
+} from './threadedArchive.js';
+
+describe('findVisibleArchiveMessage', () => {
+  const parent = { id: 'head', thread_id: 'thread-1', message_count: 3 };
+  const sibling = { id: 'other', thread_id: 'thread-2', message_count: 2 };
+  const messages = [parent, sibling];
+  const threadMessages = {
+    'thread-1': [{ id: 'oldest' }, { id: 'middle' }, { id: 'head' }],
+    'thread-2': [{ id: 'other-child' }, { id: 'other' }],
+  };
+
+  it('returns the selected visible row directly', () => {
+    assert.equal(findVisibleArchiveMessage(messages, 'head', threadMessages), parent);
+  });
+
+  it('maps an expanded sub-message selection back to its visible thread row', () => {
+    assert.equal(findVisibleArchiveMessage(messages, 'middle', threadMessages), parent);
+  });
+
+  it('returns null when the selection is no longer represented in the list', () => {
+    assert.equal(findVisibleArchiveMessage(messages, 'missing', threadMessages), null);
+  });
+});
+
+describe('unreadCountsByAccount', () => {
+  it('groups only unread archive targets by account', () => {
+    assert.deepEqual(
+      [...unreadCountsByAccount([
+        { account_id: 'account-1', is_read: false },
+        { account_id: 'account-1', is_read: true },
+        { account_id: 'account-2', is_read: false },
+      ])],
+      [['account-1', 1], ['account-2', 1]],
+    );
+  });
+});
+
+describe('thread load invalidation', () => {
+  it('rejects an in-flight load captured before cache invalidation', () => {
+    const versions = new Map();
+    const captured = currentThreadLoadVersion(versions, 'thread-1');
+    assert.equal(isCurrentThreadLoad(versions, 'thread-1', captured), true);
+    invalidateThreadLoad(versions, 'thread-1');
+    assert.equal(isCurrentThreadLoad(versions, 'thread-1', captured), false);
+  });
+
+  it('removes a cache key without leaving a non-array sentinel behind', () => {
+    const cache = { 'thread-1': [{ id: 'one' }], 'thread-2': [{ id: 'two' }] };
+    const next = removeThreadCacheEntry(cache, 'thread-1');
+    assert.equal(Object.hasOwn(next, 'thread-1'), false);
+    assert.deepEqual(next['thread-2'], [{ id: 'two' }]);
+    assert.deepEqual(cache['thread-1'], [{ id: 'one' }]);
+  });
+});
+
+describe('archiveTargetsForFolder', () => {
+  const parent = { id: 'head', folder: 'INBOX', thread_id: 'thread-1', message_count: 4 };
+  const resolved = [
+    { id: 'oldest', account_id: 'account-1', folder: 'INBOX' },
+    { id: 'sent-reply', account_id: 'account-1', folder: 'Sent' },
+    { id: 'head', account_id: 'account-1', folder: 'INBOX' },
+    { id: 'other-account', account_id: 'account-2', folder: 'INBOX' },
+    { id: 'oldest', account_id: 'account-1', folder: 'INBOX' },
+  ];
+
+  it('archives every unique member in the active folder but leaves other folders alone', () => {
+    assert.deepEqual(
+      archiveTargetsForFolder(parent, resolved, 'INBOX', true).map(message => message.id),
+      ['oldest', 'head', 'other-account'],
+    );
+  });
+
+  it('limits a thread action to the selected account when one is active', () => {
+    assert.deepEqual(
+      archiveTargetsForFolder(parent, resolved, 'INBOX', true, 'account-1').map(message => message.id),
+      ['oldest', 'head'],
+    );
+  });
+
+  it('archives only the selected message outside threaded list mode', () => {
+    assert.deepEqual(archiveTargetsForFolder(parent, resolved, 'INBOX', false), [parent]);
+  });
+
+  it('falls back to the visible row when thread resolution has no active-folder member', () => {
+    assert.deepEqual(
+      archiveTargetsForFolder(parent, [{ id: 'sent-reply', folder: 'Sent' }], 'INBOX', true),
+      [parent],
+    );
+  });
+});

--- a/frontend/src/utils/threadedArchive.test.js
+++ b/frontend/src/utils/threadedArchive.test.js
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import {
+import * as threadedArchive from './threadedArchive.js';
+
+const {
   archiveTargetsForFolder,
   currentThreadLoadVersion,
   findVisibleArchiveMessage,
@@ -8,7 +10,7 @@ import {
   isCurrentThreadLoad,
   removeThreadCacheEntry,
   unreadCountsByAccount,
-} from './threadedArchive.js';
+} = threadedArchive;
 
 describe('findVisibleArchiveMessage', () => {
   const parent = { id: 'head', thread_id: 'thread-1', message_count: 3 };
@@ -29,6 +31,53 @@ describe('findVisibleArchiveMessage', () => {
 
   it('returns null when the selection is no longer represented in the list', () => {
     assert.equal(findVisibleArchiveMessage(messages, 'missing', threadMessages), null);
+  });
+});
+
+describe('archiveViewKey', () => {
+  it('distinguishes account, folder, search, and threaded view changes', () => {
+    assert.equal(typeof threadedArchive.archiveViewKey, 'function');
+    const original = {
+      selectedAccountId: 'account-1',
+      selectedFolder: 'INBOX',
+      searchQuery: '',
+      threadedView: true,
+      unreadOnly: false,
+      activeCategory: 'primary',
+      currentPage: 1,
+      searchAllFolders: false,
+      activeGtdTab: null,
+      pageSize: 50,
+      scrollMode: 'paginated',
+      categorizationEnabled: true,
+      accountCategorizationEnabled: true,
+      unifiedInboxAccountKey: 'account-1,account-2',
+      showGtdTab: false,
+    };
+
+    assert.equal(threadedArchive.archiveViewKey({ ...original }), threadedArchive.archiveViewKey(original));
+    for (const changed of [
+      { selectedAccountId: 'account-2' },
+      { selectedFolder: 'Sent' },
+      { searchQuery: 'from:alice' },
+      { threadedView: false },
+      { unreadOnly: true },
+      { activeCategory: 'updates' },
+      { currentPage: 2 },
+      { searchAllFolders: true },
+      { activeGtdTab: 'todo' },
+      { pageSize: 100 },
+      { scrollMode: 'infinite' },
+      { categorizationEnabled: false },
+      { accountCategorizationEnabled: false },
+      { unifiedInboxAccountKey: 'account-1' },
+      { showGtdTab: true },
+    ]) {
+      assert.notEqual(
+        threadedArchive.archiveViewKey({ ...original, ...changed }),
+        threadedArchive.archiveViewKey(original),
+      );
+    }
   });
 });
 
@@ -96,5 +145,125 @@ describe('archiveTargetsForFolder', () => {
       archiveTargetsForFolder(parent, [{ id: 'sent-reply', folder: 'Sent' }], 'INBOX', true),
       [parent],
     );
+  });
+
+  it('includes the visible row when a stale cache contains only active-folder siblings', () => {
+    assert.deepEqual(
+      archiveTargetsForFolder(
+        { ...parent, account_id: 'account-1' },
+        [{ id: 'oldest', account_id: 'account-1', folder: 'INBOX' }],
+        'INBOX',
+        true,
+        'account-1',
+      ).map(message => message.id),
+      ['oldest', 'head'],
+    );
+  });
+});
+
+describe('archiveTargetGroupsForRows', () => {
+  it('resolves every unique active-folder member for each selected thread row', async () => {
+    assert.equal(typeof threadedArchive.archiveTargetGroupsForRows, 'function');
+
+    const first = { id: 'first-head', thread_id: 'thread-1', message_count: 2 };
+    const second = { id: 'second-head', thread_id: 'thread-2', message_count: 3 };
+    const resolvedByThread = {
+      'thread-1': [
+        { id: 'first-oldest', account_id: 'account-1', folder: 'INBOX' },
+        { id: 'first-head', account_id: 'account-1', folder: 'INBOX' },
+      ],
+      'thread-2': [
+        { id: 'second-sent', account_id: 'account-1', folder: 'Sent' },
+        { id: 'second-oldest', account_id: 'account-1', folder: 'INBOX' },
+        { id: 'second-head', account_id: 'account-1', folder: 'INBOX' },
+        { id: 'second-oldest', account_id: 'account-1', folder: 'INBOX' },
+      ],
+    };
+
+    const groups = await threadedArchive.archiveTargetGroupsForRows(
+      [first, second],
+      message => resolvedByThread[message.thread_id],
+      'INBOX',
+      () => true,
+      'account-1',
+    );
+
+    assert.deepEqual(
+      groups.map(({ row, targets }) => ({
+        row: row.id,
+        targets: targets.map(target => target.id),
+      })),
+      [
+        { row: 'first-head', targets: ['first-oldest', 'first-head'] },
+        { row: 'second-head', targets: ['second-oldest', 'second-head'] },
+      ],
+    );
+  });
+
+  it('bounds concurrent thread resolution', async () => {
+    const rows = Array.from({ length: 12 }, (_, index) => ({
+      id: `head-${index}`,
+      thread_id: `thread-${index}`,
+      folder: 'INBOX',
+      message_count: 2,
+    }));
+    let active = 0;
+    let maxActive = 0;
+
+    await threadedArchive.archiveTargetGroupsForRows(
+      rows,
+      async (message) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        active -= 1;
+        return [message];
+      },
+      'INBOX',
+      () => true,
+    );
+
+    assert.equal(maxActive, 8);
+  });
+});
+
+describe('archiveInChunks', () => {
+  it('keeps each request within the backend limit and merges results', async () => {
+    assert.equal(typeof threadedArchive.archiveInChunks, 'function');
+    const ids = Array.from({ length: 501 }, (_, index) => `id-${index}`);
+    const calls = [];
+
+    const result = await threadedArchive.archiveInChunks(ids, async (chunk) => {
+      calls.push(chunk);
+      return {
+        archived: chunk.slice(0, -1),
+        noArchiveFolder: chunk.slice(-1),
+      };
+    });
+
+    assert.deepEqual(calls.map(chunk => chunk.length), [500, 1]);
+    assert.deepEqual(result.archived, ids.slice(0, 499));
+    assert.deepEqual(result.noArchiveFolder, [ids[499], ids[500]]);
+  });
+
+  it('preserves completed chunks and reports the unconfirmed remainder after an error', async () => {
+    const ids = Array.from({ length: 1001 }, (_, index) => `id-${index}`);
+    let call = 0;
+
+    let result;
+    try {
+      result = await threadedArchive.archiveInChunks(ids, async (chunk) => {
+        call += 1;
+        if (call === 2) throw new Error('network failed');
+        return { archived: chunk, noArchiveFolder: [] };
+      });
+    } catch (error) {
+      assert.fail(`archiveInChunks discarded completed chunk results: ${error.message}`);
+    }
+
+    assert.deepEqual(result.archived, ids.slice(0, 500));
+    assert.deepEqual(result.unconfirmed, ids.slice(500));
+    assert.equal(result.error.message, 'network failed');
+    assert.equal(call, 2);
   });
 });

--- a/frontend/src/utils/undoableAction.js
+++ b/frontend/src/utils/undoableAction.js
@@ -1,0 +1,31 @@
+export const UNDO_WINDOW_MS = 4500;
+export const UNDO_COMMIT_DELAY_MS = UNDO_WINDOW_MS + 250;
+
+export function createUndoableCommit({
+  delayMs = UNDO_WINDOW_MS,
+  commit,
+  undo,
+  schedule = setTimeout,
+  cancel = clearTimeout,
+}) {
+  let state = 'pending';
+  const timer = schedule(async () => {
+    if (state !== 'pending') return;
+    state = 'committing';
+    try {
+      await commit();
+    } finally {
+      state = 'committed';
+    }
+  }, delayMs);
+
+  return {
+    undo() {
+      if (state !== 'pending') return false;
+      state = 'undone';
+      cancel(timer);
+      undo();
+      return true;
+    },
+  };
+}

--- a/frontend/src/utils/undoableAction.test.js
+++ b/frontend/src/utils/undoableAction.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as undoableAction from './undoableAction.js';
+
+function fakeTimer() {
+  let callback;
+  let cancelled = false;
+  return {
+    schedule(fn) {
+      callback = fn;
+      return 'timer';
+    },
+    cancel(timer) {
+      assert.equal(timer, 'timer');
+      cancelled = true;
+    },
+    async fire() {
+      return callback();
+    },
+    wasCancelled() {
+      return cancelled;
+    },
+  };
+}
+
+describe('createUndoableCommit', () => {
+  it('cancels a pending commit and runs undo exactly once', async () => {
+    assert.equal(typeof undoableAction.createUndoableCommit, 'function');
+    const timer = fakeTimer();
+    const calls = [];
+    const action = undoableAction.createUndoableCommit({
+      delayMs: 4500,
+      commit: async () => { calls.push('commit'); },
+      undo: () => { calls.push('undo'); },
+      schedule: timer.schedule,
+      cancel: timer.cancel,
+    });
+
+    assert.equal(action.undo(), true);
+    assert.equal(action.undo(), false);
+    await timer.fire();
+
+    assert.equal(timer.wasCancelled(), true);
+    assert.deepEqual(calls, ['undo']);
+  });
+
+  it('rejects a late undo after the commit has started', async () => {
+    assert.equal(typeof undoableAction.createUndoableCommit, 'function');
+    const timer = fakeTimer();
+    const calls = [];
+    const action = undoableAction.createUndoableCommit({
+      delayMs: 4500,
+      commit: async () => { calls.push('commit'); },
+      undo: () => { calls.push('undo'); },
+      schedule: timer.schedule,
+      cancel: timer.cancel,
+    });
+
+    await timer.fire();
+    assert.equal(action.undo(), false);
+
+    assert.equal(timer.wasCancelled(), false);
+    assert.deepEqual(calls, ['commit']);
+  });
+});


### PR DESCRIPTION
## Summary

Threaded Inbox triage had two coupled failures: opening a collapsed conversation expanded every child row, and rapid archives could let an older sibling return as the replacement head. This keeps selection, disclosure, and archive state on the right boundaries.

Closes #361.

## Changes

- Keep a thread collapsed when its row is opened; the reading pane still opens the newest message, and only the accessible count/chevron toggles child rows.
- Keep Safari touch handling from routing a count-button tap through the row-open path.
- Archive every conversation member in the active folder and account from keyboard, swipe, multi-select, and context-menu actions, while preserving Sent and other-folder copies.
- Guard pending and completed archive state by stable thread identity, scoped to the source folder and account, so a replacement head cannot reappear during a refetch.
- Use one undo transaction window, reject late Undo actions after commit starts, and keep rollback scoped to the action-time list view.
- Resolve destructive thread targets from a fresh server snapshot, bound concurrent thread loads, and chunk archive requests at the backend's 500-ID limit.
- Invalidate expanded-thread caches across partial failures and stale in-flight loads, while reconciling unread counts per account.

## Testing

- `cd frontend && npm ci`
- `npm test` — 1,579 passed
- `npm run lint`
- `npm run build`
- Repeated the full test, lint, and build gate on a clean remote Linux runner with Node 22.
- Reproduced the original selection behavior in the Safari installed web app.
- Verified the rebuilt local UI keeps row clicks collapsed, expands only from the count control, and refetches children after archive-failure recovery.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
