### PR TITLE
feat(gtd): show GTD state indicators in inbox rows

### DIFF
--- a/backend/src/plugins/api.js
+++ b/backend/src/plugins/api.js
@@ -95,5 +95,6 @@ export {
   getMessageCopyFolders,
   getMessageFields,
   getMessageAnnotations,
+  getLabelMetadata,
   setMessageAnnotation,
 } from '../services/mailAccess.js';

--- a/backend/src/plugins/gtd/routes.js
+++ b/backend/src/plugins/gtd/routes.js
@@ -4,7 +4,7 @@ import { getGtdSections } from './gtdSections.js';
 import { queueGistGeneration } from './gtdGist.js';
 import { importPet, decodeUploadedSheet, getPetMeta, getPetSheet, parsePetSlug, customPetSlug } from './gtdPet.js';
 import { getGtdConfig, resolveGtdStateFolder, sanitizeGtdFolders, sanitizeGtdFoldersDetailed, DEFAULT_GTD_FOLDERS, planGtdFolderPersist, invalidateGtdConfigCache } from './gtdConfig.js';
-import { applyLabel, removeExactLabelCopy, removeLabel, markThreadRead, ensureLabelFolders, archiveInboxCopy, broadcast, loadOwnedMessage, getOwnedAccount, getMessageCopyFolders, getAccountConfig, setAccountConfig } from '../api.js';
+import { applyLabel, removeExactLabelCopy, removeLabel, markThreadRead, ensureLabelFolders, archiveInboxCopy, broadcast, loadOwnedMessage, getOwnedAccount, getMessageCopyFolders, getLabelMetadata, getAccountConfig, setAccountConfig } from '../api.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -13,6 +13,7 @@ router.use(requireAuth);
 // id is a clean 400 rather than a parametrized query that just finds nothing (404) or a
 // driver cast error. Same idiom + regex as mail.js.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const METADATA_STATE_ORDER = ['todo', 'watch', 'delegated', 'reference', 'someday'];
 
 // Shared classify precondition: an account must have GTD enabled and the request's
 // state must resolve to a designated folder. Returns { folder } to proceed, or
@@ -79,6 +80,51 @@ router.get('/sections', async (req, res) => {
     userId: req.session.userId,
     broadcast,
   }).catch(err => console.warn('GTD gist generation error:', err.message));
+});
+
+// Bounded, plugin-owned metadata for ordinary message rows. Core supplies only the neutral row
+// slot; GTD resolves its configured label folders here without coupling the message-list query to
+// any plugin schema or state.
+router.post('/metadata', async (req, res) => {
+  const { accountId, messageIds } = req.body || {};
+  if (typeof accountId !== 'string' || !UUID_RE.test(accountId)) {
+    return res.status(400).json({ error: 'Invalid account id' });
+  }
+  if (!Array.isArray(messageIds) || messageIds.length < 1 || messageIds.length > 100) {
+    return res.status(400).json({ error: 'messageIds must contain 1–100 ids' });
+  }
+  if (messageIds.some(id => typeof id !== 'string' || !UUID_RE.test(id))) {
+    return res.status(400).json({ error: 'Invalid message id' });
+  }
+
+  const ids = [...new Set(messageIds)];
+  const account = await getOwnedAccount(req.session.userId, accountId);
+  if (!account) return res.status(404).json({ error: 'Account not found' });
+
+  const { enabled, folders } = await getGtdConfig(accountId);
+  if (!enabled) return res.json({ messages: {} });
+
+  const stateByFolder = new Map();
+  for (const state of METADATA_STATE_ORDER) {
+    const folder = folders?.[state];
+    if (folder && !stateByFolder.has(folder)) stateByFolder.set(folder, state);
+  }
+  const rows = await getLabelMetadata(accountId, ids, [...stateByFolder.keys()]);
+  const messages = {};
+  for (const row of rows) {
+    const state = stateByFolder.get(row.folder);
+    if (!state) continue;
+    if (!messages[row.messageId]) messages[row.messageId] = { states: [], dates: {}, date: null };
+    const entry = messages[row.messageId];
+    if (!entry.states.includes(state)) entry.states.push(state);
+    entry.dates[state] = row.date;
+    if (row.date && (!entry.date || new Date(row.date) > new Date(entry.date))) entry.date = row.date;
+  }
+  for (const entry of Object.values(messages)) {
+    entry.states.sort((a, b) => METADATA_STATE_ORDER.indexOf(a) - METADATA_STATE_ORDER.indexOf(b));
+    entry.dates = Object.fromEntries(entry.states.map(state => [state, entry.dates[state] ?? null]));
+  }
+  return res.json({ messages });
 });
 
 // ── GTD Inbox-Zero pet ────────────────────────────────────────────────────────

--- a/backend/src/plugins/gtd/routes.metadata.test.js
+++ b/backend/src/plugins/gtd/routes.metadata.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+
+vi.mock('../../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => { req.session = { userId: 'u1' }; next(); },
+}));
+vi.mock('./gtdConfig.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, getGtdConfig: vi.fn() };
+});
+
+import express from 'express';
+import { query } from '../../services/db.js';
+import { getGtdConfig, DEFAULT_GTD_FOLDERS } from './gtdConfig.js';
+import gtdRoutes from './routes.js';
+
+const ACCOUNT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const M1 = '11111111-1111-4111-8111-111111111111';
+const M2 = '22222222-2222-4222-8222-222222222222';
+let server;
+let base;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/gtd', gtdRoutes);
+  await new Promise(resolve => { server = app.listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => new Promise(resolve => server.close(resolve)));
+
+beforeEach(() => {
+  query.mockReset();
+  getGtdConfig.mockReset();
+  getGtdConfig.mockResolvedValue({ enabled: true, folders: DEFAULT_GTD_FOLDERS });
+  query.mockImplementation(async sql => {
+    if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [{ id: ACCOUNT, user_id: 'u1' }] };
+    if (sql.includes('FROM messages target')) return { rows: [
+      { message_id: M1, folder: 'Watch', date: new Date('2026-07-01T00:00:00.000Z') },
+      { message_id: M1, folder: 'Todo', date: new Date('2026-08-01T00:00:00.000Z') },
+      { message_id: M2, folder: 'Reference', date: null },
+    ] };
+    return { rows: [] };
+  });
+});
+
+const metadata = body => fetch(`${base}/api/gtd/metadata`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+describe('POST /api/gtd/metadata', () => {
+  it.each([
+    { accountId: 'bad', messageIds: [M1] },
+    { accountId: [ACCOUNT], messageIds: [M1] },
+    { accountId: ACCOUNT, messageIds: [] },
+    { accountId: ACCOUNT, messageIds: ['bad'] },
+    { accountId: ACCOUNT, messageIds: Array.from({ length: 101 }, (_, i) => `${String(i).padStart(8, '0')}-1111-4111-8111-111111111111`) },
+  ])('rejects malformed or unbounded input before capability calls', async body => {
+    const res = await metadata(body);
+    expect(res.status).toBe(400);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the account is not owned by the session user', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns no metadata when GTD is disabled without reading label copies', async () => {
+    getGtdConfig.mockResolvedValueOnce({ enabled: false, folders: DEFAULT_GTD_FOLDERS });
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
+    expect(await res.json()).toEqual({ messages: {} });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates ids and returns canonical states with per-state and newest dates', async () => {
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1, M1, M2] });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ messages: {
+      [M1]: {
+        states: ['todo', 'watch'],
+        dates: { todo: '2026-08-01T00:00:00.000Z', watch: '2026-07-01T00:00:00.000Z' },
+        date: '2026-08-01T00:00:00.000Z',
+      },
+      [M2]: { states: ['reference'], dates: { reference: null }, date: null },
+    } });
+    const labelCall = query.mock.calls.find(([sql]) => sql.includes('FROM messages target'));
+    expect(labelCall[1][1]).toEqual([M1, M2]);
+  });
+
+  it('honors configured folder overrides', async () => {
+    getGtdConfig.mockResolvedValueOnce({
+      enabled: true,
+      folders: { ...DEFAULT_GTD_FOLDERS, todo: 'Next Actions' },
+    });
+    query.mockImplementation(async sql => {
+      if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [{ id: ACCOUNT, user_id: 'u1' }] };
+      if (sql.includes('FROM messages target')) return { rows: [
+        { message_id: M1, folder: 'Next Actions', date: new Date('2026-08-02T00:00:00.000Z') },
+      ] };
+      return { rows: [] };
+    });
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
+    expect((await res.json()).messages[M1].states).toEqual(['todo']);
+  });
+});

--- a/backend/src/services/mailAccess.js
+++ b/backend/src/services/mailAccess.js
@@ -147,6 +147,32 @@ export async function getMessageAnnotations(accountId, ids, pluginId) {
   return out;
 }
 
+// Label-folder membership for a bounded set of message rows. Targets are scoped to one account;
+// their live siblings are joined by the stored thread key so plugins can decorate existing rows
+// without adding feature-specific joins to the core message-list query.
+export async function getLabelMetadata(accountId, messageIds, labelFolders) {
+  if (!messageIds?.length || !labelFolders?.length) return [];
+  const { rows } = await query(
+    `SELECT target.id AS message_id, sibling.folder, MAX(sibling.date) AS date
+       FROM messages target
+       JOIN messages sibling
+         ON sibling.account_id = target.account_id
+        AND sibling.thread_key = target.thread_key
+        AND sibling.folder = ANY($3::text[])
+        AND sibling.is_deleted = false
+      WHERE target.account_id = $1
+        AND target.id = ANY($2::uuid[])
+      GROUP BY target.id, sibling.folder
+      ORDER BY target.id, sibling.folder`,
+    [accountId, messageIds, labelFolders]
+  );
+  return rows.map(row => ({
+    messageId: row.message_id,
+    folder: row.folder,
+    date: row.date == null ? null : new Date(row.date).toISOString(),
+  }));
+}
+
 // Merge `patch` into a plugin's namespace of a message's annotations (creating the namespace if
 // absent). Only ever touches plugin_annotations -> pluginId. Returns rows updated (0 if the
 // message isn't in the account). The annotation cache is cleaned with the message row on delete.

--- a/backend/src/services/mailAccess.labelMetadata.test.js
+++ b/backend/src/services/mailAccess.labelMetadata.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./db.js', () => ({ query: vi.fn() }));
+import { query } from './db.js';
+import { getLabelMetadata } from './mailAccess.js';
+
+const ACCOUNT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const M1 = '11111111-1111-4111-8111-111111111111';
+const M2 = '22222222-2222-4222-8222-222222222222';
+
+beforeEach(() => query.mockReset());
+
+describe('getLabelMetadata', () => {
+  it('maps requested rows to live same-thread label folders', async () => {
+    query.mockResolvedValueOnce({ rows: [
+      { message_id: M1, folder: 'Todo', date: new Date('2026-08-01T00:00:00.000Z') },
+      { message_id: M2, folder: 'Watch', date: new Date('2026-07-01T00:00:00.000Z') },
+    ] });
+
+    const result = await getLabelMetadata(ACCOUNT, [M1, M2], ['Todo', 'Watch']);
+
+    expect(result).toEqual([
+      { messageId: M1, folder: 'Todo', date: '2026-08-01T00:00:00.000Z' },
+      { messageId: M2, folder: 'Watch', date: '2026-07-01T00:00:00.000Z' },
+    ]);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/target\.account_id = \$1/);
+    expect(sql).toMatch(/target\.id = ANY\(\$2::uuid\[\]\)/);
+    expect(sql).toMatch(/sibling\.account_id = target\.account_id/);
+    expect(sql).toMatch(/sibling\.thread_key = target\.thread_key/);
+    expect(sql).toMatch(/sibling\.folder = ANY\(\$3::text\[\]\)/);
+    expect(sql).toMatch(/sibling\.is_deleted = false/);
+    expect(sql).toMatch(/MAX\(sibling\.date\)/);
+    expect(params).toEqual([ACCOUNT, [M1, M2], ['Todo', 'Watch']]);
+  });
+
+  it('returns no metadata without querying when ids or folders are empty', async () => {
+    expect(await getLabelMetadata(ACCOUNT, [], ['Todo'])).toEqual([]);
+    expect(await getLabelMetadata(ACCOUNT, [M1], [])).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -34,6 +34,7 @@ import {
   unreadCountsByAccount,
 } from '../utils/threadedArchive.js';
 import { createUndoableCommit, UNDO_COMMIT_DELAY_MS, UNDO_WINDOW_MS } from '../utils/undoableAction.js';
+import { PluginSlot } from '../plugins/PluginSlot.jsx';
 
 // Folder icon for move picker
 function FolderIcon({ specialUse, size = 13 }) {
@@ -4313,9 +4314,13 @@ function ThreadRow({ message, isExpanded, threadMsgs, isLoadingThread, selectedM
           <div style={{
             fontSize: 12, fontWeight: unreadCount > 0 ? 500 : 400,
             color: unreadCount > 0 ? 'var(--text-primary)' : 'var(--text-secondary)',
-            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginBottom: 2,
+            overflow: 'hidden', whiteSpace: 'nowrap', marginBottom: 2,
+            display: 'flex', alignItems: 'center', gap: 5,
           }}>
-            {message.subject || t('common.noSubject')}
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', flex: 1, minWidth: 0 }}>
+              {message.subject || t('common.noSubject')}
+            </span>
+            <PluginSlot name="message-row-meta" ctx={{ message, surface: 'thread' }} />
           </div>
           {/* Row 3: snippet */}
           {showMessagePreviews && (
@@ -4632,10 +4637,14 @@ function MessageRow({ message, selected, lastViewed, isChecked, selectionMode, s
         <div style={{
           fontSize: 13, fontWeight: message.is_read ? 400 : 500,
           color: message.is_read ? 'var(--text-secondary)' : 'var(--text-primary)',
-          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          overflow: 'hidden', whiteSpace: 'nowrap',
           marginBottom: 3,
+          display: 'flex', alignItems: 'center', gap: 5,
         }}>
-          {message.subject || t('message.noSubject')}
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', flex: 1, minWidth: 0 }}>
+            {message.subject || t('message.noSubject')}
+          </span>
+          <PluginSlot name="message-row-meta" ctx={{ message, surface: 'message' }} />
         </div>
 
         {/* Row 3: Snippet */}

--- a/frontend/src/hooks/useGtdTriage.js
+++ b/frontend/src/hooks/useGtdTriage.js
@@ -9,6 +9,7 @@ import {
 import { openReplyFromMessage, openForwardFromMessage } from '../utils/composeFromMessage.js';
 import { resolveContextMenuMessage } from '../utils/contextMenuPolicy.js';
 import { doneGtdRow } from '../utils/gtdDone.js';
+import { invalidateGtdMetadata } from '../plugins/gtd/metadataStore.js';
 
 // One pending delayed auto-read across ALL GTD surfaces (module scope, not per hook
 // instance): the sidebar and the tab browse list are mounted together in desktop row
@@ -88,6 +89,7 @@ export function useGtdTriage() {
       removeGtdThread,
       restoreGtdThread,
       addNotification,
+      invalidateGtdMetadata,
       scheduleGtdSectionsFetch,
       t,
     });

--- a/frontend/src/plugins/gtd/GtdContextMenu.jsx
+++ b/frontend/src/plugins/gtd/GtdContextMenu.jsx
@@ -3,6 +3,7 @@ import { GTD_STATES, GTD_COLORS, resolveAccountGtdFolders, gtdStatesInFolders, u
 import { useStore } from '../../store/index.js';
 import { api } from '../../utils/api.js';
 import { classifyWithUndo } from './classification.js';
+import { invalidateGtdMetadata, removeGtdMetadataState } from './metadataStore.js';
 
 // GTD's context-menu contributions, injected into core's 'context-menu-actions' collector so the
 // menu itself carries no GTD-specific code. Placement is preserved: core splices these items into
@@ -22,14 +23,27 @@ function GtdContextSubmenu({ message, account, onClose, onBack }) {
   // Classify = COPY into the state's label folder (message stays put); remove = strip that label.
   // Store-based, so they run the same on every surface — no dependency on the caller's onAction.
   const classify = (state) => {
-    void classifyWithUndo(message.id, state, {
+    void classifyWithUndo(message, state, {
       api,
       store: { addNotification, scheduleGtdSectionsFetch },
       t,
     });
     onClose();
   };
-  const removeFrom = (state) => { unclassifyThread(message.id, state, { gtdUnclassify: api.gtdUnclassify, addNotification, scheduleGtdSectionsFetch, t }); onClose(); };
+  const removeFrom = (state) => {
+    void unclassifyThread(message.id, state, {
+      gtdUnclassify: api.gtdUnclassify,
+      addNotification,
+      scheduleGtdSectionsFetch,
+      t,
+    }).then(removed => {
+      if (removed) {
+        removeGtdMetadataState(message, state);
+        invalidateGtdMetadata();
+      }
+    });
+    onClose();
+  };
   return (
     <>
       <div

--- a/frontend/src/plugins/gtd/GtdInboxIndicators.jsx
+++ b/frontend/src/plugins/gtd/GtdInboxIndicators.jsx
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getGtdMetadata, subscribeGtdMetadata } from './metadataStore.js';
+import { buildInboxGtdIndicators } from './indicators.js';
+
+export default function GtdInboxIndicators({ message }) {
+  const { t } = useTranslation();
+  const metadata = useSyncExternalStore(
+    subscribeGtdMetadata,
+    () => getGtdMetadata(message.id),
+    () => null,
+  );
+  const indicators = buildInboxGtdIndicators(metadata, t);
+  if (!indicators.length) return null;
+
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, minWidth: 0, overflow: 'hidden', flexShrink: 0 }}>
+      {indicators.map(indicator => (
+        <span key={indicator.state} style={{
+          color: indicator.color,
+          background: indicator.background,
+          borderRadius: 7,
+          padding: '0 5px',
+          fontSize: 10,
+          fontWeight: 600,
+          whiteSpace: 'nowrap',
+        }}>
+          {indicator.label}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/plugins/gtd/GtdRowDone.jsx
+++ b/frontend/src/plugins/gtd/GtdRowDone.jsx
@@ -3,6 +3,7 @@ import { useStore } from '../../store/index.js';
 import { api } from '../../utils/api.js';
 import { advanceSelectionAfterRemoval } from '../../utils/listSelection.js';
 import { ActionBtn } from '../../components/RowHoverActions.jsx';
+import { invalidateGtdMetadata } from './metadataStore.js';
 
 // The GTD "done" checkmark for the row hover cluster, rendered via the 'row-hover-action' slot.
 //
@@ -29,6 +30,7 @@ export default function GtdRowDone({ message, done }) {
     if (unreadDelta > 0) decrementUnread(message.account_id, unreadDelta);
     try {
       const res = await api.gtdDone(message.id);
+      invalidateGtdMetadata();
       // Labels stripped but the archive step failed: the optimistic removal is still correct, but
       // the email is still in the inbox — say so rather than leave a gap.
       if (res?.archiveFailed) {

--- a/frontend/src/plugins/gtd/GtdRuntime.jsx
+++ b/frontend/src/plugins/gtd/GtdRuntime.jsx
@@ -1,10 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../../store/index.js';
 import { gtdActiveForContext } from '../../utils/gtd.js';
 import { api } from '../../utils/api.js';
 import { shortcutBus } from '../../utils/shortcutBus.js';
 import { classifyWithUndo, undoLatestGtdNotification } from './classification.js';
+import {
+  getGtdMetadataRefreshGeneration,
+  startGtdMetadataFetch,
+  subscribeGtdMetadataRefresh,
+} from './metadataStore.js';
+import { shouldShowInboxGtdMetadata } from './indicators.js';
 
 // GTD's headless runtime: the single owner of the GTD sections fetch. Reloads whenever the context
 // (unified vs a single account) changes and GTD is active there; both the rail and the tab list read
@@ -14,7 +20,11 @@ export default function GtdRuntime() {
   const { t } = useTranslation();
   const accounts = useStore(s => s.accounts);
   const selectedAccountId = useStore(s => s.selectedAccountId);
+  const selectedFolder = useStore(s => s.selectedFolder);
   const fetchGtdSections = useStore(s => s.fetchGtdSections);
+  const messages = useStore(s => s.messages);
+  const searchResults = useStore(s => s.searchResults);
+  const searchQuery = useStore(s => s.searchQuery);
 
   const gtdActive = gtdActiveForContext(accounts, selectedAccountId, true);
   // Also key on the set of GTD-enabled accounts so enabling a second account refetches the unified
@@ -23,6 +33,25 @@ export default function GtdRuntime() {
   useEffect(() => {
     if (gtdActive) fetchGtdSections();
   }, [gtdActive, selectedAccountId, gtdEnabledKey, fetchGtdSections]);
+
+  const metadataSurfaceActive = shouldShowInboxGtdMetadata({ selectedFolder, searchQuery });
+  const renderedPool = metadataSurfaceActive ? (searchQuery.trim() ? searchResults : messages) : [];
+  const enabledAccountIds = new Set(accounts.filter(account => account.gtd_enabled).map(account => account.id));
+  const metadataMessages = renderedPool.filter(message => enabledAccountIds.has(message.account_id));
+  const metadataKey = metadataMessages.map(message => `${message.account_id}:${message.id}`).join(',');
+  const metadataConfigKey = accounts
+    .filter(account => account.gtd_enabled)
+    .map(account => `${account.id}:${JSON.stringify(account.gtd_folders || {})}`)
+    .sort()
+    .join(',');
+  const metadataRefreshGeneration = useSyncExternalStore(
+    subscribeGtdMetadataRefresh,
+    getGtdMetadataRefreshGeneration,
+  );
+  useEffect(() => {
+    if (!gtdActive || !metadataSurfaceActive) return;
+    return startGtdMetadataFetch(metadataMessages, { api });
+  }, [gtdActive, metadataSurfaceActive, metadataKey, metadataConfigKey, metadataRefreshGeneration]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // GTD classify keys (t/w/d): COPY the selected message into a state's label folder. Silent no-op
   // unless the selected message's account has GTD enabled. Only wired while GTD is activated (this
@@ -35,7 +64,7 @@ export default function GtdRuntime() {
       const msg = pool.find(m => m.id === selectedMessageId);
       if (!msg) return;
       if (!accts.find(a => a.id === msg.account_id)?.gtd_enabled) return;
-      void classifyWithUndo(msg.id, state, {
+      void classifyWithUndo(msg, state, {
         api,
         store: { addNotification, scheduleGtdSectionsFetch },
         t,

--- a/frontend/src/plugins/gtd/classification.js
+++ b/frontend/src/plugins/gtd/classification.js
@@ -1,10 +1,19 @@
-export async function classifyWithUndo(messageId, state, {
+import {
+  invalidateGtdMetadata,
+  patchGtdMetadata,
+  removeGtdMetadataState,
+} from './metadataStore.js';
+
+export async function classifyWithUndo(message, state, {
   api,
   store,
   t,
 }) {
+  const messageId = typeof message === 'string' ? message : message?.id;
   try {
     const result = await api.gtdClassify(messageId, state);
+    patchGtdMetadata(message, state, typeof message === 'object' ? message.date : null);
+    invalidateGtdMetadata();
     store.scheduleGtdSectionsFetch();
 
     const notification = {
@@ -20,6 +29,8 @@ export async function classifyWithUndo(messageId, state, {
         consumed = true;
         try {
           await api.gtdUndoClassify(result.undoToken);
+          removeGtdMetadataState(message, state);
+          invalidateGtdMetadata();
           store.scheduleGtdSectionsFetch();
           return true;
         } catch (err) {

--- a/frontend/src/plugins/gtd/classification.test.js
+++ b/frontend/src/plugins/gtd/classification.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { classifyWithUndo, undoLatestGtdNotification } from './classification.js';
+import { getGtdMetadata, getGtdMetadataRefreshGeneration } from './metadataStore.js';
 
 function createHarness(classifyResult = {}) {
   const notifications = [];
@@ -86,6 +87,51 @@ describe('classifyWithUndo', () => {
     assert.equal(harness.calls.refresh, 0);
     assert.equal(harness.notifications[0].type, 'error');
     assert.equal(harness.notifications[0].title, 'gtd.classifyFailed');
+  });
+
+  it('optimistically patches metadata for the classified visible message', async () => {
+    const message = {
+      id: 'metadata-message',
+      date: '2026-08-04T00:00:00.000Z',
+    };
+    const harness = createHarness({ ok: true, applied: true, undoToken: null });
+
+    const refreshBefore = getGtdMetadataRefreshGeneration();
+    await classifyWithUndo(message, 'reference', harness);
+
+    assert.deepEqual(harness.calls.classify, [[message.id, 'reference']]);
+    assert.deepEqual(getGtdMetadata(message.id), {
+      states: ['reference'],
+      dates: { reference: message.date },
+      date: message.date,
+    });
+    assert.equal(getGtdMetadataRefreshGeneration(), refreshBefore + 1);
+  });
+
+  it('removes the optimistic state after a successful undo', async () => {
+    const message = {
+      id: 'metadata-undo-message',
+      date: '2026-08-05T00:00:00.000Z',
+    };
+    const harness = createHarness({
+      ok: true,
+      applied: true,
+      undoToken: {
+        messageId: message.id,
+        state: 'todo',
+        folder: 'GTD/Todo',
+        uid: 904,
+      },
+    });
+
+    const refreshBefore = getGtdMetadataRefreshGeneration();
+    await classifyWithUndo(message, 'todo', harness);
+    assert.deepEqual(getGtdMetadata(message.id)?.states, ['todo']);
+
+    await harness.notifications[0].onUndo();
+
+    assert.equal(getGtdMetadata(message.id), null);
+    assert.equal(getGtdMetadataRefreshGeneration(), refreshBefore + 2);
   });
 });
 

--- a/frontend/src/plugins/gtd/index.jsx
+++ b/frontend/src/plugins/gtd/index.jsx
@@ -14,6 +14,9 @@ import { buildGtdContextItems } from './GtdContextMenu.jsx';
 import { gtdActiveForContext } from '../../utils/gtd.js';
 import { accountAffectsUnifiedInbox } from '../../utils/unifiedInbox.js';
 import { useStore } from '../../store/index.js';
+import GtdInboxIndicators from './GtdInboxIndicators.jsx';
+import { shouldShowInboxGtdMetadata } from './indicators.js';
+import { invalidateGtdMetadata } from './metadataStore.js';
 
 // Right-sidebar panel: GTD's triage rail. Live when GTD is on for the current account scope
 // (per-user activation is already checked by the slot registry, so pass `true` here).
@@ -54,6 +57,16 @@ registerSlot('row-hover-action', {
   render: (ctx) => <GtdRowDone message={ctx.message} done={ctx.done} />,
 });
 
+registerSlot('message-row-meta', {
+  pluginId: 'gtd',
+  isActive: (ctx) => {
+    const store = useStore.getState();
+    return gtdActiveForContext(store.accounts, ctx.message.account_id, true)
+      && shouldShowInboxGtdMetadata(store);
+  },
+  render: (ctx) => <GtdInboxIndicators message={ctx.message} />,
+});
+
 // WS: a GTD label folder changed (tick / classify copy-remove / transition strip). Refetch the
 // rail+tab sections when the event's account is in the current rail scope (debounced in the store).
 registerWsHandler('gtd_sections_updated', {
@@ -65,6 +78,7 @@ registerWsHandler('gtd_sections_updated', {
       store.selectedAccountId === data.accountId
     ) {
       store.scheduleGtdSectionsFetch();
+      invalidateGtdMetadata();
     }
   },
 });
@@ -76,6 +90,9 @@ registerReconnectHandler({
   pluginId: 'gtd',
   handler: () => {
     const { accounts, selectedAccountId, scheduleGtdSectionsFetch } = useStore.getState();
-    if (gtdActiveForContext(accounts, selectedAccountId, true)) scheduleGtdSectionsFetch();
+    if (gtdActiveForContext(accounts, selectedAccountId, true)) {
+      scheduleGtdSectionsFetch();
+      invalidateGtdMetadata();
+    }
   },
 });

--- a/frontend/src/plugins/gtd/indicators.js
+++ b/frontend/src/plugins/gtd/indicators.js
@@ -1,0 +1,49 @@
+const STATE_ORDER = ['todo', 'watch', 'delegated', 'reference', 'someday'];
+const WAITING_STATES = new Set(['watch', 'delegated']);
+const STALE_DAYS = 14;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const COLORS = {
+  todo: '#4A9EDD',
+  watch: '#D9B430',
+  delegated: '#E08B3D',
+  reference: '#7157d9',
+  someday: 'var(--text-tertiary)',
+};
+
+const BACKGROUNDS = {
+  todo: 'rgba(74,158,221,0.16)',
+  watch: 'rgba(217,180,48,0.15)',
+  delegated: 'rgba(224,139,61,0.15)',
+  reference: 'rgba(113,87,217,0.16)',
+  someday: 'rgba(139,139,155,0.16)',
+};
+
+export function shouldShowInboxGtdMetadata({ selectedFolder, searchQuery }) {
+  return Boolean(searchQuery?.trim()) || selectedFolder === 'INBOX';
+}
+
+function wholeDays(date, now) {
+  const timestamp = new Date(date).getTime();
+  if (!date || !Number.isFinite(timestamp)) return null;
+  return Math.max(0, Math.floor((now - timestamp) / DAY_MS));
+}
+
+export function buildInboxGtdIndicators(metadata, t, now = Date.now()) {
+  if (!Array.isArray(metadata?.states)) return [];
+  const states = new Set(metadata.states.filter(state => STATE_ORDER.includes(state)));
+  return STATE_ORDER.filter(state => states.has(state)).map(state => {
+    const waiting = WAITING_STATES.has(state);
+    const hasStateDate = Object.hasOwn(metadata.dates || {}, state);
+    const stateDate = hasStateDate ? metadata.dates[state] : metadata.date;
+    const days = waiting ? wholeDays(stateDate, now) : null;
+    const stale = waiting && days != null && days > STALE_DAYS;
+    return {
+      state,
+      label: waiting && days != null ? `⏱ ${days}d` : t(`gtd.state.${state}`),
+      stale,
+      color: stale ? '#ff9b9b' : COLORS[state],
+      background: stale ? 'rgba(248,113,113,.16)' : BACKGROUNDS[state],
+    };
+  });
+}

--- a/frontend/src/plugins/gtd/indicators.test.js
+++ b/frontend/src/plugins/gtd/indicators.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildInboxGtdIndicators, shouldShowInboxGtdMetadata } from './indicators.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-08-20T00:00:00.000Z');
+const t = key => key;
+
+describe('buildInboxGtdIndicators', () => {
+  it('deduplicates valid states into canonical display order', () => {
+    const result = buildInboxGtdIndicators({
+      states: ['someday', 'watch', 'todo', 'watch', 'reference', 'delegated'],
+      dates: {},
+      date: null,
+    }, t, NOW);
+
+    assert.deepEqual(result.map(item => item.state), ['todo', 'watch', 'delegated', 'reference', 'someday']);
+    assert.equal(result[0].label, 'gtd.state.todo');
+  });
+
+  it('shows whole-day aging for waiting states and turns stale after 14 days', () => {
+    const fourteen = new Date(NOW - 14 * DAY).toISOString();
+    const fifteen = new Date(NOW - 15 * DAY).toISOString();
+    const result = buildInboxGtdIndicators({
+      states: ['watch', 'delegated'],
+      dates: { watch: fourteen, delegated: fifteen },
+      date: fifteen,
+    }, t, NOW);
+
+    assert.deepEqual(result.map(item => ({ state: item.state, label: item.label, stale: item.stale })), [
+      { state: 'watch', label: '⏱ 14d', stale: false },
+      { state: 'delegated', label: '⏱ 15d', stale: true },
+    ]);
+    assert.notEqual(result[0].color, result[1].color);
+  });
+
+  it('uses a ten-day aging label without marking the waiting state stale', () => {
+    const result = buildInboxGtdIndicators({
+      states: ['watch'],
+      dates: { watch: new Date(NOW - 10 * DAY).toISOString() },
+    }, t, NOW);
+    assert.equal(result[0].label, '⏱ 10d');
+    assert.equal(result[0].stale, false);
+  });
+
+  it('preserves an explicit unknown waiting date instead of borrowing another state date', () => {
+    const result = buildInboxGtdIndicators({
+      states: ['watch', 'todo'],
+      dates: { watch: null, todo: new Date(NOW - 20 * DAY).toISOString() },
+      date: new Date(NOW - 20 * DAY).toISOString(),
+    }, t, NOW);
+
+    assert.equal(result.find(item => item.state === 'watch').label, 'gtd.state.watch');
+    assert.equal(result.find(item => item.state === 'watch').stale, false);
+  });
+
+  it('returns no indicators for malformed metadata', () => {
+    assert.deepEqual(buildInboxGtdIndicators(null, t, NOW), []);
+    assert.deepEqual(buildInboxGtdIndicators({ states: 'todo' }, t, NOW), []);
+    assert.deepEqual(buildInboxGtdIndicators({ states: ['invalid'] }, t, NOW), []);
+  });
+});
+
+describe('shouldShowInboxGtdMetadata', () => {
+  it('shows metadata in Inbox and active search results only', () => {
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'INBOX', searchQuery: '' }), true);
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'Sent', searchQuery: 'casey' }), true);
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'Sent', searchQuery: '' }), false);
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'Trash', searchQuery: '   ' }), false);
+  });
+});

--- a/frontend/src/plugins/gtd/metadataStore.js
+++ b/frontend/src/plugins/gtd/metadataStore.js
@@ -1,0 +1,148 @@
+const STATE_ORDER = ['todo', 'watch', 'delegated', 'reference', 'someday'];
+const metadata = new Map();
+const listeners = new Set();
+const refreshListeners = new Set();
+let requestGeneration = 0;
+let refreshGeneration = 0;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeGtdMetadata(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getGtdMetadata(messageId) {
+  return metadata.get(messageId) ?? null;
+}
+
+export function subscribeGtdMetadataRefresh(listener) {
+  refreshListeners.add(listener);
+  return () => refreshListeners.delete(listener);
+}
+
+export function getGtdMetadataRefreshGeneration() {
+  return refreshGeneration;
+}
+
+export function invalidateGtdMetadata() {
+  requestGeneration += 1;
+  refreshGeneration += 1;
+  for (const listener of refreshListeners) listener();
+}
+
+export async function fetchVisibleGtdMetadata(messages, { api }) {
+  const generation = ++requestGeneration;
+  const idsByAccount = new Map();
+  for (const message of messages || []) {
+    if (!message?.id || !message.account_id) continue;
+    if (!idsByAccount.has(message.account_id)) idsByAccount.set(message.account_id, new Set());
+    idsByAccount.get(message.account_id).add(message.id);
+  }
+
+  const batches = [];
+  for (const [accountId, idSet] of idsByAccount) {
+    const ids = [...idSet];
+    for (let offset = 0; offset < ids.length; offset += 100) {
+      const chunk = ids.slice(offset, offset + 100);
+      let request;
+      try {
+        request = Promise.resolve(api.gtdMetadata(accountId, chunk));
+      } catch (error) {
+        request = Promise.reject(error);
+      }
+      batches.push({
+        ids: chunk,
+        request,
+      });
+    }
+  }
+  const responses = await Promise.allSettled(batches.map(batch => batch.request));
+  if (generation !== requestGeneration) return 'stale';
+
+  let failed = false;
+  for (const [index, response] of responses.entries()) {
+    if (response.status === 'rejected') {
+      failed = true;
+      continue;
+    }
+    const fresh = new Map(Object.entries(response.value?.messages || {}));
+    for (const id of batches[index].ids) {
+      if (fresh.has(id)) metadata.set(id, fresh.get(id));
+      else metadata.delete(id);
+    }
+  }
+  emit();
+  return failed ? 'partial' : 'complete';
+}
+
+export function startGtdMetadataFetch(messages, {
+  api,
+  delay = 2000,
+  schedule = setTimeout,
+  cancelSchedule = clearTimeout,
+  onError = error => console.error('GTD metadata fetch failed:', error),
+}) {
+  let cancelled = false;
+  let retryTimer;
+  const fetchMetadata = async (allowRetry) => {
+    if (cancelled) return;
+    try {
+      const status = await fetchVisibleGtdMetadata(messages, { api });
+      if (!cancelled && status === 'partial' && allowRetry) {
+        retryTimer = schedule(() => { void fetchMetadata(false); }, delay);
+      }
+    } catch (error) {
+      if (!cancelled) onError(error);
+    }
+  };
+  void fetchMetadata(true);
+  return () => {
+    cancelled = true;
+    if (retryTimer !== undefined) cancelSchedule(retryTimer);
+  };
+}
+
+export function patchGtdMetadata(message, state, date) {
+  const messageId = typeof message === 'string' ? message : message?.id;
+  if (!messageId || !STATE_ORDER.includes(state)) return;
+  const current = metadata.get(messageId) || { states: [], dates: {}, date: null };
+  const states = [...new Set([...current.states, state])]
+    .sort((a, b) => STATE_ORDER.indexOf(a) - STATE_ORDER.indexOf(b));
+  const dates = { ...current.dates };
+  if (!(state in dates)) dates[state] = date ?? null;
+  const dated = Object.values(dates).filter(Boolean).sort();
+  metadata.set(messageId, {
+    ...current,
+    states,
+    dates,
+    date: dated.at(-1) ?? null,
+  });
+  requestGeneration += 1;
+  emit();
+}
+
+export function removeGtdMetadataState(message, state) {
+  const messageId = typeof message === 'string' ? message : message?.id;
+  const current = messageId ? metadata.get(messageId) : null;
+  if (!current?.states?.includes(state)) return;
+
+  const states = current.states.filter(item => item !== state);
+  if (states.length === 0) {
+    metadata.delete(messageId);
+  } else {
+    const dates = { ...current.dates };
+    delete dates[state];
+    const dated = Object.values(dates).filter(Boolean).sort();
+    metadata.set(messageId, {
+      ...current,
+      states,
+      dates,
+      date: dated.at(-1) ?? null,
+    });
+  }
+  requestGeneration += 1;
+  emit();
+}

--- a/frontend/src/plugins/gtd/metadataStore.test.js
+++ b/frontend/src/plugins/gtd/metadataStore.test.js
@@ -1,0 +1,170 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fetchVisibleGtdMetadata,
+  getGtdMetadata,
+  getGtdMetadataRefreshGeneration,
+  invalidateGtdMetadata,
+  patchGtdMetadata,
+  startGtdMetadataFetch,
+  subscribeGtdMetadataRefresh,
+} from './metadataStore.js';
+
+const A1 = 'account-1';
+const A2 = 'account-2';
+const M1 = '11111111-1111-4111-8111-111111111111';
+const M2 = '22222222-2222-4222-8222-222222222222';
+const flushMicrotasks = async () => {
+  for (let index = 0; index < 4; index += 1) await Promise.resolve();
+};
+
+describe('fetchVisibleGtdMetadata', () => {
+  it('groups by account, deduplicates, and chunks requests at 100 ids', async () => {
+    const calls = [];
+    const messages = Array.from({ length: 101 }, (_, i) => ({ id: `m-${i}`, account_id: A1 }));
+    messages.push(messages[0], { id: M2, account_id: A2 });
+    const api = { gtdMetadata: async (accountId, ids) => {
+      calls.push([accountId, ids]);
+      return { messages: {} };
+    } };
+
+    await fetchVisibleGtdMetadata(messages, { api });
+
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls.map(([accountId, ids]) => [accountId, ids.length]), [
+      [A1, 100], [A1, 1], [A2, 1],
+    ]);
+  });
+
+  it('ignores a slow response superseded by a newer fetch', async () => {
+    let resolveSlow;
+    const slowApi = { gtdMetadata: () => new Promise(resolve => { resolveSlow = resolve; }) };
+    const fastApi = { gtdMetadata: async () => ({ messages: {
+      [M1]: { states: ['watch'], dates: { watch: '2026-08-01T00:00:00.000Z' }, date: '2026-08-01T00:00:00.000Z' },
+    } }) };
+
+    const slow = fetchVisibleGtdMetadata([{ id: M1, account_id: A1 }], { api: slowApi });
+    await fetchVisibleGtdMetadata([{ id: M1, account_id: A1 }], { api: fastApi });
+    resolveSlow({ messages: {
+      [M1]: { states: ['todo'], dates: { todo: '2026-07-01T00:00:00.000Z' }, date: '2026-07-01T00:00:00.000Z' },
+    } });
+    await slow;
+
+    assert.deepEqual(getGtdMetadata(M1).states, ['watch']);
+  });
+
+  it('clears cached labels omitted by a fresh response', async () => {
+    patchGtdMetadata(M2, 'todo', '2026-08-01T00:00:00.000Z');
+    await fetchVisibleGtdMetadata([{ id: M2, account_id: A1 }], {
+      api: { gtdMetadata: async () => ({ messages: {} }) },
+    });
+    assert.equal(getGtdMetadata(M2), null);
+  });
+
+  it('applies successful account responses without clearing data from a failed request', async () => {
+    patchGtdMetadata(M2, 'todo', '2026-08-01T00:00:00.000Z');
+    const result = await fetchVisibleGtdMetadata([
+      { id: M1, account_id: A1 },
+      { id: M2, account_id: A2 },
+    ], {
+      api: { gtdMetadata: async (accountId) => {
+        if (accountId === A2) throw new Error('account offline');
+        return { messages: {
+          [M1]: { states: ['watch'], dates: { watch: '2026-08-02T00:00:00.000Z' }, date: '2026-08-02T00:00:00.000Z' },
+        } };
+      } },
+    });
+
+    assert.equal(result, 'partial');
+    assert.deepEqual(getGtdMetadata(M1)?.states, ['watch']);
+    assert.deepEqual(getGtdMetadata(M2)?.states, ['todo']);
+  });
+
+  it('does not let an older fetch overwrite an optimistic classification', async () => {
+    const id = 'optimistic-race-message';
+    let resolveFetch;
+    const pending = fetchVisibleGtdMetadata([{ id, account_id: A1 }], {
+      api: { gtdMetadata: () => new Promise(resolve => { resolveFetch = resolve; }) },
+    });
+
+    patchGtdMetadata(id, 'todo', '2026-08-04T00:00:00.000Z');
+    resolveFetch({ messages: {} });
+
+    assert.equal(await pending, 'stale');
+    assert.deepEqual(getGtdMetadata(id)?.states, ['todo']);
+  });
+});
+
+describe('startGtdMetadataFetch', () => {
+  it('does not schedule a late partial retry after cancellation', async () => {
+    let rejectRequest;
+    const scheduled = [];
+    const cancel = startGtdMetadataFetch([{ id: M1, account_id: A1 }], {
+      api: { gtdMetadata: () => new Promise((_resolve, reject) => { rejectRequest = reject; }) },
+      schedule: callback => { scheduled.push(callback); return callback; },
+      cancelSchedule: () => {},
+      onError: () => {},
+    });
+
+    cancel();
+    rejectRequest(new Error('offline'));
+    await flushMicrotasks();
+
+    assert.equal(scheduled.length, 0);
+  });
+
+  it('schedules at most one retry for a partial response', async () => {
+    const scheduled = [];
+    let calls = 0;
+    const cancel = startGtdMetadataFetch([{ id: M1, account_id: A1 }], {
+      api: { gtdMetadata: async () => { calls += 1; throw new Error('offline'); } },
+      schedule: callback => { scheduled.push(callback); return callback; },
+      cancelSchedule: () => {},
+      onError: () => {},
+    });
+    await flushMicrotasks();
+
+    assert.equal(scheduled.length, 1);
+    scheduled[0]();
+    await flushMicrotasks();
+
+    assert.equal(calls, 2);
+    assert.equal(scheduled.length, 1);
+    cancel();
+  });
+});
+
+describe('invalidateGtdMetadata', () => {
+  it('advances the refresh generation and notifies runtime subscribers', () => {
+    const before = getGtdMetadataRefreshGeneration();
+    let calls = 0;
+    const unsubscribe = subscribeGtdMetadataRefresh(() => { calls += 1; });
+
+    invalidateGtdMetadata();
+    unsubscribe();
+    invalidateGtdMetadata();
+
+    assert.equal(getGtdMetadataRefreshGeneration(), before + 2);
+    assert.equal(calls, 1);
+  });
+});
+
+describe('patchGtdMetadata', () => {
+  it('inserts states canonically without overwriting older state dates', () => {
+    const id = 'patch-message';
+    patchGtdMetadata(id, 'someday', '2026-08-03T00:00:00.000Z');
+    patchGtdMetadata(id, 'watch', '2026-08-02T00:00:00.000Z');
+    patchGtdMetadata(id, 'todo', '2026-08-01T00:00:00.000Z');
+    patchGtdMetadata(id, 'watch', '2026-08-09T00:00:00.000Z');
+
+    assert.deepEqual(getGtdMetadata(id), {
+      states: ['todo', 'watch', 'someday'],
+      dates: {
+        todo: '2026-08-01T00:00:00.000Z',
+        watch: '2026-08-02T00:00:00.000Z',
+        someday: '2026-08-03T00:00:00.000Z',
+      },
+      date: '2026-08-03T00:00:00.000Z',
+    });
+  });
+});

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -399,6 +399,7 @@ export const api = {
     return request('GET', `/gtd/sections${qs ? '?' + qs : ''}`);
   },
   gtdClassify: (messageId, state) => request('POST', '/gtd/classify', { messageId, state }),
+  gtdMetadata: (accountId, messageIds) => request('POST', '/gtd/metadata', { accountId, messageIds }),
   gtdUndoClassify: (undoToken) => request('POST', '/gtd/classify/undo', undoToken),
   gtdUnclassify: (messageId, state) => request('DELETE', '/gtd/classify', { messageId, state }),
   // GTD "done": strip the row's label(s) for these states, mark read, archive the INBOX

--- a/frontend/src/utils/gtd.js
+++ b/frontend/src/utils/gtd.js
@@ -572,9 +572,11 @@ export async function unclassifyThread(id, state, { gtdUnclassify, addNotificati
     await gtdUnclassify(id, state);
     scheduleGtdSectionsFetch();
     addNotification({ title: t('gtd.removed'), body: t(`gtd.state.${state}`) });
+    return true;
   } catch (err) {
     console.error('GTD unclassify failed:', err.message);
     addNotification({ title: t('gtd.removeFailed'), body: t(`gtd.state.${state}`) });
+    return false;
   }
 }
 

--- a/frontend/src/utils/gtd.test.js
+++ b/frontend/src/utils/gtd.test.js
@@ -1211,7 +1211,8 @@ describe('unclassifyThread', () => {
       scheduleGtdSectionsFetch: () => calls.push(['schedule']),
       t,
     };
-    await unclassifyThread('m1', 'todo', deps);
+    const removed = await unclassifyThread('m1', 'todo', deps);
+    assert.equal(removed, true);
     assert.deepEqual(calls, [
       ['unclassify', 'm1', 'todo'],
       ['schedule'],
@@ -1227,7 +1228,8 @@ describe('unclassifyThread', () => {
       scheduleGtdSectionsFetch: () => calls.push(['schedule']),
       t,
     };
-    await unclassifyThread('m1', 'todo', deps);
+    const removed = await unclassifyThread('m1', 'todo', deps);
+    assert.equal(removed, false);
     assert.deepEqual(calls, [['notify', 'gtd.removeFailed', 'gtd.state.todo']]);
   });
 });

--- a/frontend/src/utils/gtdDone.js
+++ b/frontend/src/utils/gtdDone.js
@@ -9,6 +9,7 @@ export async function doneGtdRow(thread, states, {
   removeGtdThread,
   restoreGtdThread,
   addNotification,
+  invalidateGtdMetadata,
   scheduleGtdSectionsFetch,
   t,
 }) {
@@ -19,6 +20,7 @@ export async function doneGtdRow(thread, states, {
   try {
     const result = await gtdDone(thread.id, states);
     setCompletedGtdRemoval(identity, states);
+    invalidateGtdMetadata?.();
     if (result?.archiveFailed) {
       addNotification({ title: t('gtd.doneArchiveFailed'), body: thread.subject || t('common.noSubject') });
     }

--- a/frontend/src/utils/gtdDone.test.js
+++ b/frontend/src/utils/gtdDone.test.js
@@ -99,4 +99,14 @@ describe('doneGtdRow', () => {
     ]);
     assert.equal(completedGtdRemovalMap.size, 1);
   });
+
+  it('invalidates visible GTD metadata after a successful mutation', async () => {
+    const calls = [];
+    await doneGtdRow(thread, states, deps({
+      invalidateGtdMetadata: () => calls.push('invalidate'),
+      scheduleGtdSectionsFetch: () => calls.push('schedule'),
+    }));
+
+    assert.deepEqual(calls, ['invalidate', 'schedule']);
+  });
 });


### PR DESCRIPTION
## Summary

Ports the inbox GTD state indicators from closed PR #330 onto the plugin boundary described in #368. Ordinary inbox and search rows can now show every GTD state on the thread, with the oldest relevant classification date, without putting GTD-specific joins or fields into MailFlow's core message query.

The prerequisite plugin-boundary work from #370 is merged, and this branch is rebased onto current `main`.

## Changes

- Add a bounded, plugin-owned metadata endpoint for up to 100 visible messages at a time.
- Expose only a neutral `message-row-meta` slot from the core message list. GTD owns the labels, colors, ordering, dates, and account gating.
- Resolve state metadata across every live copy of the same message and thread, including custom GTD folder mappings.
- Group and chunk visible-row requests per account, ignore superseded responses, and keep optimistic classification and undo state coherent with server refreshes.
- Refresh indicators after GTD WebSocket events, reconnects, folder-map changes, classification, undo, and unclassification.
- Show compact state chips and a conservative age for multi-state threads.
- Treat partial metadata responses as retryable and keep retries bounded and cancelable when no consumers remain.

Refs #368

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
