### PR TITLE
feat(gtd): add delegated contact API

### DIFF
--- a/backend/eslint.plugins-boundary.js
+++ b/backend/eslint.plugins-boundary.js
@@ -15,7 +15,7 @@ import globals from 'globals';
 export default [
   {
     files: ['src/plugins/*/**/*.js'],
-    ignores: ['**/*.test.js'],
+    ignores: ['**/*.test.js', 'src/plugins/gtd/**/*.js'],
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'module',
@@ -31,6 +31,29 @@ export default [
           {
             group: ['../*', '!../api.js'],
             message: 'Plugin boundary: from the plugin dir, only "../api.js" (the plugin API) may be imported.',
+          },
+        ],
+      }],
+    },
+  },
+  {
+    files: ['src/plugins/gtd/**/*.js'],
+    ignores: ['**/*.test.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: ['../../**'],
+            message: 'Plugin boundary: import core capabilities from a reviewed plugin API.',
+          },
+          {
+            group: ['../*', '!../api.js', '!../gtdApi.js'],
+            message: 'Bundled GTD may import only "../api.js", "../gtdApi.js", and its siblings.',
           },
         ],
       }],

--- a/backend/src/plugins/README.md
+++ b/backend/src/plugins/README.md
@@ -10,8 +10,8 @@ correctness*, not for whether it could compromise the app. That's what lets a co
 plugin without a deep security review of every PR.
 
 Two tiers (conceptual): **Tier-1** = trusted, in-repo (like GTD today); **Tier-2** = untrusted /
-third-party. Both use the *same* capability surface — GTD was migrated fully onto it so the surface
-is proven.
+third-party. GTD uses the public capability surface plus one bundled-only, namespace-bound
+annotation surface; third-party plugins cannot import that internal surface.
 
 ---
 
@@ -60,7 +60,6 @@ Everything a plugin may do, grouped:
 - **Summarize:** `summarizeMessage`, `summarizeAvailable` (fails closed when the AI provider is off)
 - **Per-plugin storage:** `storage.*` (the `plugin_data` table — KV + blobs, owner-scoped, cascade-cleaned)
 - **Per-account plugin config:** `getAccountConfig`, `setAccountConfig` (the `plugin_account_config` table)
-- **Per-message annotations:** `getMessageAnnotations`, `setMessageAnnotation` (namespaced `messages.plugin_annotations`)
 - **Activation:** `isPluginActivated`, `isPluginActivatedForAccount`
 - **Logging:** `logger` · **Auth middleware:** `requireAuth` · **Folder resolution:** `resolveAllDraftsPaths`
 - **Ownership-scoped mail/account reads:** `loadOwnedMessage`, `getOwnedAccount`, `listUserAccounts`, `getAccountAddresses`, `getMessagesByThreadKeys`, `getMessageCopyFolders`, `getMessageFields`, the thread-key resolvers, …

--- a/backend/src/plugins/api.js
+++ b/backend/src/plugins/api.js
@@ -95,5 +95,6 @@ export {
   getMessageCopyFolders,
   getMessageFields,
   getMessageAnnotations,
+  getLabelMetadata,
   setMessageAnnotation,
 } from '../services/mailAccess.js';

--- a/backend/src/plugins/api.js
+++ b/backend/src/plugins/api.js
@@ -31,11 +31,13 @@ export { notifyOnLabelTouch } from '../services/labelsRead.js';
 // Apply/remove a label (a message copy in a label folder) and mark a thread read. The mail
 // engine is bound in by the platform (getMailEngine) so a plugin performs these mail actions
 // without ever holding the engine itself. resolveLabelCopyUid is pure (no engine).
-export const applyLabel = (account, message, labelFolder) => labelsWrite.applyLabel(getMailEngine(), account, message, labelFolder);
+export const applyLabel = (account, message, labelFolder, options) => labelsWrite.applyLabel(getMailEngine(), account, message, labelFolder, options);
 export const removeLabel = (message, labelFolder) => labelsWrite.removeLabel(getMailEngine(), message, labelFolder);
 export const removeExactLabelCopy = (message, labelFolder, uid) => labelsWrite.removeExactLabelCopy(getMailEngine(), message, labelFolder, uid);
 export const markThreadRead = (account, message) => labelsWrite.markThreadRead(getMailEngine(), account, message);
 export const ensureLabelFolders = (account, folderPaths) => labelsWrite.ensureLabelFolders(getMailEngine(), account, folderPaths);
+export const listLabelCopyUids = labelsWrite.listLabelCopyUids;
+export const reconcileLabelApply = (account, message, folder, beforeUids) => labelsWrite.reconcileLabelApply(getMailEngine(), account, message, folder, beforeUids);
 export const resolveLabelCopyUid = labelsWrite.resolveLabelCopyUid;
 
 // ── Archive ───────────────────────────────────────────────────────────────────
@@ -84,6 +86,8 @@ export { resolveAllDraftsPaths } from '../utils/mailUtils.js';
 // reads mail/account data only through these — never raw SQL, never across users.
 export {
   loadOwnedMessage,
+  loadOwnedMessages,
+  loadOwnedContact,
   getOwnedAccount,
   listUserAccounts,
   getAccountAddresses,
@@ -94,7 +98,5 @@ export {
   getThreadKeyForUid,
   getMessageCopyFolders,
   getMessageFields,
-  getMessageAnnotations,
   getLabelMetadata,
-  setMessageAnnotation,
 } from '../services/mailAccess.js';

--- a/backend/src/plugins/gtd/gtdDelegationLock.js
+++ b/backend/src/plugins/gtd/gtdDelegationLock.js
@@ -1,0 +1,31 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// One process-wide queue per account/thread. Delegation writes and label-removal cleanup must
+// share this lock: otherwise a final-copy removal can clear the snapshot after a concurrent
+// delegation call has just recreated the label and written a new snapshot.
+const queues = new Map();
+const ownership = new AsyncLocalStorage();
+
+export async function withGtdDelegationLock(accountId, threadKey, work) {
+  const key = `${accountId}\0${threadKey}`;
+  const held = ownership.getStore()?.get(key);
+  if (held?.active) return work();
+
+  const previous = queues.get(key) || Promise.resolve();
+  const current = previous.catch(() => {}).then(async () => {
+    const token = { active: true };
+    const context = new Map(ownership.getStore() || []);
+    context.set(key, token);
+    try {
+      return await ownership.run(context, work);
+    } finally {
+      token.active = false;
+    }
+  });
+  queues.set(key, current);
+  try {
+    return await current;
+  } finally {
+    if (queues.get(key) === current) queues.delete(key);
+  }
+}

--- a/backend/src/plugins/gtd/gtdDelegationLock.test.js
+++ b/backend/src/plugins/gtd/gtdDelegationLock.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { withGtdDelegationLock } from './gtdDelegationLock.js';
+
+describe('withGtdDelegationLock', () => {
+  it('serializes work for one account thread without blocking other threads', async () => {
+    let releaseFirst;
+    const order = [];
+    const first = withGtdDelegationLock('a1', 'thread-1', async () => {
+      order.push('first-start');
+      await new Promise(resolve => { releaseFirst = resolve; });
+      order.push('first-end');
+    });
+    const second = withGtdDelegationLock('a1', 'thread-1', async () => {
+      order.push('second');
+    });
+    const other = withGtdDelegationLock('a1', 'thread-2', async () => {
+      order.push('other');
+    });
+
+    await other;
+    expect(order).toEqual(['first-start', 'other']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(['first-start', 'other', 'first-end', 'second']);
+  });
+
+  it('allows an awaited same-thread hook to re-enter the owning operation', async () => {
+    const result = await Promise.race([
+      withGtdDelegationLock('a1', 'thread-reentrant', () => (
+        withGtdDelegationLock('a1', 'thread-reentrant', async () => 'nested')
+      )),
+      new Promise(resolve => setTimeout(() => resolve('timed-out'), 30)),
+    ]);
+    expect(result).toBe('nested');
+  });
+});

--- a/backend/src/plugins/gtd/gtdDelegations.js
+++ b/backend/src/plugins/gtd/gtdDelegations.js
@@ -1,0 +1,180 @@
+import {
+  applyLabel,
+  ensureLabelFolders,
+  getOwnedAccount,
+  listLabelCopyUids,
+  loadOwnedContact,
+  loadOwnedMessages,
+  reconcileLabelApply,
+  removeExactLabelCopy,
+} from '../api.js';
+import { setThreadAnnotation } from '../gtdApi.js';
+import { getGtdConfig, resolveGtdStateFolder } from './gtdConfig.js';
+import { withGtdDelegationLock } from './gtdDelegationLock.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class GtdDelegationError extends Error {
+  constructor(code, status) {
+    super(code);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function failure(messageId, error, compensated = false) {
+  return { messageId, ok: false, error, compensated };
+}
+
+function snapshotContact(contact, now = new Date()) {
+  const timestamp = now.toISOString();
+  return {
+    contactId: contact?.id ?? null,
+    displayName: contact
+      ? contact.display_name || contact.primary_email || 'Unknown contact'
+      : null,
+    primaryEmail: contact?.primary_email || null,
+    delegatedAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+export async function delegateMessages({ userId, messageIds, contactId }) {
+  if (!Array.isArray(messageIds)) throw new GtdDelegationError('invalid_request', 400);
+  const ids = [...new Set(messageIds)];
+  if (ids.length < 1 || ids.length > 100 || ids.some(id => !UUID_RE.test(id))) {
+    throw new GtdDelegationError('invalid_request', 400);
+  }
+  if (contactId !== null && !UUID_RE.test(contactId || '')) {
+    throw new GtdDelegationError('invalid_request', 400);
+  }
+
+  const contact = contactId === null ? null : await loadOwnedContact(userId, contactId);
+  if (contactId !== null && !contact) throw new GtdDelegationError('contact_not_found', 404);
+
+  const owned = await loadOwnedMessages(userId, ids);
+  const byId = new Map(owned.map(message => [message.id, message]));
+  const outcomes = new Map(ids.filter(id => !byId.has(id)).map(id => [id, failure(id, 'not_found')]));
+  const threads = new Map();
+
+  for (const id of ids) {
+    const message = byId.get(id);
+    if (!message) continue;
+    if (!message.thread_key) {
+      outcomes.set(id, failure(id, 'operation_failed'));
+      continue;
+    }
+    const key = `${message.account_id}\0${message.thread_key}`;
+    const group = threads.get(key) || { message, ids: [] };
+    group.ids.push(id);
+    threads.set(key, group);
+  }
+
+  const byAccount = new Map();
+  for (const group of threads.values()) {
+    const groups = byAccount.get(group.message.account_id) || [];
+    groups.push(group);
+    byAccount.set(group.message.account_id, groups);
+  }
+
+  await Promise.all([...byAccount.entries()].map(async ([accountId, groups]) => {
+    let account;
+    let folder;
+    try {
+      account = await getOwnedAccount(userId, accountId);
+      if (!account?.enabled) throw new Error('account_unavailable');
+      const config = await getGtdConfig(accountId);
+      folder = config.enabled ? resolveGtdStateFolder('delegated', config.folders) : null;
+      if (!folder) throw new Error('delegation_disabled');
+    } catch {
+      for (const { ids: threadIds } of groups) {
+        for (const messageId of threadIds) outcomes.set(messageId, failure(messageId, 'operation_failed'));
+      }
+      return;
+    }
+
+    let ensureFolderPromise;
+    const ensureDelegatedFolder = () => {
+      ensureFolderPromise ??= ensureLabelFolders(account, [folder]).then(([ensured]) => {
+        if (ensured?.error) throw new Error('delegation_folder_unavailable');
+      });
+      return ensureFolderPromise;
+    };
+
+    let cursor = 0;
+    const runNext = async () => {
+      while (cursor < groups.length) {
+        const group = groups[cursor++];
+        await withGtdDelegationLock(accountId, group.message.thread_key, async () => {
+          const { message, ids: threadIds } = group;
+          let createdUid = null;
+          let created = false;
+          try {
+            const beforeUids = await listLabelCopyUids(accountId, message.thread_key, folder);
+            if (beforeUids.length === 0) {
+              await ensureDelegatedFolder();
+              let applied;
+              try {
+                applied = await applyLabel(account, message, folder, {
+                  folderEnsured: true,
+                  skipPostCopyTransitions: true,
+                });
+              } catch (error) {
+                if (error?.copiedUid != null) {
+                  created = true;
+                  createdUid = error.copiedUid;
+                }
+                throw error;
+              }
+              created = applied.applied;
+              createdUid = applied.uid;
+              if (created && createdUid == null) {
+                const reconciled = await reconcileLabelApply(account, message, folder, beforeUids);
+                if (reconciled.ambiguous) throw new GtdDelegationError('operation_ambiguous', 409);
+                createdUid = reconciled.uid;
+              }
+            }
+
+            // Keep a durable start boundary even for a personless delegation. The public API
+            // still returns null in that case, but the transition engine needs delegatedAt to
+            // distinguish the reply that was already newest when the user delegated from a
+            // genuinely newer inbound reply that should clear the state.
+            const storedDelegation = snapshotContact(contact);
+            const delegation = contact ? storedDelegation : null;
+            await setThreadAnnotation(
+              accountId, message.thread_key, 'delegation', storedDelegation,
+            );
+            for (const messageId of threadIds) outcomes.set(messageId, {
+              messageId,
+              ok: true,
+              accountId,
+              threadKey: message.thread_key,
+              delegation,
+            });
+          } catch (error) {
+            const ambiguous = error instanceof GtdDelegationError && error.code === 'operation_ambiguous';
+            let compensated = false;
+            if (!ambiguous && created && createdUid != null) {
+              try {
+                compensated = (await removeExactLabelCopy(message, folder, createdUid)).removed;
+              } catch { /* best effort; report uncompensated */ }
+            }
+            const code = error instanceof GtdDelegationError ? error.code : 'operation_failed';
+            for (const messageId of threadIds) outcomes.set(messageId, failure(messageId, code, compensated));
+          }
+        });
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(4, groups.length) }, runNext));
+  }));
+
+  const results = ids.map(id => outcomes.get(id));
+  const successCount = results.filter(result => result.ok).length;
+  const failureCount = results.length - successCount;
+  return {
+    status: failureCount === 0 ? 'success' : successCount === 0 ? 'failed' : 'partial',
+    successCount,
+    failureCount,
+    results,
+  };
+}

--- a/backend/src/plugins/gtd/gtdDelegations.test.js
+++ b/backend/src/plugins/gtd/gtdDelegations.test.js
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../api.js', () => ({
+  applyLabel: vi.fn(),
+  ensureLabelFolders: vi.fn(),
+  getOwnedAccount: vi.fn(),
+  listLabelCopyUids: vi.fn(),
+  loadOwnedContact: vi.fn(),
+  loadOwnedMessages: vi.fn(),
+  reconcileLabelApply: vi.fn(),
+  removeExactLabelCopy: vi.fn(),
+}));
+vi.mock('../gtdApi.js', () => ({ setThreadAnnotation: vi.fn() }));
+vi.mock('./gtdConfig.js', () => ({
+  getGtdConfig: vi.fn(),
+  resolveGtdStateFolder: vi.fn((_state, folders) => folders.delegated),
+}));
+
+import * as api from '../api.js';
+import * as gtdApi from '../gtdApi.js';
+import { getGtdConfig } from './gtdConfig.js';
+import { withGtdDelegationLock } from './gtdDelegationLock.js';
+import { delegateMessages, GtdDelegationError } from './gtdDelegations.js';
+
+const USER = '11111111-1111-4111-8111-111111111111';
+const ACCOUNT = '22222222-2222-4222-8222-222222222222';
+const MESSAGE_A = '33333333-3333-4333-8333-333333333333';
+const MESSAGE_B = '44444444-4444-4444-8444-444444444444';
+const CONTACT = '55555555-5555-4555-8555-555555555555';
+const contact = { id: CONTACT, display_name: 'Casey Rivera', primary_email: 'casey@example.test' };
+const row = id => ({
+  id,
+  account_id: ACCOUNT,
+  uid: id === MESSAGE_A ? 10 : 11,
+  folder: 'INBOX',
+  message_id: `<${id}@example.test>`,
+  thread_key: 'thread-1',
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.loadOwnedContact.mockResolvedValue(contact);
+  api.loadOwnedMessages.mockResolvedValue([row(MESSAGE_A)]);
+  api.getOwnedAccount.mockResolvedValue({ id: ACCOUNT, user_id: USER, enabled: true });
+  api.ensureLabelFolders.mockResolvedValue([{ folder: 'Delegated', path: 'Delegated', created: false }]);
+  getGtdConfig.mockResolvedValue({ enabled: true, folders: { delegated: 'Delegated' } });
+  api.listLabelCopyUids.mockResolvedValue([]);
+  api.applyLabel.mockResolvedValue({ applied: true, uid: 77 });
+  api.reconcileLabelApply.mockResolvedValue({ uid: 78, ambiguous: false });
+  gtdApi.setThreadAnnotation.mockResolvedValue(2);
+  api.removeExactLabelCopy.mockResolvedValue({ removed: true });
+});
+
+describe('delegateMessages', () => {
+  it('deduplicates IDs and labels one logical thread once', async () => {
+    api.loadOwnedMessages.mockResolvedValue([row(MESSAGE_A), row(MESSAGE_B)]);
+    const result = await delegateMessages({ userId: USER, messageIds: [MESSAGE_A, MESSAGE_A, MESSAGE_B], contactId: CONTACT });
+    expect(result).toMatchObject({ status: 'success', successCount: 2, failureCount: 0 });
+    expect(result.results.map(item => item.messageId)).toEqual([MESSAGE_A, MESSAGE_B]);
+    expect(api.applyLabel).toHaveBeenCalledTimes(1);
+    expect(gtdApi.setThreadAnnotation).toHaveBeenCalledTimes(1);
+    expect(result.results[0].delegation).toMatchObject({
+      contactId: CONTACT,
+      displayName: contact.display_name,
+      primaryEmail: contact.primary_email,
+    });
+  });
+
+  it('loads account state and ensures the delegated folder once for a multi-thread batch', async () => {
+    api.loadOwnedMessages.mockResolvedValue([
+      { ...row(MESSAGE_A), thread_key: 'thread-1' },
+      { ...row(MESSAGE_B), thread_key: 'thread-2' },
+    ]);
+
+    await delegateMessages({ userId: USER, messageIds: [MESSAGE_A, MESSAGE_B], contactId: CONTACT });
+
+    expect(api.getOwnedAccount).toHaveBeenCalledTimes(1);
+    expect(getGtdConfig).toHaveBeenCalledTimes(1);
+    expect(api.ensureLabelFolders).toHaveBeenCalledTimes(1);
+    expect(api.ensureLabelFolders).toHaveBeenCalledWith(
+      { id: ACCOUNT, user_id: USER, enabled: true }, ['Delegated'],
+    );
+    expect(api.applyLabel).toHaveBeenCalledTimes(2);
+    expect(api.applyLabel.mock.calls.every(call => (
+      call[3]?.folderEnsured === true && call[3]?.skipPostCopyTransitions === true
+    ))).toBe(true);
+  });
+
+  it('bounds concurrent IMAP work per account', async () => {
+    const ids = Array.from(
+      { length: 8 },
+      (_, index) => `${String(index + 1).padStart(8, '0')}-1111-4111-8111-111111111111`,
+    );
+    api.loadOwnedMessages.mockResolvedValue(ids.map((id, index) => ({
+      ...row(id), thread_key: `thread-${index + 1}`,
+    })));
+    let release;
+    const gate = new Promise(resolve => { release = resolve; });
+    let active = 0;
+    let maximum = 0;
+    api.applyLabel.mockImplementation(async () => {
+      active += 1;
+      maximum = Math.max(maximum, active);
+      await gate;
+      active -= 1;
+      return { applied: true, uid: 77 };
+    });
+
+    const delegation = delegateMessages({ userId: USER, messageIds: ids, contactId: CONTACT });
+    await vi.waitFor(() => expect(api.applyLabel).toHaveBeenCalledTimes(4));
+    release();
+    await delegation;
+
+    expect(maximum).toBe(4);
+    expect(api.applyLabel).toHaveBeenCalledTimes(8);
+  });
+
+  it('clears the contact snapshot while retaining the Delegated label', async () => {
+    api.listLabelCopyUids.mockResolvedValue([88]);
+    const result = await delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: null });
+    expect(result.results[0]).toMatchObject({ ok: true, delegation: null });
+    expect(api.applyLabel).not.toHaveBeenCalled();
+    expect(gtdApi.setThreadAnnotation).toHaveBeenCalledWith(
+      ACCOUNT,
+      'thread-1',
+      'delegation',
+      expect.objectContaining({ contactId: null, delegatedAt: expect.any(String) }),
+    );
+  });
+
+  it('updates an existing delegated thread without touching IMAP folder setup', async () => {
+    api.listLabelCopyUids.mockResolvedValue([88]);
+    api.ensureLabelFolders.mockRejectedValue(new Error('imap offline'));
+
+    const result = await delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT });
+
+    expect(result.status).toBe('success');
+    expect(api.ensureLabelFolders).not.toHaveBeenCalled();
+    expect(api.applyLabel).not.toHaveBeenCalled();
+    expect(gtdApi.setThreadAnnotation).toHaveBeenCalled();
+  });
+
+  it('rejects a contact outside the owning user', async () => {
+    api.loadOwnedContact.mockResolvedValue(null);
+    await expect(delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT }))
+      .rejects.toMatchObject({ code: 'contact_not_found', status: 404 });
+  });
+
+  it('reports requested rows the user does not own without exposing them', async () => {
+    api.loadOwnedMessages.mockResolvedValue([]);
+    const result = await delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: null });
+    expect(result).toMatchObject({ status: 'failed', successCount: 0, failureCount: 1 });
+    expect(result.results[0]).toMatchObject({ messageId: MESSAGE_A, ok: false, error: 'not_found' });
+  });
+
+  it('compensates only the exact copy created by this call when annotation fails', async () => {
+    gtdApi.setThreadAnnotation.mockRejectedValue(new Error('write failed'));
+    const result = await delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT });
+    expect(api.removeExactLabelCopy).toHaveBeenCalledWith(row(MESSAGE_A), 'Delegated', 77);
+    expect(result.results[0]).toMatchObject({ ok: false, compensated: true });
+  });
+
+  it('settles when compensation re-enters cleanup for the same thread', async () => {
+    gtdApi.setThreadAnnotation.mockRejectedValue(new Error('write failed'));
+    api.removeExactLabelCopy.mockImplementation(() => (
+      withGtdDelegationLock(ACCOUNT, 'thread-1', async () => ({ removed: true }))
+    ));
+    const result = await Promise.race([
+      delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT }),
+      new Promise(resolve => setTimeout(() => resolve('timed-out'), 50)),
+    ]);
+    expect(result).not.toBe('timed-out');
+    expect(result.results[0]).toMatchObject({ ok: false, compensated: true });
+  });
+
+  it('never compensates a pre-existing label', async () => {
+    api.listLabelCopyUids.mockResolvedValue([88]);
+    gtdApi.setThreadAnnotation.mockRejectedValue(new Error('write failed'));
+    await delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT });
+    expect(api.removeExactLabelCopy).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent calls for one thread so only one copy is created', async () => {
+    let labelled = false;
+    api.listLabelCopyUids.mockImplementation(async () => labelled ? [77] : []);
+    api.applyLabel.mockImplementation(async () => { labelled = true; return { applied: true, uid: 77 }; });
+    const [first, second] = await Promise.all([
+      delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT }),
+      delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT }),
+    ]);
+    expect(first.status).toBe('success');
+    expect(second.status).toBe('success');
+    expect(api.applyLabel).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles a non-UIDPLUS copy before writing annotations', async () => {
+    api.applyLabel.mockResolvedValue({ applied: true, uid: null });
+    await delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT });
+    expect(api.reconcileLabelApply).toHaveBeenCalledWith(
+      { id: ACCOUNT, user_id: USER, enabled: true }, row(MESSAGE_A), 'Delegated', [],
+    );
+    expect(gtdApi.setThreadAnnotation).toHaveBeenCalled();
+  });
+
+  it('reports ambiguous non-UIDPLUS reconciliation without guessing or annotating', async () => {
+    api.applyLabel.mockResolvedValue({ applied: true, uid: null });
+    api.reconcileLabelApply.mockResolvedValue({ uid: null, ambiguous: true });
+    const result = await delegateMessages({ userId: USER, messageIds: [MESSAGE_A], contactId: CONTACT });
+    expect(result.results[0]).toMatchObject({ ok: false, error: 'operation_ambiguous', compensated: false });
+    expect(gtdApi.setThreadAnnotation).not.toHaveBeenCalled();
+    expect(api.removeExactLabelCopy).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid and oversized requests before reading data', async () => {
+    const ids = Array.from({ length: 101 }, (_, i) => `${String(i).padStart(8, '0')}-0000-4000-8000-000000000000`);
+    await expect(delegateMessages({ userId: USER, messageIds: ids, contactId: null })).rejects.toBeInstanceOf(GtdDelegationError);
+    expect(api.loadOwnedMessages).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/plugins/gtd/gtdGist.js
+++ b/backend/src/plugins/gtd/gtdGist.js
@@ -1,4 +1,5 @@
-import { summarizeMessage, summarizeAvailable, getMessageFields, getMessageAnnotations, setMessageAnnotation } from '../api.js';
+import { summarizeMessage, summarizeAvailable, getMessageFields } from '../api.js';
+import { getMessageAnnotations, setMessageAnnotation } from '../gtdApi.js';
 
 // AI-condensed one-line gist for GTD "waiting" entries. The client shows the raw
 // message snippet by default; when a gist has been generated for a waiting thread's
@@ -62,7 +63,7 @@ const _inFlight = new Set();
 async function generateForAccount(accountId, ids) {
   // Skip ids that already carry a cached gist (belt-and-suspenders over the sections-side filter,
   // so a head that got a gist since the sections snapshot isn't regenerated / doesn't re-broadcast).
-  const existing = await getMessageAnnotations(accountId, ids, 'gtd');
+  const existing = await getMessageAnnotations(accountId, ids);
   const need = ids.filter((id) => !existing[id]?.gist);
   if (!need.length) return 0;
 
@@ -76,7 +77,7 @@ async function generateForAccount(accountId, ids) {
     });
     if (!gist) return;
     // Store under GTD's annotation namespace on the message (cleaned with the message on delete).
-    const n = await setMessageAnnotation(accountId, row.id, 'gtd', { gist });
+    const n = await setMessageAnnotation(accountId, row.id, { gist });
     if (n > 0) wrote++;
   });
   return wrote;

--- a/backend/src/plugins/gtd/gtdSections.js
+++ b/backend/src/plugins/gtd/gtdSections.js
@@ -1,5 +1,6 @@
 import { getGtdConfig, GTD_STATES } from './gtdConfig.js';
-import { resolveAllDraftsPaths, listThreadHeadsByLabels, notifyOnLabelTouch, listUserAccounts, getMessageAnnotations } from '../api.js';
+import { resolveAllDraftsPaths, listThreadHeadsByLabels, notifyOnLabelTouch, listUserAccounts } from '../api.js';
+import { getMessageAnnotations } from '../gtdApi.js';
 
 // States the frontend merges into the single "Waiting" section (utils/gtd.js). Their
 // counts must dedupe a thread holding BOTH labels; see the waiting_agg CTE below.
@@ -74,7 +75,7 @@ export async function getGtdSections({ userId, accountId = null, limit } = {}) {
 
     // The labels-read capability is generic (no GTD columns); merge GTD's own per-message gist
     // (stored in the message's plugin annotations) onto each head so mapHead can surface it.
-    const gists = await getMessageAnnotations(acct.id, rows.map(r => r.id), 'gtd');
+    const gists = await getMessageAnnotations(acct.id, rows.map(r => r.id));
     for (const row of rows) row.gist = gists[row.id]?.gist ?? null;
 
     // Fold this account's rows in. total/unread are constant within a state, so add

--- a/backend/src/plugins/gtd/gtdTransitions.js
+++ b/backend/src/plugins/gtd/gtdTransitions.js
@@ -1,5 +1,7 @@
 import { getGtdConfig } from './gtdConfig.js';
 import { resolveAllDraftsPaths, logger, getAccountAddresses, getThreadKeysForMessageIds as _threadKeysForIds, getThreadKeysInFolders as _threadKeysInFolders, getThreadKeysForMessageIdHeaders, getMessagesByThreadKeys } from '../api.js';
+import { getThreadAnnotationRows } from '../gtdApi.js';
+import { withGtdDelegationLock } from './gtdDelegationLock.js';
 
 // Transition rules for auto-stripping a GTD label once a thread's state has moved on,
 // evaluated per thread against its LAST non-draft message. Designed to match the
@@ -69,6 +71,15 @@ export async function getOwnerAddresses(accountId) {
 export const threadKeysForMessageIds = (accountId, ids) => _threadKeysForIds(accountId, ids);
 export const threadKeysInFolders = (accountId, folders) => _threadKeysInFolders(accountId, folders);
 
+async function withThreadTransitionLocks(accountId, keys, work, index = 0) {
+  if (index >= keys.length) return work();
+  return withGtdDelegationLock(
+    accountId,
+    keys[index],
+    () => withThreadTransitionLocks(accountId, keys, work, index + 1),
+  );
+}
+
 // ── Transition engine ────────────────────────────────────────────────────────
 // Apply the GTD Labeler rules to a set of threads for one account.
 //
@@ -111,17 +122,35 @@ export async function runGtdTransitions(imapManager, account, threadKeys) {
   const draftPaths = await resolveAllDraftsPaths(account.id, account.folder_mappings);
   const owner = await getOwnerAddresses(account.id);
 
-  const rows = await getMessagesByThreadKeys(account.id, keys);
+  // Acquire every affected thread in stable order before taking the message/annotation snapshot.
+  // An explicit delegation uses the same lock. Whichever operation entered first therefore
+  // finishes first, and a tick can never inspect a half-written label + delegation marker.
+  await withThreadTransitionLocks(account.id, [...keys].sort(), async () => {
+    const [rows, annotationRows] = await Promise.all([
+      getMessagesByThreadKeys(account.id, keys),
+      getThreadAnnotationRows(account.id, keys),
+    ]);
 
-  const byThread = new Map();
-  for (const row of rows) {
-    if (!byThread.has(row.thread_key)) byThread.set(row.thread_key, []);
-    byThread.get(row.thread_key).push(row);
-  }
+    const delegatedAtByThread = new Map();
+    for (const row of annotationRows) {
+      const raw = row.plugin_annotations?.gtd?.delegation?.delegatedAt;
+      const timestamp = Date.parse(raw);
+      if (!Number.isFinite(timestamp)) continue;
+      const previous = delegatedAtByThread.get(row.thread_key);
+      if (previous == null || timestamp > previous) {
+        delegatedAtByThread.set(row.thread_key, timestamp);
+      }
+    }
 
-  let anyStripped = false;
+    const byThread = new Map();
+    for (const row of rows) {
+      if (!byThread.has(row.thread_key)) byThread.set(row.thread_key, []);
+      byThread.get(row.thread_key).push(row);
+    }
 
-  for (const [, threadRows] of byThread) {
+    let anyStripped = false;
+
+    for (const [threadKey, threadRows] of byThread) {
     const nonDraft = threadRows.filter((r) => !draftPaths.has(r.folder));
     if (nonDraft.length === 0) continue;
 
@@ -136,7 +165,18 @@ export async function runGtdTransitions(imapManager, account, threadKeys) {
 
     for (const [state, folder] of Object.entries(stateFolder)) {
       const rule = STRIP_RULE[state];
-      const shouldStrip = rule === 'self' ? isSelf : rule === 'other' ? !isSelf : false;
+      let shouldStrip = rule === 'self' ? isSelf : rule === 'other' ? !isSelf : false;
+      if (state === 'delegated' && shouldStrip) {
+        const delegatedAt = delegatedAtByThread.get(threadKey);
+        if (delegatedAt != null) {
+          // Explicit delegation starts a new waiting period. The external message that was
+          // already newest at that moment must not immediately cancel it; only a later-dated
+          // external reply can do so. With an invalid/missing message date, retain the explicit
+          // state because there is no evidence that the message arrived after delegation.
+          const newestAt = Date.parse(newest.date);
+          shouldStrip = Number.isFinite(newestAt) && newestAt > delegatedAt;
+        }
+      }
       if (!shouldStrip) continue;
 
       for (const copy of threadRows.filter((r) => r.folder === folder)) {
@@ -153,10 +193,11 @@ export async function runGtdTransitions(imapManager, account, threadKeys) {
     }
   }
 
-  // One batched emit per run (not per stripped copy) so the rail converges once.
-  if (anyStripped) {
-    imapManager.broadcast({ type: 'gtd_sections_updated', accountId: account.id }, account.user_id);
-  }
+    // One batched emit per run (not per stripped copy) so the rail converges once.
+    if (anyStripped) {
+      imapManager.broadcast({ type: 'gtd_sections_updated', accountId: account.id }, account.user_id);
+    }
+  });
 }
 
 // ── Sent-message hook ────────────────────────────────────────────────────────

--- a/backend/src/plugins/gtd/gtdTransitions.test.js
+++ b/backend/src/plugins/gtd/gtdTransitions.test.js
@@ -16,6 +16,7 @@ import {
 import { query } from '../../services/db.js';
 import { getGtdConfig } from './gtdConfig.js';
 import { resolveAllDraftsPaths } from '../../utils/mailUtils.js';
+import { withGtdDelegationLock } from './gtdDelegationLock.js';
 
 const DEFAULT_FOLDERS = { todo: 'Todo', watch: 'Watch', delegated: 'Delegated', someday: 'Someday', reference: 'Reference' };
 const account = { id: 'acct-1', user_id: 'user-1', email_address: 'me@example.com', folder_mappings: {} };
@@ -29,6 +30,7 @@ function mockQuery({ owner = [{ addr: 'me@example.com' }], rows = [], sent = [] 
   query.mockImplementation((sql) => {
     if (sql.includes('message_id = ANY')) return Promise.resolve({ rows: sent });
     if (sql.includes('account_aliases')) return Promise.resolve({ rows: owner });
+    if (sql.includes('plugin_annotations')) return Promise.resolve({ rows });
     if (sql.includes('thread_key = ANY')) return Promise.resolve({ rows });
     return Promise.resolve({ rows: [] });
   });
@@ -119,6 +121,71 @@ describe('runGtdTransitions', () => {
     expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 22, 'Watch');
     expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 23, 'Delegated');
     expect(mgr.removeMessageCopy).not.toHaveBeenCalledWith('acct-1', 21, 'Todo');
+  });
+
+  it('does not let an active tick remove an explicit delegation based on an older reply', async () => {
+    const rows = [
+      {
+        thread_key: 't1', uid: 20, folder: 'INBOX', from_email: 'them@other.com',
+        date: '2026-07-09T12:00:00Z', id: 'r1',
+        plugin_annotations: { gtd: { delegation: {
+          contactId: null,
+          delegatedAt: '2026-07-09T13:00:00Z',
+        } } },
+      },
+      {
+        thread_key: 't1', uid: 23, folder: 'Delegated', from_email: 'them@other.com',
+        date: '2026-07-09T12:00:00Z', id: 'r4',
+        plugin_annotations: { gtd: { delegation: {
+          contactId: null,
+          delegatedAt: '2026-07-09T13:00:00Z',
+        } } },
+      },
+    ];
+    mockQuery({ rows });
+    const mgr = fakeManager();
+    let release;
+    let entered;
+    const lockEntered = new Promise(resolve => { entered = resolve; });
+    const delegationWrite = withGtdDelegationLock('acct-1', 't1', async () => {
+      entered();
+      await new Promise(resolve => { release = resolve; });
+    });
+    await lockEntered;
+
+    const tick = runGtdTransitions(mgr, account, ['t1']);
+    await Promise.resolve();
+    expect(query.mock.calls.some(([sql]) => sql.includes('FROM messages'))).toBe(false);
+
+    release();
+    await delegationWrite;
+    await tick;
+    expect(mgr.removeMessageCopy).not.toHaveBeenCalledWith('acct-1', 23, 'Delegated');
+  });
+
+  it('strips an explicit delegation after a newer external reply', async () => {
+    const rows = [
+      {
+        thread_key: 't1', uid: 20, folder: 'INBOX', from_email: 'them@other.com',
+        date: '2026-07-09T14:00:00Z', id: 'r1',
+        plugin_annotations: { gtd: { delegation: {
+          contactId: null,
+          delegatedAt: '2026-07-09T13:00:00Z',
+        } } },
+      },
+      {
+        thread_key: 't1', uid: 23, folder: 'Delegated', from_email: 'them@other.com',
+        date: '2026-07-09T12:00:00Z', id: 'r4',
+        plugin_annotations: { gtd: { delegation: {
+          contactId: null,
+          delegatedAt: '2026-07-09T13:00:00Z',
+        } } },
+      },
+    ];
+    mockQuery({ rows });
+    const mgr = fakeManager();
+    await runGtdTransitions(mgr, account, ['t1']);
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 23, 'Delegated');
   });
 
   it('treats an alias sender as the owner (self-strips Todo)', async () => {

--- a/backend/src/plugins/gtd/hooks.js
+++ b/backend/src/plugins/gtd/hooks.js
@@ -12,7 +12,22 @@ import { getGtdFolderSet, getGtdConfig, gtdTickFolders, sanitizeGtdFoldersDetail
 import { runGtdTransitions, threadKeysForMessageIds, threadKeysInFolders, runTransitionsForSentMessage, invalidateOwnerAddressesCache } from './gtdTransitions.js';
 import { emitGtdIfRelevant } from './gtdSections.js';
 import { deleteUserPet } from './gtdPet.js';
-import { logger, getThreadKeyForUid, listUserAccounts, getAccountConfig, setAccountConfig } from '../api.js';
+import { withGtdDelegationLock } from './gtdDelegationLock.js';
+import {
+  getAccountConfig,
+  getThreadKeyForUid,
+  getThreadKeysForMessageIdHeaders,
+  getThreadKeysForMessageIds,
+  listLabelCopyUids,
+  listUserAccounts,
+  logger,
+  setAccountConfig,
+} from '../api.js';
+import {
+  getAnnotatedThreadKeysMissingFolder,
+  getThreadAnnotationRows,
+  setThreadAnnotation,
+} from '../gtdApi.js';
 
 // Choose the INBOX message ids to run GTD transitions over after a sync batch completes.
 //   newInboxIds — the id of every row the sync newly inserted into INBOX, collected REGARDLESS
@@ -117,6 +132,11 @@ export async function gtdSyncTick({ mgr, account }) {
       }
     }
 
+    const delegatedFolder = config.folders?.delegated;
+    const clearedDelegations = delegatedFolder
+      ? await clearOrphanedDelegations(account.id, delegatedFolder)
+      : 0;
+
     if (changedFolders.length > 0) {
       // A label folder's membership changed (a state added/removed elsewhere — another client or
       // an external automation). Re-run transitions for the threads those folders now touch so a
@@ -129,6 +149,8 @@ export async function gtdSyncTick({ mgr, account }) {
       } catch (err) {
         console.warn(`GTD transitions error ${account.id}:`, err.message);
       }
+    }
+    if (changedFolders.length > 0 || clearedDelegations > 0) {
       mgr.broadcast({ type: 'gtd_sections_updated', accountId: account.id }, account.user_id);
     }
   } catch (err) {
@@ -145,10 +167,18 @@ export async function gtdSyncTick({ mgr, account }) {
 // deferred insert saw stale thread state, so re-running here applies any needed strip immediately.
 // Gated on gtd_enabled; transition failures are debug-level. Uses only generic mgr primitives
 // (syncFolderOnDemand, broadcast) plus GTD's own DB read + transition engine.
-export function emitAfterDeferredCopySync(mgr, account, toFolder, srcUid, fromFolder) {
-  return mgr.syncFolderOnDemand(account, toFolder)
+export function emitAfterDeferredCopySync(
+  mgr,
+  account,
+  toFolder,
+  srcUid,
+  fromFolder,
+  { skipPostCopyTransitions = false } = {},
+) {
+  return mgr.syncFolderOnDemand(account, toFolder, { freshAfterActive: true })
     .then(async () => {
       mgr.broadcast({ type: 'gtd_sections_updated', accountId: account.id }, account.user_id);
+      if (skipPostCopyTransitions) return;
       if (!(await getGtdConfig(account.id)).enabled) return;
       try {
         const threadKey = await getThreadKeyForUid(account.id, srcUid, fromFolder);
@@ -163,19 +193,99 @@ export function emitAfterDeferredCopySync(mgr, account, toFolder, srcUid, fromFo
 // runHook('afterLabelCopy'): core just COPY'd a message into a label folder. Broadcast the GTD
 // section refresh (unconditional, mirroring the pre-plugin manager-level emit — it carries no row
 // and is safe on both paths), then, on the deferred (non-UIDPLUS) path where the sibling row isn't
-// inserted yet, kick off the deferred reconcile. That reconcile is intentionally NOT awaited so
-// the label write never blocks on the destination sync. Never throws into core.
-export async function afterLabelCopy({ mgr, account, toFolder, fromFolder, srcUid, newUid }) {
+// inserted yet, wait for the deferred reconcile. The copy must not report success before callers
+// that require read-after-write consistency can observe the destination row. Never throws into core.
+export async function afterLabelCopy({
+  mgr, account, toFolder, fromFolder, srcUid, newUid, skipPostCopyTransitions,
+}) {
   mgr.broadcast({ type: 'gtd_sections_updated', accountId: account.id }, account.user_id);
   if (newUid == null) {
-    emitAfterDeferredCopySync(mgr, account, toFolder, srcUid, fromFolder);
+    await emitAfterDeferredCopySync(mgr, account, toFolder, srcUid, fromFolder, {
+      skipPostCopyTransitions,
+    });
   }
 }
 
 // runHook('afterLabelRemove'): core just deleted one folder's copy of a message. Broadcast the
 // GTD section refresh so clients refetch — same manager-level emit the pre-plugin code did.
-export async function afterLabelRemove({ mgr, account }) {
+async function reconcileDelegationRemoval(account, folder, threadKey) {
+  if (!threadKey) return;
+  const config = await getGtdConfig(account.id);
+  const delegatedFolder = config.enabled ? config.folders?.delegated : null;
+  if (!delegatedFolder || folder !== delegatedFolder) return;
+  return withGtdDelegationLock(account.id, threadKey, async () => {
+    const remaining = await listLabelCopyUids(account.id, threadKey, delegatedFolder);
+    if (remaining.length === 0) {
+      await setThreadAnnotation(account.id, threadKey, 'delegation', null);
+      return true;
+    }
+    return false;
+  });
+}
+
+export async function clearOrphanedDelegations(accountId, delegatedFolder) {
+  const threadKeys = await getAnnotatedThreadKeysMissingFolder(
+    accountId, delegatedFolder, 'delegation',
+  );
+  let cleared = 0;
+  for (const threadKey of threadKeys) {
+    const didClear = await withGtdDelegationLock(accountId, threadKey, async () => {
+      if ((await listLabelCopyUids(accountId, threadKey, delegatedFolder)).length > 0) return false;
+      await setThreadAnnotation(accountId, threadKey, 'delegation', null);
+      return true;
+    });
+    if (didClear) cleared += 1;
+  }
+  return cleared;
+}
+
+export async function afterLabelRemove({ mgr, account, folder, threadKey }) {
   mgr.broadcast({ type: 'gtd_sections_updated', accountId: account.id }, account.user_id);
+  await reconcileDelegationRemoval(account, folder, threadKey);
+}
+
+// Reconcile removes rows deleted by another IMAP client without passing through
+// removeMessageCopy. Core reports the affected thread keys through this generic hook so the GTD
+// snapshot cannot outlive the final Delegated copy.
+export async function messageRowsDeleted({ account, folder, threadKeys }) {
+  for (const threadKey of new Set(threadKeys || [])) {
+    await reconcileDelegationRemoval(account, folder, threadKey);
+  }
+}
+
+export async function messageRowsIngested({ account, messageIds }) {
+  if (!messageIds?.length) return;
+  const threadKeys = await getThreadKeysForMessageIds(account.id, messageIds);
+  for (const threadKey of threadKeys) {
+    // Inheritance may be emitted by the destination sync of a non-UIDPLUS delegation COPY.
+    // Do not make that sync wait for the same thread lock held by the delegating request: the
+    // request is itself waiting for the destination sync. Queue the durable annotation fan-out
+    // behind the writer and let the folder sync finish first.
+    void withGtdDelegationLock(account.id, threadKey, async () => {
+      const rows = await getThreadAnnotationRows(account.id, [threadKey]);
+      const authoritative = rows.find(row => (
+        row.thread_key === threadKey && row.plugin_annotations?.gtd?.delegation
+      ))?.plugin_annotations.gtd.delegation;
+      if (authoritative) {
+        await setThreadAnnotation(account.id, threadKey, 'delegation', authoritative);
+      }
+    }).catch(err => logger.debug(`delegation inheritance failed for ${threadKey}: ${err.message}`));
+  }
+}
+
+async function clearMissingDelegations(accountId, messageIds) {
+  if (!messageIds?.length) return;
+  const config = await getGtdConfig(accountId);
+  const folder = config.enabled ? config.folders?.delegated : null;
+  if (!folder) return;
+  const threadKeys = await getThreadKeysForMessageIdHeaders(accountId, messageIds);
+  for (const threadKey of threadKeys) {
+    await withGtdDelegationLock(accountId, threadKey, async () => {
+      if ((await listLabelCopyUids(accountId, threadKey, folder)).length === 0) {
+        await setThreadAnnotation(accountId, threadKey, 'delegation', null);
+      }
+    });
+  }
 }
 
 // runHook('onMailMutation'): an ordinary mail mutation (archive/delete/move/read/star/snooze)
@@ -186,6 +296,11 @@ export async function afterLabelRemove({ mgr, account }) {
 // never turned into a 500.
 export async function onMailMutation({ imapManager, accountId, userId, messageIds, actedFolders }) {
   await emitGtdIfRelevant(imapManager, accountId, userId, messageIds, actedFolders);
+  try {
+    await clearMissingDelegations(accountId, messageIds);
+  } catch (err) {
+    logger.debug(`GTD delegation reconciliation skipped for ${accountId}: ${err.message}`);
+  }
 }
 
 // runHook('onSentMessage'): a sent message just synced into the Sent folder. Re-run GTD

--- a/backend/src/plugins/gtd/hooks.test.js
+++ b/backend/src/plugins/gtd/hooks.test.js
@@ -20,7 +20,8 @@ import { getAccountConfig, setAccountConfig } from '../accountConfig.js';
 import { runGtdTransitions, threadKeysForMessageIds, runTransitionsForSentMessage, invalidateOwnerAddressesCache } from './gtdTransitions.js';
 import { emitGtdIfRelevant } from './gtdSections.js';
 import { deleteUserPet } from './gtdPet.js';
-import { relocateExemptFolders, sectionsChanged, inboxIngest, selectGtdReevalIds, gtdEnabledForAccount, emitAfterDeferredCopySync, afterLabelCopy, afterLabelRemove, onMailMutation, onSentMessage, onUserDelete, enrichAccount, validateAccountSettings, persistAccountSettings, onAccountIdentityChanged, onPluginActivationChanged } from './hooks.js';
+import { withGtdDelegationLock } from './gtdDelegationLock.js';
+import { clearOrphanedDelegations, relocateExemptFolders, sectionsChanged, inboxIngest, selectGtdReevalIds, gtdEnabledForAccount, emitAfterDeferredCopySync, afterLabelCopy, afterLabelRemove, messageRowsDeleted, messageRowsIngested, onMailMutation, onSentMessage, onUserDelete, enrichAccount, validateAccountSettings, persistAccountSettings, onAccountIdentityChanged, onPluginActivationChanged } from './hooks.js';
 
 describe('gtd hooks — relocateExemptFolders', () => {
   beforeEach(() => getGtdFolderSet.mockReset());
@@ -143,7 +144,7 @@ describe('gtd hooks — emitAfterDeferredCopySync', () => {
     const mgr = { syncFolderOnDemand: vi.fn().mockResolvedValue(undefined), broadcast: vi.fn() };
     const account = { id: 'acct-1', user_id: 'user-1' }; // gtd_enabled falsy → no transition re-run
     await emitAfterDeferredCopySync(mgr, account, 'Todo', 100, 'INBOX');
-    expect(mgr.syncFolderOnDemand).toHaveBeenCalledWith(account, 'Todo');
+    expect(mgr.syncFolderOnDemand).toHaveBeenCalledWith(account, 'Todo', { freshAfterActive: true });
     expect(mgr.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'acct-1' }, 'user-1');
     expect(runGtdTransitions).not.toHaveBeenCalled();
   });
@@ -164,6 +165,23 @@ describe('gtd hooks — emitAfterDeferredCopySync', () => {
     await emitAfterDeferredCopySync(mgr, account, 'Todo', 100, 'INBOX');
     expect(query.mock.calls[0][1]).toEqual(['acct-1', 100, 'INBOX']);
     expect(runGtdTransitions).toHaveBeenCalledWith(mgr, account, ['thr-9']);
+  });
+
+  it('skips post-copy transitions for an explicit delegation while still syncing and emitting', async () => {
+    const mgr = { syncFolderOnDemand: vi.fn().mockResolvedValue(undefined), broadcast: vi.fn() };
+    const account = { id: 'acct-1', user_id: 'user-1' };
+    getGtdConfig.mockResolvedValue({ enabled: true });
+
+    await emitAfterDeferredCopySync(mgr, account, 'Delegated', 100, 'INBOX', {
+      skipPostCopyTransitions: true,
+    });
+
+    expect(mgr.syncFolderOnDemand).toHaveBeenCalledWith(
+      account, 'Delegated', { freshAfterActive: true },
+    );
+    expect(mgr.broadcast).toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+    expect(runGtdTransitions).not.toHaveBeenCalled();
   });
 
   it('swallows a transition re-run failure after still emitting', async () => {
@@ -193,13 +211,163 @@ describe('gtd hooks — afterLabelCopy / afterLabelRemove', () => {
     const account = { id: 'a1', user_id: 'u1' };
     await afterLabelCopy({ mgr, account, toFolder: 'Todo', fromFolder: 'INBOX', srcUid: 5, newUid: null });
     expect(mgr.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'a1' }, 'u1');
-    expect(mgr.syncFolderOnDemand).toHaveBeenCalledWith(account, 'Todo');
+    expect(mgr.syncFolderOnDemand).toHaveBeenCalledWith(account, 'Todo', { freshAfterActive: true });
+  });
+
+  it('afterLabelCopy waits for non-UIDPLUS destination reconciliation', async () => {
+    let finishSync;
+    const sync = new Promise(resolve => { finishSync = resolve; });
+    const mgr = { broadcast: vi.fn(), syncFolderOnDemand: vi.fn(() => sync) };
+    const account = { id: 'a1', user_id: 'u1' };
+    let settled = false;
+    const copyHook = afterLabelCopy({
+      mgr, account, toFolder: 'Todo', fromFolder: 'INBOX', srcUid: 5, newUid: null,
+    }).then(() => { settled = true; });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    finishSync();
+    await copyHook;
+    expect(settled).toBe(true);
   });
 
   it('afterLabelRemove broadcasts the section refresh', async () => {
     const mgr = { broadcast: vi.fn() };
     await afterLabelRemove({ mgr, account: { id: 'a1', user_id: 'u1' } });
     expect(mgr.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'a1' }, 'u1');
+  });
+
+  it('clears delegation only after the final Delegated copy disappears', async () => {
+    getGtdConfig.mockResolvedValue({ enabled: true, folders: { delegated: 'Delegated' } });
+    query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rowCount: 3, rows: [] });
+    const mgr = { broadcast: vi.fn() };
+    await afterLabelRemove({
+      mgr,
+      account: { id: 'a1', user_id: 'u1' },
+      folder: 'Delegated',
+      threadKey: 'thread-1',
+    });
+    expect(query.mock.calls[0][1]).toEqual(['a1', 'thread-1', 'Delegated']);
+    expect(query.mock.calls[1][0]).toContain('(plugin_annotations -> $3) - $4');
+  });
+
+  it('retains delegation while a Delegated copy survives', async () => {
+    getGtdConfig.mockResolvedValue({ enabled: true, folders: { delegated: 'Delegated' } });
+    query.mockResolvedValueOnce({ rows: [{ uid: 91 }] });
+    await afterLabelRemove({
+      mgr: { broadcast: vi.fn() },
+      account: { id: 'a1', user_id: 'u1' },
+      folder: 'Delegated',
+      threadKey: 'thread-1',
+    });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('serializes final-copy cleanup with delegation writes for the same thread', async () => {
+    getGtdConfig.mockResolvedValue({ enabled: true, folders: { delegated: 'Delegated' } });
+    query.mockResolvedValueOnce({ rows: [{ uid: 91 }] });
+    let release;
+    let signalEntered;
+    const entered = new Promise(resolve => { signalEntered = resolve; });
+    const held = withGtdDelegationLock('a1', 'thread-locked', () => {
+      signalEntered();
+      return new Promise(resolve => { release = resolve; });
+    });
+    await entered;
+    const cleanup = afterLabelRemove({
+      mgr: { broadcast: vi.fn() },
+      account: { id: 'a1', user_id: 'u1' },
+      folder: 'Delegated',
+      threadKey: 'thread-locked',
+    });
+    await Promise.resolve();
+    expect(query).not.toHaveBeenCalled();
+    release();
+    await held;
+    await cleanup;
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('gtd hooks — delegation inheritance', () => {
+  beforeEach(() => query.mockReset());
+
+  it('copies an authoritative thread delegation onto newly ingested rows', async () => {
+    const delegation = { contactId: 'c1', displayName: 'Casey' };
+    query
+      .mockResolvedValueOnce({ rows: [{ thread_key: 'thread-1' }] })
+      .mockResolvedValueOnce({ rows: [
+        { id: 'new-row', thread_key: 'thread-1', plugin_annotations: {} },
+        { id: 'old-row', thread_key: 'thread-1', plugin_annotations: { gtd: { delegation } } },
+      ] })
+      .mockResolvedValueOnce({ rowCount: 2, rows: [] });
+
+    await messageRowsIngested({ account: { id: 'a1' }, messageIds: ['new-row'] });
+
+    await vi.waitFor(() => expect(query).toHaveBeenCalledTimes(3));
+    expect(query.mock.calls[2][1]).toEqual(['a1', 'thread-1', 'gtd', 'delegation', JSON.stringify(delegation)]);
+  });
+
+  it('does not block folder sync while inheritance waits for an active delegation write', async () => {
+    const delegation = { contactId: 'new-contact', displayName: 'New Contact' };
+    query
+      .mockResolvedValueOnce({ rows: [{ thread_key: 'thread-ingest-locked' }] })
+      .mockResolvedValueOnce({ rows: [
+        { id: 'new-row', thread_key: 'thread-ingest-locked', plugin_annotations: {} },
+        { id: 'old-row', thread_key: 'thread-ingest-locked', plugin_annotations: { gtd: { delegation } } },
+      ] })
+      .mockResolvedValueOnce({ rowCount: 2, rows: [] });
+    let release;
+    let signalEntered;
+    const entered = new Promise(resolve => { signalEntered = resolve; });
+    const held = withGtdDelegationLock('a1', 'thread-ingest-locked', () => {
+      signalEntered();
+      return new Promise(resolve => { release = resolve; });
+    });
+    await entered;
+
+    const ingest = messageRowsIngested({ account: { id: 'a1' }, messageIds: ['new-row'] });
+    await expect(Promise.race([
+      ingest.then(() => 'settled'),
+      new Promise(resolve => setTimeout(() => resolve('timed-out'), 50)),
+    ])).resolves.toBe('settled');
+    expect(query).toHaveBeenCalledTimes(1);
+    release();
+    await held;
+    await vi.waitFor(() => expect(query).toHaveBeenCalledTimes(3));
+    expect(query.mock.calls[1][1]).toEqual(['a1', ['thread-ingest-locked']]);
+    expect(query.mock.calls[2][1]).toEqual([
+      'a1', 'thread-ingest-locked', 'gtd', 'delegation', JSON.stringify(delegation),
+    ]);
+  });
+
+  it('clears delegation after external deletion removes the final Delegated copy', async () => {
+    getGtdConfig.mockResolvedValue({ enabled: true, folders: { delegated: 'Delegated' } });
+    query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rowCount: 2, rows: [] });
+
+    await messageRowsDeleted({
+      account: { id: 'a1', user_id: 'u1' },
+      folder: 'Delegated',
+      threadKeys: ['thread-1'],
+    });
+
+    expect(query.mock.calls[0][1]).toEqual(['a1', 'thread-1', 'Delegated']);
+    expect(query.mock.calls[1][0]).toContain('(plugin_annotations -> $3) - $4');
+  });
+
+  it('sweeps an orphaned snapshot after a prior delete hook failure', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ thread_key: 'thread-orphan' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rowCount: 2, rows: [] });
+
+    await expect(clearOrphanedDelegations('a1', 'Delegated')).resolves.toBe(1);
+    expect(query.mock.calls[0][0]).toContain('NOT EXISTS');
+    expect(query.mock.calls[2][1]).toEqual(['a1', 'thread-orphan', 'gtd', 'delegation']);
   });
 });
 

--- a/backend/src/plugins/gtd/index.js
+++ b/backend/src/plugins/gtd/index.js
@@ -6,7 +6,7 @@
 // of its own. GTD's code still lives under routes/ and services/; later phases move its
 // storage and UI behind the plugin boundary. Behavior is unchanged.
 import gtdRoutes from './routes.js';
-import { relocateExemptFolders, sectionsChanged, inboxIngest, afterLabelCopy, afterLabelRemove, onMailMutation, onSentMessage, onUserDelete, enrichAccount, validateAccountSettings, persistAccountSettings, onAccountIdentityChanged, onPluginActivationChanged, gtdEnabledForAccount, gtdSyncTick } from './hooks.js';
+import { relocateExemptFolders, sectionsChanged, inboxIngest, afterLabelCopy, afterLabelRemove, messageRowsDeleted, messageRowsIngested, onMailMutation, onSentMessage, onUserDelete, enrichAccount, validateAccountSettings, persistAccountSettings, onAccountIdentityChanged, onPluginActivationChanged, gtdEnabledForAccount, gtdSyncTick } from './hooks.js';
 
 export const gtdPlugin = {
   id: 'gtd',
@@ -30,6 +30,8 @@ export const gtdPlugin = {
     // broadcast (and, for copy, run a gtd_enabled-gated deferred reconcile inside the handler).
     afterLabelCopy,
     afterLabelRemove,
+    messageRowsDeleted: { handler: messageRowsDeleted, isActive: gtdEnabledForAccount },
+    messageRowsIngested: { handler: messageRowsIngested, isActive: gtdEnabledForAccount },
     // Fired by the mail/send/admin routes for ordinary mail mutations, sent-message sync, and
     // user deletion. Each self-gates internally (gtd_enabled / pet-slug presence), so they stay
     // unconditional here and match the pre-plugin direct calls.

--- a/backend/src/plugins/gtd/routes.delegations.test.js
+++ b/backend/src/plugins/gtd/routes.delegations.test.js
@@ -1,0 +1,62 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => { req.session = { userId: 'user-1' }; next(); },
+}));
+vi.mock('./gtdDelegations.js', () => ({
+  delegateMessages: vi.fn(),
+  GtdDelegationError: class GtdDelegationError extends Error {
+    constructor(code, status) { super(code); this.code = code; this.status = status; }
+  },
+}));
+
+import express from 'express';
+import { delegateMessages, GtdDelegationError } from './gtdDelegations.js';
+import gtdRoutes from './routes.js';
+
+const MESSAGE = '11111111-1111-4111-8111-111111111111';
+const CONTACT = '22222222-2222-4222-8222-222222222222';
+let server;
+let base;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/gtd', gtdRoutes);
+  await new Promise(resolve => { server = app.listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+afterAll(async () => new Promise(resolve => server.close(resolve)));
+beforeEach(() => vi.clearAllMocks());
+
+const post = body => fetch(`${base}/api/gtd/delegations`, {
+  method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+});
+
+describe('POST /api/gtd/delegations', () => {
+  it.each([
+    {},
+    { messageIds: [] },
+    { messageIds: ['bad'], contactId: null },
+    { messageIds: [MESSAGE], contactId: 'bad' },
+  ])('rejects malformed input before the service', async body => {
+    expect((await post(body)).status).toBe(400);
+    expect(delegateMessages).not.toHaveBeenCalled();
+  });
+
+  it('maps a non-owned contact to the same 404 as an absent contact', async () => {
+    delegateMessages.mockRejectedValueOnce(new GtdDelegationError('contact_not_found', 404));
+    const res = await post({ messageIds: [MESSAGE], contactId: CONTACT });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'Contact not found' });
+  });
+
+  it.each(['success', 'partial', 'failed'])('passes through a %s batch result', async status => {
+    const result = { status, successCount: status === 'failed' ? 0 : 1, failureCount: status === 'success' ? 0 : 1, results: [] };
+    delegateMessages.mockResolvedValueOnce(result);
+    const res = await post({ messageIds: [MESSAGE], contactId: null });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(result);
+    expect(delegateMessages).toHaveBeenCalledWith({ userId: 'user-1', messageIds: [MESSAGE], contactId: null });
+  });
+});

--- a/backend/src/plugins/gtd/routes.js
+++ b/backend/src/plugins/gtd/routes.js
@@ -4,7 +4,7 @@ import { getGtdSections } from './gtdSections.js';
 import { queueGistGeneration } from './gtdGist.js';
 import { importPet, decodeUploadedSheet, getPetMeta, getPetSheet, parsePetSlug, customPetSlug } from './gtdPet.js';
 import { getGtdConfig, resolveGtdStateFolder, sanitizeGtdFolders, sanitizeGtdFoldersDetailed, DEFAULT_GTD_FOLDERS, planGtdFolderPersist, invalidateGtdConfigCache } from './gtdConfig.js';
-import { applyLabel, removeExactLabelCopy, removeLabel, markThreadRead, ensureLabelFolders, archiveInboxCopy, broadcast, loadOwnedMessage, getOwnedAccount, getMessageCopyFolders, getAccountConfig, setAccountConfig } from '../api.js';
+import { applyLabel, removeExactLabelCopy, removeLabel, markThreadRead, ensureLabelFolders, archiveInboxCopy, broadcast, loadOwnedMessage, getOwnedAccount, getMessageCopyFolders, getLabelMetadata, getAccountConfig, setAccountConfig } from '../api.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -13,6 +13,7 @@ router.use(requireAuth);
 // id is a clean 400 rather than a parametrized query that just finds nothing (404) or a
 // driver cast error. Same idiom + regex as mail.js.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const METADATA_STATE_ORDER = ['todo', 'watch', 'delegated', 'reference', 'someday'];
 
 // Shared classify precondition: an account must have GTD enabled and the request's
 // state must resolve to a designated folder. Returns { folder } to proceed, or
@@ -79,6 +80,51 @@ router.get('/sections', async (req, res) => {
     userId: req.session.userId,
     broadcast,
   }).catch(err => console.warn('GTD gist generation error:', err.message));
+});
+
+// Bounded, plugin-owned metadata for ordinary message rows. Core supplies only the neutral row
+// slot; GTD resolves its configured label folders here without coupling the message-list query to
+// any plugin schema or state.
+router.post('/metadata', async (req, res) => {
+  const { accountId, messageIds } = req.body || {};
+  if (typeof accountId !== 'string' || !UUID_RE.test(accountId)) {
+    return res.status(400).json({ error: 'Invalid account id' });
+  }
+  if (!Array.isArray(messageIds) || messageIds.length < 1 || messageIds.length > 100) {
+    return res.status(400).json({ error: 'messageIds must contain 1–100 ids' });
+  }
+  if (messageIds.some(id => typeof id !== 'string' || !UUID_RE.test(id))) {
+    return res.status(400).json({ error: 'Invalid message id' });
+  }
+
+  const ids = [...new Set(messageIds)];
+  const account = await getOwnedAccount(req.session.userId, accountId);
+  if (!account) return res.status(404).json({ error: 'Account not found' });
+
+  const { enabled, folders } = await getGtdConfig(accountId);
+  if (!enabled) return res.json({ messages: {} });
+
+  const stateByFolder = new Map();
+  for (const state of METADATA_STATE_ORDER) {
+    const folder = folders?.[state];
+    if (folder && !stateByFolder.has(folder)) stateByFolder.set(folder, state);
+  }
+  const rows = await getLabelMetadata(accountId, ids, [...stateByFolder.keys()]);
+  const messages = {};
+  for (const row of rows) {
+    const state = stateByFolder.get(row.folder);
+    if (!state) continue;
+    if (!messages[row.messageId]) messages[row.messageId] = { states: [], dates: {}, date: null };
+    const entry = messages[row.messageId];
+    if (!entry.states.includes(state)) entry.states.push(state);
+    entry.dates[state] = row.date;
+    if (row.date && (!entry.date || new Date(row.date) > new Date(entry.date))) entry.date = row.date;
+  }
+  for (const entry of Object.values(messages)) {
+    entry.states.sort((a, b) => METADATA_STATE_ORDER.indexOf(a) - METADATA_STATE_ORDER.indexOf(b));
+    entry.dates = Object.fromEntries(entry.states.map(state => [state, entry.dates[state] ?? null]));
+  }
+  return res.json({ messages });
 });
 
 // ── GTD Inbox-Zero pet ────────────────────────────────────────────────────────

--- a/backend/src/plugins/gtd/routes.js
+++ b/backend/src/plugins/gtd/routes.js
@@ -5,6 +5,8 @@ import { queueGistGeneration } from './gtdGist.js';
 import { importPet, decodeUploadedSheet, getPetMeta, getPetSheet, parsePetSlug, customPetSlug } from './gtdPet.js';
 import { getGtdConfig, resolveGtdStateFolder, sanitizeGtdFolders, sanitizeGtdFoldersDetailed, DEFAULT_GTD_FOLDERS, planGtdFolderPersist, invalidateGtdConfigCache } from './gtdConfig.js';
 import { applyLabel, removeExactLabelCopy, removeLabel, markThreadRead, ensureLabelFolders, archiveInboxCopy, broadcast, loadOwnedMessage, getOwnedAccount, getMessageCopyFolders, getLabelMetadata, getAccountConfig, setAccountConfig } from '../api.js';
+import { getMessageAnnotations } from '../gtdApi.js';
+import { delegateMessages, GtdDelegationError } from './gtdDelegations.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -109,12 +111,23 @@ router.post('/metadata', async (req, res) => {
     const folder = folders?.[state];
     if (folder && !stateByFolder.has(folder)) stateByFolder.set(folder, state);
   }
-  const rows = await getLabelMetadata(accountId, ids, [...stateByFolder.keys()]);
+  const [rows, annotations] = await Promise.all([
+    getLabelMetadata(accountId, ids, [...stateByFolder.keys()]),
+    getMessageAnnotations(accountId, ids),
+  ]);
   const messages = {};
   for (const row of rows) {
     const state = stateByFolder.get(row.folder);
     if (!state) continue;
-    if (!messages[row.messageId]) messages[row.messageId] = { states: [], dates: {}, date: null };
+    const storedDelegation = annotations[row.messageId]?.delegation;
+    if (!messages[row.messageId]) messages[row.messageId] = {
+      states: [],
+      dates: {},
+      date: null,
+      // A personless delegation retains an internal delegatedAt boundary so an older reply
+      // cannot immediately clear it, but remains null in the public metadata contract.
+      delegation: storedDelegation?.contactId ? storedDelegation : null,
+    };
     const entry = messages[row.messageId];
     if (!entry.states.includes(state)) entry.states.push(state);
     entry.dates[state] = row.date;
@@ -125,6 +138,28 @@ router.post('/metadata', async (req, res) => {
     entry.dates = Object.fromEntries(entry.states.map(state => [state, entry.dates[state] ?? null]));
   }
   return res.json({ messages });
+});
+
+router.post('/delegations', async (req, res) => {
+  const { messageIds, contactId } = req.body || {};
+  if (!Array.isArray(messageIds) || messageIds.length < 1 || messageIds.length > 100) {
+    return res.status(400).json({ error: 'messageIds must contain 1–100 ids' });
+  }
+  if (messageIds.some(id => typeof id !== 'string' || !UUID_RE.test(id))) {
+    return res.status(400).json({ error: 'Invalid message id' });
+  }
+  if (contactId !== null && !UUID_RE.test(contactId || '')) {
+    return res.status(400).json({ error: 'Invalid contact id' });
+  }
+  try {
+    return res.json(await delegateMessages({ userId: req.session.userId, messageIds, contactId }));
+  } catch (error) {
+    if (error instanceof GtdDelegationError && error.code === 'contact_not_found') {
+      return res.status(404).json({ error: 'Contact not found' });
+    }
+    if (error instanceof GtdDelegationError) return res.status(error.status).json({ error: error.code });
+    throw error;
+  }
 });
 
 // ── GTD Inbox-Zero pet ────────────────────────────────────────────────────────

--- a/backend/src/plugins/gtd/routes.metadata.test.js
+++ b/backend/src/plugins/gtd/routes.metadata.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
+
+vi.mock('../../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => { req.session = { userId: 'u1' }; next(); },
+}));
+vi.mock('./gtdConfig.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, getGtdConfig: vi.fn() };
+});
+
+import express from 'express';
+import { query } from '../../services/db.js';
+import { getGtdConfig, DEFAULT_GTD_FOLDERS } from './gtdConfig.js';
+import gtdRoutes from './routes.js';
+
+const ACCOUNT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const M1 = '11111111-1111-4111-8111-111111111111';
+const M2 = '22222222-2222-4222-8222-222222222222';
+let server;
+let base;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/gtd', gtdRoutes);
+  await new Promise(resolve => { server = app.listen(0, resolve); });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => new Promise(resolve => server.close(resolve)));
+
+beforeEach(() => {
+  query.mockReset();
+  getGtdConfig.mockReset();
+  getGtdConfig.mockResolvedValue({ enabled: true, folders: DEFAULT_GTD_FOLDERS });
+  query.mockImplementation(async sql => {
+    if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [{ id: ACCOUNT, user_id: 'u1' }] };
+    if (sql.includes('FROM messages target')) return { rows: [
+      { message_id: M1, folder: 'Watch', date: new Date('2026-07-01T00:00:00.000Z') },
+      { message_id: M1, folder: 'Todo', date: new Date('2026-08-01T00:00:00.000Z') },
+      { message_id: M2, folder: 'Reference', date: null },
+    ] };
+    return { rows: [] };
+  });
+});
+
+const metadata = body => fetch(`${base}/api/gtd/metadata`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+describe('POST /api/gtd/metadata', () => {
+  it.each([
+    { accountId: 'bad', messageIds: [M1] },
+    { accountId: [ACCOUNT], messageIds: [M1] },
+    { accountId: ACCOUNT, messageIds: [] },
+    { accountId: ACCOUNT, messageIds: ['bad'] },
+    { accountId: ACCOUNT, messageIds: Array.from({ length: 101 }, (_, i) => `${String(i).padStart(8, '0')}-1111-4111-8111-111111111111`) },
+  ])('rejects malformed or unbounded input before capability calls', async body => {
+    const res = await metadata(body);
+    expect(res.status).toBe(400);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the account is not owned by the session user', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns no metadata when GTD is disabled without reading label copies', async () => {
+    getGtdConfig.mockResolvedValueOnce({ enabled: false, folders: DEFAULT_GTD_FOLDERS });
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
+    expect(await res.json()).toEqual({ messages: {} });
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates ids and returns canonical states with per-state and newest dates', async () => {
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1, M1, M2] });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ messages: {
+      [M1]: {
+        states: ['todo', 'watch'],
+        dates: { todo: '2026-08-01T00:00:00.000Z', watch: '2026-07-01T00:00:00.000Z' },
+        date: '2026-08-01T00:00:00.000Z',
+      },
+      [M2]: { states: ['reference'], dates: { reference: null }, date: null },
+    } });
+    const labelCall = query.mock.calls.find(([sql]) => sql.includes('FROM messages target'));
+    expect(labelCall[1][1]).toEqual([M1, M2]);
+  });
+
+  it('honors configured folder overrides', async () => {
+    getGtdConfig.mockResolvedValueOnce({
+      enabled: true,
+      folders: { ...DEFAULT_GTD_FOLDERS, todo: 'Next Actions' },
+    });
+    query.mockImplementation(async sql => {
+      if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [{ id: ACCOUNT, user_id: 'u1' }] };
+      if (sql.includes('FROM messages target')) return { rows: [
+        { message_id: M1, folder: 'Next Actions', date: new Date('2026-08-02T00:00:00.000Z') },
+      ] };
+      return { rows: [] };
+    });
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
+    expect((await res.json()).messages[M1].states).toEqual(['todo']);
+  });
+});

--- a/backend/src/plugins/gtd/routes.metadata.test.js
+++ b/backend/src/plugins/gtd/routes.metadata.test.js
@@ -41,6 +41,9 @@ beforeEach(() => {
       { message_id: M1, folder: 'Todo', date: new Date('2026-08-01T00:00:00.000Z') },
       { message_id: M2, folder: 'Reference', date: null },
     ] };
+    if (sql.includes('plugin_annotations -> $3')) return { rows: [
+      { id: M1, ann: { delegation: { contactId: 'c1' } } },
+    ] };
     return { rows: [] };
   });
 });
@@ -85,8 +88,9 @@ describe('POST /api/gtd/metadata', () => {
         states: ['todo', 'watch'],
         dates: { todo: '2026-08-01T00:00:00.000Z', watch: '2026-07-01T00:00:00.000Z' },
         date: '2026-08-01T00:00:00.000Z',
+        delegation: { contactId: 'c1' },
       },
-      [M2]: { states: ['reference'], dates: { reference: null }, date: null },
+      [M2]: { states: ['reference'], dates: { reference: null }, date: null, delegation: null },
     } });
     const labelCall = query.mock.calls.find(([sql]) => sql.includes('FROM messages target'));
     expect(labelCall[1][1]).toEqual([M1, M2]);
@@ -99,12 +103,30 @@ describe('POST /api/gtd/metadata', () => {
     });
     query.mockImplementation(async sql => {
       if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [{ id: ACCOUNT, user_id: 'u1' }] };
-      if (sql.includes('FROM messages target')) return { rows: [
+    if (sql.includes('FROM messages target')) return { rows: [
         { message_id: M1, folder: 'Next Actions', date: new Date('2026-08-02T00:00:00.000Z') },
-      ] };
+    ] };
+    if (sql.includes('plugin_annotations -> $3')) return { rows: [{ id: M1, ann: { delegation: { contactId: 'c1' } } }] };
       return { rows: [] };
     });
     const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
     expect((await res.json()).messages[M1].states).toEqual(['todo']);
+  });
+
+  it('keeps the internal personless-delegation marker out of metadata responses', async () => {
+    query.mockImplementation(async sql => {
+      if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [{ id: ACCOUNT, user_id: 'u1' }] };
+      if (sql.includes('FROM messages target')) return { rows: [
+        { message_id: M1, folder: 'Delegated', date: new Date('2026-08-02T00:00:00.000Z') },
+      ] };
+      if (sql.includes('plugin_annotations -> $3')) return { rows: [{
+        id: M1,
+        ann: { delegation: { contactId: null, delegatedAt: '2026-08-02T01:00:00.000Z' } },
+      }] };
+      return { rows: [] };
+    });
+
+    const res = await metadata({ accountId: ACCOUNT, messageIds: [M1] });
+    expect((await res.json()).messages[M1].delegation).toBeNull();
   });
 });

--- a/backend/src/plugins/gtd/tick.test.js
+++ b/backend/src/plugins/gtd/tick.test.js
@@ -37,7 +37,7 @@ describe('gtd hooks — gtdSyncTick', () => {
   });
 
   beforeEach(() => {
-    query.mockReset();
+    query.mockReset().mockResolvedValue({ rows: [], rowCount: 0 });
     getAccountConfig.mockReset();
     runGtdTransitions.mockReset();
     threadKeysInFolders.mockReset();
@@ -86,6 +86,7 @@ describe('gtd hooks — gtdSyncTick', () => {
     expect(mgr.syncFolderViaPool).toHaveBeenCalledWith(account, 'Todo');
     expect(mgr.broadcast).not.toHaveBeenCalled();
     expect(runGtdTransitions).not.toHaveBeenCalled();
+    expect(query.mock.calls.some(([sql]) => sql.includes('NOT EXISTS'))).toBe(true);
   });
 
   it('broadcasts gtd_sections_updated and re-runs transitions when a folder fingerprint changes', async () => {

--- a/backend/src/plugins/gtdApi.js
+++ b/backend/src/plugins/gtdApi.js
@@ -1,0 +1,31 @@
+// Trusted, bundled-GTD annotation capabilities. These wrappers bind the namespace in core so the
+// sandboxed plugin API never accepts a caller-supplied plugin id or exposes another plugin's data.
+import {
+  getAnnotatedThreadKeysMissingFolder as _getAnnotatedThreadKeysMissingFolder,
+  getMessageAnnotations as _getMessageAnnotations,
+  getThreadAnnotationRows as _getThreadAnnotationRows,
+  setMessageAnnotation as _setMessageAnnotation,
+  setThreadAnnotation as _setThreadAnnotation,
+} from '../services/mailAccess.js';
+
+const PLUGIN_ID = 'gtd';
+
+export const getMessageAnnotations = (accountId, ids) => (
+  _getMessageAnnotations(accountId, ids, PLUGIN_ID)
+);
+
+export const setMessageAnnotation = (accountId, messageId, patch) => (
+  _setMessageAnnotation(accountId, messageId, PLUGIN_ID, patch)
+);
+
+export const getAnnotatedThreadKeysMissingFolder = (accountId, folder, key) => (
+  _getAnnotatedThreadKeysMissingFolder(accountId, folder, PLUGIN_ID, key)
+);
+
+export const getThreadAnnotationRows = (accountId, threadKeys) => (
+  _getThreadAnnotationRows(accountId, threadKeys)
+);
+
+export const setThreadAnnotation = (accountId, threadKey, key, value) => (
+  _setThreadAnnotation(accountId, threadKey, PLUGIN_ID, key, value)
+);

--- a/backend/src/plugins/gtdApi.test.js
+++ b/backend/src/plugins/gtdApi.test.js
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/mailAccess.js', () => ({
+  getAnnotatedThreadKeysMissingFolder: vi.fn(),
+  getMessageAnnotations: vi.fn(),
+  getThreadAnnotationRows: vi.fn(),
+  setMessageAnnotation: vi.fn(),
+  setThreadAnnotation: vi.fn(),
+}));
+
+import * as mailAccess from '../services/mailAccess.js';
+import {
+  getAnnotatedThreadKeysMissingFolder,
+  getMessageAnnotations,
+  setMessageAnnotation,
+  setThreadAnnotation,
+} from './gtdApi.js';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('bundled GTD annotation capabilities', () => {
+  it('binds message annotation reads and writes to the GTD namespace', async () => {
+    await getMessageAnnotations('account-1', ['message-1']);
+    await setMessageAnnotation('account-1', 'message-1', { gist: 'Follow up' });
+
+    expect(mailAccess.getMessageAnnotations).toHaveBeenCalledWith(
+      'account-1', ['message-1'], 'gtd',
+    );
+    expect(mailAccess.setMessageAnnotation).toHaveBeenCalledWith(
+      'account-1', 'message-1', 'gtd', { gist: 'Follow up' },
+    );
+  });
+
+  it('binds thread annotation queries and writes to the GTD namespace', async () => {
+    await getAnnotatedThreadKeysMissingFolder('account-1', 'Delegated', 'delegation');
+    await setThreadAnnotation('account-1', 'thread-1', 'delegation', { contactId: 'contact-1' });
+
+    expect(mailAccess.getAnnotatedThreadKeysMissingFolder).toHaveBeenCalledWith(
+      'account-1', 'Delegated', 'gtd', 'delegation',
+    );
+    expect(mailAccess.setThreadAnnotation).toHaveBeenCalledWith(
+      'account-1', 'thread-1', 'gtd', 'delegation', { contactId: 'contact-1' },
+    );
+  });
+});

--- a/backend/src/plugins/mailEngineFacade.js
+++ b/backend/src/plugins/mailEngineFacade.js
@@ -23,21 +23,15 @@ export function createPluginMailFacade(engine) {
     isConnected: (accountId) => engine.connections.has(accountId),
 
     // Claim / release the on-demand sync lock for one folder, coordinating with core's own
-    // user-triggered syncs (same `${accountId}:${folder}` key set). tryClaim returns false when the
-    // folder is already being synced. Narrows the raw `onDemandSyncing` Set so a plugin can't clear
-    // or inspect core's locks.
-    tryClaimFolderSync: (accountId, folder) => {
-      const key = `${accountId}:${folder}`;
-      if (engine.onDemandSyncing.has(key)) return false;
-      engine.onDemandSyncing.add(key);
-      return true;
-    },
-    releaseFolderSync: (accountId, folder) => engine.onDemandSyncing.delete(`${accountId}:${folder}`),
+    // user-triggered syncs. Core keeps an awaitable claim so consistency-sensitive callers can
+    // wait for the active owner without exposing the lock map to plugins.
+    tryClaimFolderSync: (accountId, folder) => engine._tryClaimFolderSync(accountId, folder),
+    releaseFolderSync: (accountId, folder) => engine._releaseFolderSync(accountId, folder),
 
     // Sync-capability primitives — all run on pooled connections, never disturbing the IDLE client.
     folderFingerprint: (accountId, folder) => engine.folderFingerprint(accountId, folder),
     syncFolderViaPool: (account, folder) => engine.syncFolderViaPool(account, folder),
-    syncFolderOnDemand: (account, folder) => engine.syncFolderOnDemand(account, folder),
+    syncFolderOnDemand: (account, folder, options) => engine.syncFolderOnDemand(account, folder, options),
 
     // Remove a message's copy from a label folder (GTD transition strips).
     removeMessageCopy: (accountId, uid, folder) => engine.removeMessageCopy(accountId, uid, folder),

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -784,7 +784,8 @@ export async function insertCopiedSibling(accountId, uid, fromFolder, toFolder, 
       thread_references, thread_id, is_bulk,
       read_changed_at, star_changed_at, spam_score_sa, spam_score_ml,
       spam_verdict, spam_analyzed_at, spam_details, spam_user_override,
-      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email
+      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email,
+      plugin_annotations
     )
     SELECT
       account_id, $4, $5, message_id, subject,
@@ -794,7 +795,8 @@ export async function insertCopiedSibling(accountId, uid, fromFolder, toFolder, 
       thread_references, thread_id, is_bulk,
       read_changed_at, star_changed_at, spam_score_sa, spam_score_ml,
       spam_verdict, spam_analyzed_at, spam_details, spam_user_override,
-      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email
+      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email,
+      plugin_annotations
     FROM messages
     WHERE account_id = $1 AND folder = $2 AND uid = $3
     ON CONFLICT (account_id, uid, folder) DO NOTHING
@@ -805,6 +807,38 @@ export async function insertCopiedSibling(accountId, uid, fromFolder, toFolder, 
     adjustFolderCounts(accountId, toFolder, 1, row.is_read ? 0 : 1);
   }
   return row ? row.id : null;
+}
+
+export async function rollbackCopiedMessageOnInsertFailure(
+  manager, account, toFolder, newUid, insertError,
+) {
+  try {
+    await manager.permanentDeleteMessage(account, newUid, toFolder);
+  } catch (rollbackError) {
+    // The copy is confirmed on the server but has no local row. Preserve enough context for the
+    // caller to report an uncompensated operation and for logs to identify the orphan exactly.
+    insertError.copiedUid = newUid;
+    insertError.rollbackError = rollbackError;
+  }
+  throw insertError;
+}
+
+// Delete the rows identified by reconcileDeletes' IMAP snapshot and report their thread keys to
+// plugins. RETURNING makes the hook reflect only rows that survived the cutoff re-check, not every
+// candidate from the earlier SELECT.
+export async function deleteReconciledMessageRows(account, folder, orphanUids, reconcileStartedAt) {
+  const deleted = await query(
+    `DELETE FROM messages
+     WHERE account_id = $1 AND folder = $2 AND uid = ANY($3::bigint[])
+       AND (synced_at IS NULL OR synced_at < $4)
+     RETURNING thread_key`,
+    [account.id, folder, orphanUids, reconcileStartedAt]
+  );
+  const threadKeys = [...new Set(deleted.rows.map(row => row.thread_key).filter(Boolean))];
+  if (threadKeys.length > 0) {
+    await pluginRegistry.runHook('messageRowsDeleted', { account, folder, threadKeys });
+  }
+  return deleted.rowCount ?? deleted.rows.length;
 }
 
 // DB half of removeMessageCopy: delete exactly one folder's copy of a message. Scoped
@@ -821,6 +855,16 @@ export async function deleteMessageCopyRow(accountId, uid, folder) {
     adjustFolderCounts(accountId, folder, -1, row.is_read ? 0 : -1);
   }
   return row ? 1 : 0;
+}
+
+export async function labelCopyThreadKey(accountId, uid, folder) {
+  const { rows } = await query(
+    `SELECT thread_key FROM messages
+      WHERE account_id = $1 AND uid = $2 AND folder = $3
+      LIMIT 1`,
+    [accountId, uid, folder]
+  );
+  return rows[0]?.thread_key ?? null;
 }
 
 // Notify label-feed plugins that an ordinary mail mutation changed the messages table outside
@@ -1299,7 +1343,9 @@ export class ImapManager {
     this.backfillAllRunning = new Set(); // accountId — prevent concurrent full backfill sequences
     this._bgConnSem = createKeyedSemaphore(BACKGROUND_CONN_MAX_PER_HOST); // cap concurrent background IMAP conns (backfill + snippet indexer) per provider host
     this._connectCooldown = new Map(); // accountId -> { until: ms, failures: number } after connection refusals
-    this.onDemandSyncing = new Set(); // `${accountId}:${folder}` — prevent duplicate on-demand syncs
+    // `${accountId}:${folder}` -> { promise, release? }. Callers that need read-after-write
+    // consistency can await the active owner instead of treating "already running" as complete.
+    this.onDemandSyncing = new Map();
     // Bounded engine facade handed to plugin hooks instead of `this` — plugins get only the reviewed
     // sync/label primitives (see mailEngineFacade), never the raw engine, its connections, or locks.
     this.pluginFacade = createPluginMailFacade(this);
@@ -2655,7 +2701,9 @@ export class ImapManager {
         // THIS account (GTD's handler is active only when gtd_enabled), so a mailbox with no such
         // plugin collects nothing and issues no extra queries — identical to the pre-plugin gate.
         const wantsInboxIngest = folder === 'INBOX' && await pluginRegistry.hasActiveAsync('inboxIngest', { account });
+        const wantsMessageRowsIngested = await pluginRegistry.hasActiveAsync('messageRowsIngested', { account });
         const newInboxIds = [];
+        const ingestedMessageIds = [];
         const ingestDeletedIds = new Set();
 
         // Relocate-exempt label folders for this account (empty when no label plugin is
@@ -2802,6 +2850,7 @@ export class ImapManager {
             ]);
             if (result.rows[0]?.is_new) {
               insertedCount++;
+              if (wantsMessageRowsIngested) ingestedMessageIds.push(result.rows[0].id);
               // Inbox-ingest candidate: any newly-inserted INBOX row, read OR unread (read state
               // is not a gate here — the plugin decides). The unread-only push below still drives
               // notifications. Gated on wantsInboxIngest so a mailbox with no ingest plugin builds
@@ -3085,6 +3134,11 @@ export class ImapManager {
         if (wantsInboxIngest && newInboxIds.length > 0) {
           await pluginRegistry.runHook('inboxIngest', {
             mgr: this.pluginFacade, account, newInboxIds, deletedIds: ingestDeletedIds,
+          });
+        }
+        if (wantsMessageRowsIngested && ingestedMessageIds.length > 0) {
+          await pluginRegistry.runHook('messageRowsIngested', {
+            account, messageIds: ingestedMessageIds,
           });
         }
         // Reconcile the cached unread badge from actual rows now that this pass's inserts, flag
@@ -4069,26 +4123,60 @@ export class ImapManager {
   // Syncs the most recent messages in a specific folder on demand.
   // Called when the user navigates to a folder that has no local messages yet.
   // Uses a pooled connection — does NOT touch the main sync connection.
-  async syncFolderOnDemand(account, folder) {
+  async _syncFolderOnDemandNow(account, folder) {
+    await withFreshClient(account, async (client) => {
+      await this.syncMessages(account, client, folder, 100, false, true);
+    });
+  }
+
+  async syncFolderOnDemand(account, folder, { freshAfterActive = false } = {}) {
     const key = `${account.id}:${folder}`;
-    if (this.onDemandSyncing.has(key)) {
-      console.log(`syncFolderOnDemand skipped (already running): ${logAccount(account)}/${folder}`);
-      return;
+    const active = this.onDemandSyncing.get(key);
+    if (active) {
+      console.log(`syncFolderOnDemand waiting (already running): ${logAccount(account)}/${folder}`);
+      await active.promise;
+      if (!freshAfterActive) return;
+      // A sync that started before a non-UIDPLUS COPY may not have observed the new destination
+      // row. Once that older owner settles, take a new claim and perform one post-copy pass.
+      if (this.onDemandSyncing.get(key) === active) this.onDemandSyncing.delete(key);
+      return this.syncFolderOnDemand(account, folder);
     }
-    this.onDemandSyncing.add(key);
-    console.log(`syncFolderOnDemand start: ${logAccount(account)}/${folder}`);
+
+    const task = (async () => {
+      console.log(`syncFolderOnDemand start: ${logAccount(account)}/${folder}`);
+      try {
+        await this._syncFolderOnDemandNow(account, folder);
+        console.log(`syncFolderOnDemand done: ${logAccount(account)}/${folder}`);
+        // sync_complete fires mailflow:refresh in the frontend, reloading the message list
+        this.broadcast({ type: 'sync_complete', accountId: account.id }, account.user_id);
+      } catch (err) {
+        console.error(`On-demand sync error ${logAccount(account)}/${folder}:`, err.message);
+      }
+    })();
+    const entry = { promise: task, release: null };
+    this.onDemandSyncing.set(key, entry);
     try {
-      await withFreshClient(account, async (client) => {
-        await this.syncMessages(account, client, folder, 100, false, true);
-      });
-      console.log(`syncFolderOnDemand done: ${logAccount(account)}/${folder}`);
-      // sync_complete fires mailflow:refresh in the frontend, reloading the message list
-      this.broadcast({ type: 'sync_complete', accountId: account.id }, account.user_id);
-    } catch (err) {
-      console.error(`On-demand sync error ${logAccount(account)}/${folder}:`, err.message);
+      return await task;
     } finally {
-      this.onDemandSyncing.delete(key);
+      if (this.onDemandSyncing.get(key) === entry) this.onDemandSyncing.delete(key);
     }
+  }
+
+  _tryClaimFolderSync(accountId, folder) {
+    const key = `${accountId}:${folder}`;
+    if (this.onDemandSyncing.has(key)) return false;
+    let release;
+    const promise = new Promise(resolve => { release = resolve; });
+    this.onDemandSyncing.set(key, { promise, release });
+    return true;
+  }
+
+  _releaseFolderSync(accountId, folder) {
+    const key = `${accountId}:${folder}`;
+    const entry = this.onDemandSyncing.get(key);
+    if (!entry) return;
+    entry.release?.();
+    if (this.onDemandSyncing.get(key) === entry) this.onDemandSyncing.delete(key);
   }
 
   // Periodically pull new mail into the special-use spam/Junk folder. Server-side spam filtering
@@ -4108,9 +4196,7 @@ export class ImapManager {
       spamPath = await resolveSpamFolder(account.id, account.folder_mappings);
     } catch { return; }
     if (!spamPath) return;
-    const key = `${account.id}:${spamPath}`;
-    if (this.onDemandSyncing.has(key)) return;
-    this.onDemandSyncing.add(key);
+    if (!this._tryClaimFolderSync(account.id, spamPath)) return;
     const host = (account.imap_host || '').toLowerCase();
     try {
       await this._bgConnSem.acquire(host);
@@ -4125,7 +4211,7 @@ export class ImapManager {
     } catch (err) {
       console.warn(`Periodic spam sync failed for ${logAccount(account)}/${spamPath}:`, err.message);
     } finally {
-      this.onDemandSyncing.delete(key);
+      this._releaseFolderSync(account.id, spamPath);
     }
   }
 
@@ -4750,7 +4836,7 @@ export class ImapManager {
   // Post-copy notification/re-evaluation is a plugin concern: the generic `afterLabelCopy`
   // hook lets the owning plugin (GTD) broadcast its refresh event and, on the deferred path,
   // reconcile once the sibling lands. copyMessage itself stays label-feature-agnostic.
-  async copyMessage(accountId, uid, fromFolder, toFolder) {
+  async copyMessage(accountId, uid, fromFolder, toFolder, { skipPostCopyTransitions = false } = {}) {
     const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [accountId]);
     const account = accountResult.rows[0];
     if (!account) throw new Error(`copyMessage: account ${accountId} not found`);
@@ -4778,11 +4864,23 @@ export class ImapManager {
     // plugin whether the sibling is available now (UIDPLUS) or deferred to a destination sync
     // (null). The hook swallows per-plugin errors and the plugin's deferred work is fire-and-
     // forget, so this never blocks or breaks the copy.
-    await pluginRegistry.runHook('afterLabelCopy', { mgr: this.pluginFacade, account, toFolder, fromFolder, srcUid: uid, newUid });
+    await pluginRegistry.runHook('afterLabelCopy', {
+      mgr: this.pluginFacade,
+      account,
+      toFolder,
+      fromFolder,
+      srcUid: uid,
+      newUid,
+      skipPostCopyTransitions,
+    });
 
     if (newUid == null) return null;
 
-    await insertCopiedSibling(accountId, uid, fromFolder, toFolder, newUid);
+    try {
+      await insertCopiedSibling(accountId, uid, fromFolder, toFolder, newUid);
+    } catch (error) {
+      await rollbackCopiedMessageOnInsertFailure(this, account, toFolder, newUid, error);
+    }
     return newUid;
   }
 
@@ -4797,10 +4895,11 @@ export class ImapManager {
     const account = accountResult.rows[0];
     if (!account) throw new Error(`removeMessageCopy: account ${accountId} not found`);
 
+    const threadKey = await labelCopyThreadKey(accountId, uid, folder);
     await this.permanentDeleteMessage(account, uid, folder);
     const result = await deleteMessageCopyRow(accountId, uid, folder);
     // Removing a label copy changes label-feed data — let plugins broadcast their refresh.
-    await pluginRegistry.runHook('afterLabelRemove', { mgr: this.pluginFacade, account, folder, uid });
+    await pluginRegistry.runHook('afterLabelRemove', { mgr: this.pluginFacade, account, folder, uid, threadKey });
     return result;
   }
 
@@ -5318,10 +5417,7 @@ export class ImapManager {
       console.log(`Reconcile: removing ${orphanUids.length} server-deleted message(s) from ${logAccount(account)}/${folder}`);
       // Re-assert the cutoff in the DELETE: a row updated to a fresh synced_at between
       // the SELECT above and here (e.g. a concurrent bulk-move reinsert) is spared.
-      await query(
-        'DELETE FROM messages WHERE account_id = $1 AND folder = $2 AND uid = ANY($3::bigint[]) AND (synced_at IS NULL OR synced_at < $4)',
-        [account.id, folder, orphanUids, reconcileStartedAt]
-      );
+      const deletedHere = await deleteReconciledMessageRows(account, folder, orphanUids, reconcileStartedAt);
       // Resync cached folder counts from actual row data — reconcile deletes rows
       // without going through adjustFolderCounts, so counts would otherwise drift.
       await query(
@@ -5332,7 +5428,7 @@ export class ImapManager {
          WHERE f.account_id = $1 AND f.path = $2`,
         [account.id, folder]
       );
-      deletedCount += orphanUids.length;
+      deletedCount += deletedHere;
     }
 
     if (deletedCount > 0) {

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -12,7 +12,7 @@ vi.mock('../utils/redact.js', () => ({ redactEmail: vi.fn() }));
 vi.mock('./hostValidation.js', () => ({ resolveForConnection: vi.fn() }));
 vi.mock('./connectionPolicy.js', () => ({ getConnectionPolicy: vi.fn() }));
 
-import { ImapManager, providerProfile, makeClientCfg, relocateExemptGuard, insertCopiedSibling, deleteMessageCopyRow, emitSectionsChanged, ensureMailbox, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, folderSyncDue, planModseqSync, connectStaggerFor, walkStructure, parsePersistentCap, resolvePersistentCap, persistentEligible, shouldRetryIPv4 } from './imapManager.js';
+import { ImapManager, providerProfile, makeClientCfg, relocateExemptGuard, insertCopiedSibling, rollbackCopiedMessageOnInsertFailure, deleteReconciledMessageRows, deleteMessageCopyRow, labelCopyThreadKey, emitSectionsChanged, ensureMailbox, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, folderSyncDue, planModseqSync, connectStaggerFor, walkStructure, parsePersistentCap, resolvePersistentCap, persistentEligible, shouldRetryIPv4 } from './imapManager.js';
 import { pluginRegistry } from '../plugins/registry.js';
 import { EventEmitter } from 'node:events';
 import { ImapFlow } from 'imapflow';
@@ -306,6 +306,8 @@ describe('insertCopiedSibling', () => {
     expect(ins[1]).toEqual(['acct-1', 'INBOX', 100, 5001, 'Todo']);
     // delivery_addresses is copied verbatim from the source row, same as list_unsubscribe.
     expect(ins[0]).toContain('delivery_addresses');
+    // Plugin-owned metadata follows the copied sibling immediately on UIDPLUS servers.
+    expect(ins[0]).toContain('plugin_annotations');
   });
 
   it('increments destination unread only when the copied message is unread', async () => {
@@ -327,6 +329,59 @@ describe('insertCopiedSibling', () => {
     query.mockResolvedValueOnce({ rows: [] }); // DO NOTHING → no RETURNING row
     await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001);
     expect(countAdjusts()).toHaveLength(0);
+  });
+
+  it('propagates a local sibling insert failure', async () => {
+    query.mockRejectedValueOnce(new Error('database unavailable'));
+    await expect(insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001))
+      .rejects.toThrow('database unavailable');
+  });
+});
+
+describe('rollbackCopiedMessageOnInsertFailure', () => {
+  it('removes the confirmed server copy before rethrowing the insert failure', async () => {
+    const manager = { permanentDeleteMessage: vi.fn().mockResolvedValue(undefined) };
+    const account = { id: 'acct-1' };
+    const insertError = new Error('database unavailable');
+    await expect(rollbackCopiedMessageOnInsertFailure(
+      manager, account, 'Delegated', 5001, insertError,
+    )).rejects.toBe(insertError);
+    expect(manager.permanentDeleteMessage).toHaveBeenCalledWith(account, 5001, 'Delegated');
+    expect(insertError.copiedUid).toBeUndefined();
+  });
+
+  it('reports the confirmed UID when server rollback also fails', async () => {
+    const rollbackError = new Error('imap unavailable');
+    const manager = { permanentDeleteMessage: vi.fn().mockRejectedValue(rollbackError) };
+    const insertError = new Error('database unavailable');
+    await expect(rollbackCopiedMessageOnInsertFailure(
+      manager, { id: 'acct-1' }, 'Delegated', 5001, insertError,
+    )).rejects.toMatchObject({ copiedUid: 5001, rollbackError });
+  });
+});
+
+describe('deleteReconciledMessageRows', () => {
+  beforeEach(() => query.mockReset());
+
+  it('returns deleted thread keys to plugins after the guarded delete', async () => {
+    query.mockResolvedValueOnce({
+      rowCount: 2,
+      rows: [{ thread_key: 'thread-1' }, { thread_key: 'thread-1' }],
+    });
+    const runHook = vi.spyOn(pluginRegistry, 'runHook').mockResolvedValue([]);
+    const reconcileStartedAt = new Date('2026-08-26T10:00:00Z');
+    const account = { id: 'acct-1', user_id: 'user-1' };
+    try {
+      expect(await deleteReconciledMessageRows(account, 'Delegated', [41, 42], reconcileStartedAt)).toBe(2);
+      expect(query.mock.calls[0][0]).toContain('RETURNING thread_key');
+      expect(runHook).toHaveBeenCalledWith('messageRowsDeleted', {
+        account,
+        folder: 'Delegated',
+        threadKeys: ['thread-1'],
+      });
+    } finally {
+      runHook.mockRestore();
+    }
   });
 });
 
@@ -359,6 +414,49 @@ describe('deleteMessageCopyRow', () => {
     query.mockResolvedValueOnce({ rows: [] });
     await deleteMessageCopyRow('acct-1', 100, 'Todo');
     expect(countAdjusts()).toHaveLength(0);
+  });
+});
+
+describe('labelCopyThreadKey', () => {
+  beforeEach(() => query.mockReset());
+
+  it('captures the thread before a label row is removed', async () => {
+    query.mockResolvedValueOnce({ rows: [{ thread_key: 'thread-1' }] });
+    await expect(labelCopyThreadKey('acct-1', 42, 'Delegated')).resolves.toBe('thread-1');
+    expect(query.mock.calls[0][1]).toEqual(['acct-1', 42, 'Delegated']);
+  });
+});
+
+describe('syncFolderOnDemand coalescing', () => {
+  it('waits for an already claimed folder sync instead of reporting completion early', async () => {
+    const mgr = new ImapManager({ clients: new Set() });
+    const acct = { id: 'acct-1', user_id: 'user-1', email_address: 'user@example.test' };
+    expect(mgr.pluginFacade.tryClaimFolderSync(acct.id, 'Delegated')).toBe(true);
+
+    let settled = false;
+    const waiting = mgr.syncFolderOnDemand(acct, 'Delegated').then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    mgr.pluginFacade.releaseFolderSync(acct.id, 'Delegated');
+    await waiting;
+    expect(settled).toBe(true);
+  });
+
+  it('runs a fresh sync after an older claimed sync when post-copy freshness is required', async () => {
+    const mgr = new ImapManager({ clients: new Set() });
+    const acct = { id: 'acct-1', user_id: 'user-1', email_address: 'user@example.test' };
+    expect(mgr.pluginFacade.tryClaimFolderSync(acct.id, 'Delegated')).toBe(true);
+    const syncNow = vi.spyOn(mgr, '_syncFolderOnDemandNow').mockResolvedValue(undefined);
+
+    const waiting = mgr.syncFolderOnDemand(acct, 'Delegated', { freshAfterActive: true });
+    await Promise.resolve();
+    expect(syncNow).not.toHaveBeenCalled();
+    mgr.pluginFacade.releaseFolderSync(acct.id, 'Delegated');
+    await waiting;
+
+    expect(syncNow).toHaveBeenCalledTimes(1);
+    expect(syncNow).toHaveBeenCalledWith(acct, 'Delegated');
   });
 });
 
@@ -1080,7 +1178,9 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
     // wire: an active inbox-ingest plugin makes syncMessages collect the new row's id and
     // dispatch runHook('inboxIngest', …). We spy the registry rather than register a real
     // plugin so the singleton stays clean for other suites.
-    const hasActive = vi.spyOn(pluginRegistry, 'hasActiveAsync').mockImplementation(async (name) => name === 'inboxIngest');
+    const hasActive = vi.spyOn(pluginRegistry, 'hasActiveAsync').mockImplementation(async (name) => (
+      name === 'inboxIngest' || name === 'messageRowsIngested'
+    ));
     const runHook = vi.spyOn(pluginRegistry, 'runHook').mockResolvedValue([]);
     try {
       const account = {
@@ -1122,6 +1222,9 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
       // The hook receives the bounded facade, never the raw engine (`this`).
       expect(runHook).toHaveBeenCalledWith('inboxIngest', {
         mgr: mgr.pluginFacade, account, newInboxIds: ['ingest-1'], deletedIds: new Set(),
+      });
+      expect(runHook).toHaveBeenCalledWith('messageRowsIngested', {
+        account, messageIds: ['ingest-1'],
       });
     } finally {
       hasActive.mockRestore();
@@ -1221,7 +1324,7 @@ describe('_syncSpamFolder — periodic spam poll guards', () => {
   it('no-ops when the account has no resolvable spam folder', async () => {
     query.mockReset();
     query.mockResolvedValue({ rows: [] }); // resolveSpamFolder finds nothing
-    const ctx = { onDemandSyncing: new Set(), broadcast: vi.fn(), syncMessages: vi.fn() };
+    const ctx = { onDemandSyncing: new Map(), broadcast: vi.fn(), syncMessages: vi.fn() };
     await ImapManager.prototype._syncSpamFolder.call(ctx, account);
     expect(ctx.syncMessages).not.toHaveBeenCalled();
     expect(ctx.broadcast).not.toHaveBeenCalled();
@@ -1232,7 +1335,12 @@ describe('_syncSpamFolder — periodic spam poll guards', () => {
     // resolveSpamFolder's special-use lookup (identified by its name-regex clause) yields "Junk".
     query.mockImplementation((sql) =>
       sql.includes('lower(name) ~') ? Promise.resolve({ rows: [{ path: 'Junk' }] }) : Promise.resolve({ rows: [] }));
-    const ctx = { onDemandSyncing: new Set(['a1:Junk']), broadcast: vi.fn(), syncMessages: vi.fn() };
+    const ctx = {
+      onDemandSyncing: new Map([['a1:Junk', { promise: Promise.resolve(), release: null }]]),
+      _tryClaimFolderSync: ImapManager.prototype._tryClaimFolderSync,
+      broadcast: vi.fn(),
+      syncMessages: vi.fn(),
+    };
     await ImapManager.prototype._syncSpamFolder.call(ctx, account);
     expect(ctx.syncMessages).not.toHaveBeenCalled();
     expect(ctx.broadcast).not.toHaveBeenCalled();

--- a/backend/src/services/labels.js
+++ b/backend/src/services/labels.js
@@ -27,10 +27,34 @@ export async function resolveLabelCopyUid(message, folder) {
   return rows[0]?.uid ?? null;
 }
 
+export async function listLabelCopyUids(accountId, threadKey, folder) {
+  const { rows } = await query(
+    `SELECT uid FROM messages
+      WHERE account_id = $1 AND thread_key = $2 AND folder = $3
+        AND is_deleted = false
+      ORDER BY uid`,
+    [accountId, threadKey, folder]
+  );
+  return rows.map(row => Number(row.uid));
+}
+
+export async function reconcileLabelApply(imapManager, account, message, folder, beforeUids) {
+  await imapManager.syncFolderOnDemand(account, folder);
+  const before = new Set((beforeUids || []).map(Number));
+  const added = (await listLabelCopyUids(message.account_id, message.thread_key, folder))
+    .filter(uid => !before.has(uid));
+  return added.length === 1
+    ? { uid: added[0], ambiguous: false }
+    : { uid: null, ambiguous: true };
+}
+
 // Apply a label: ensure the label folder exists, then COPY the message into it (leaving the
 // original in place). imapManager.copyMessage also emits the section-refresh event. No-op when
 // the message already lives in the label folder. `message` needs { uid, folder }.
-export async function applyLabel(imapManager, account, message, labelFolder) {
+export async function applyLabel(imapManager, account, message, labelFolder, {
+  folderEnsured = false,
+  skipPostCopyTransitions = false,
+} = {}) {
   if (message.folder === labelFolder) {
     return { applied: false, uid: message.uid, reason: 'already-there' };
   }
@@ -38,8 +62,16 @@ export async function applyLabel(imapManager, account, message, labelFolder) {
   if (existingUid != null) {
     return { applied: false, uid: existingUid, reason: 'already-labelled' };
   }
-  await imapManager.ensureFolder(account, labelFolder);
-  const uid = await imapManager.copyMessage(account.id, message.uid, message.folder, labelFolder);
+  if (!folderEnsured) await imapManager.ensureFolder(account, labelFolder);
+  const uid = skipPostCopyTransitions
+    ? await imapManager.copyMessage(
+      account.id,
+      message.uid,
+      message.folder,
+      labelFolder,
+      { skipPostCopyTransitions: true },
+    )
+    : await imapManager.copyMessage(account.id, message.uid, message.folder, labelFolder);
   return { applied: true, uid: uid ?? null };
 }
 

--- a/backend/src/services/labels.test.js
+++ b/backend/src/services/labels.test.js
@@ -11,6 +11,8 @@ import {
   resolveLabelCopyUid,
   markThreadRead,
   ensureLabelFolders,
+  listLabelCopyUids,
+  reconcileLabelApply,
 } from './labels.js';
 
 const account = { id: 'acct-1' };
@@ -56,6 +58,30 @@ describe('applyLabel', () => {
     imap.copyMessage.mockResolvedValueOnce(null);
     const r = await applyLabel(imap, account, { uid: 7, folder: 'INBOX' }, 'Todo');
     expect(r).toEqual({ applied: true, uid: null });
+  });
+
+  it('skips redundant folder creation when the caller already ensured it', async () => {
+    const imap = mkImap();
+    imap.copyMessage.mockResolvedValueOnce(42);
+
+    await applyLabel(imap, account, { uid: 7, folder: 'INBOX' }, 'Todo', { folderEnsured: true });
+
+    expect(imap.ensureFolder).not.toHaveBeenCalled();
+    expect(imap.copyMessage).toHaveBeenCalledWith('acct-1', 7, 'INBOX', 'Todo');
+  });
+
+  it('passes an explicit post-copy transition suppression to the mail engine', async () => {
+    const imap = mkImap();
+    imap.copyMessage.mockResolvedValueOnce(null);
+
+    await applyLabel(imap, account, { uid: 7, folder: 'INBOX' }, 'Delegated', {
+      folderEnsured: true,
+      skipPostCopyTransitions: true,
+    });
+
+    expect(imap.copyMessage).toHaveBeenCalledWith(
+      'acct-1', 7, 'INBOX', 'Delegated', { skipPostCopyTransitions: true },
+    );
   });
 
   it('is a no-op when the message already lives in the label folder', async () => {
@@ -132,6 +158,28 @@ describe('removeLabel', () => {
     const r = await removeLabel(imap, { account_id: 'acct-1', uid: 1, folder: 'INBOX', message_id: '<m>' }, 'Todo');
     expect(r).toEqual({ removed: false });
     expect(imap.removeMessageCopy).not.toHaveBeenCalled();
+  });
+});
+
+describe('label copy reconciliation', () => {
+  it('lists live UIDs for exactly one account, thread, and folder', async () => {
+    query.mockResolvedValueOnce({ rows: [{ uid: 10 }, { uid: 11 }] });
+    await expect(listLabelCopyUids('acct-1', 'thread-1', 'Delegated')).resolves.toEqual([10, 11]);
+    expect(query.mock.calls[0][1]).toEqual(['acct-1', 'thread-1', 'Delegated']);
+    expect(query.mock.calls[0][0]).toContain('is_deleted = false');
+  });
+
+  it.each([
+    [[10], [{ uid: 10 }, { uid: 11 }], { uid: 11, ambiguous: false }],
+    [[10], [{ uid: 10 }], { uid: null, ambiguous: true }],
+    [[10], [{ uid: 10 }, { uid: 11 }, { uid: 12 }], { uid: null, ambiguous: true }],
+  ])('syncs once and attributes only one new UID', async (before, rows, expected) => {
+    query.mockResolvedValueOnce({ rows });
+    const imap = { syncFolderOnDemand: vi.fn() };
+    const message = { account_id: 'acct-1', thread_key: 'thread-1' };
+    await expect(reconcileLabelApply(imap, account, message, 'Delegated', before)).resolves.toEqual(expected);
+    expect(imap.syncFolderOnDemand).toHaveBeenCalledTimes(1);
+    expect(imap.syncFolderOnDemand).toHaveBeenCalledWith(account, 'Delegated');
   });
 });
 

--- a/backend/src/services/mailAccess.delegation.test.js
+++ b/backend/src/services/mailAccess.delegation.test.js
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => ({ query: vi.fn() }));
+import { query } from './db.js';
+import {
+  getAnnotatedThreadKeysMissingFolder,
+  getThreadAnnotationRows,
+  loadOwnedContact,
+  loadOwnedMessages,
+  setThreadAnnotation,
+} from './mailAccess.js';
+
+beforeEach(() => query.mockReset());
+
+describe('delegation-safe mail access', () => {
+  it('loads only live messages joined through the owning user', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 'm1' }] });
+    await expect(loadOwnedMessages('user-1', ['m1'])).resolves.toEqual([{ id: 'm1' }]);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('JOIN email_accounts a ON a.id = m.account_id');
+    expect(sql).toContain('a.user_id = $1');
+    expect(sql).toContain('m.is_deleted = false');
+    expect(params).toEqual(['user-1', ['m1']]);
+  });
+
+  it('loads a contact only through its owning user', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    await expect(loadOwnedContact('user-1', 'contact-1')).resolves.toBeNull();
+    expect(query.mock.calls[0][0]).toContain('c.user_id = $2');
+    expect(query.mock.calls[0][1]).toEqual(['contact-1', 'user-1']);
+  });
+
+  it('loads only annotation fields for bounded account threads', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 'm1', thread_key: 'thread-1' }] });
+    await expect(getThreadAnnotationRows('account-1', ['thread-1'])).resolves.toHaveLength(1);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('SELECT id, thread_key, plugin_annotations');
+    expect(sql).not.toContain('SELECT *');
+    expect(sql).toContain('account_id = $1');
+    expect(sql).toContain('thread_key = ANY($2::text[])');
+    expect(sql).toContain('is_deleted = false');
+    expect(params).toEqual(['account-1', ['thread-1']]);
+  });
+
+  it('finds annotated threads whose label folder has no live copy', async () => {
+    query.mockResolvedValueOnce({ rows: [{ thread_key: 'thread-orphan' }] });
+    await expect(getAnnotatedThreadKeysMissingFolder(
+      'account-1', 'Delegated', 'gtd', 'delegation',
+    )).resolves.toEqual(['thread-orphan']);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('plugin_annotations -> $3 -> $4 IS NOT NULL');
+    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toContain('label.folder = $2');
+    expect(params).toEqual(['account-1', 'Delegated', 'gtd', 'delegation']);
+  });
+
+  it('sets and clears one key without replacing the plugin namespace', async () => {
+    query.mockResolvedValue({ rowCount: 2, rows: [] });
+    const snapshot = { contactId: 'contact-1' };
+    await expect(setThreadAnnotation('account-1', 'thread-1', 'gtd', 'delegation', snapshot)).resolves.toBe(2);
+    await expect(setThreadAnnotation('account-1', 'thread-1', 'gtd', 'delegation', null)).resolves.toBe(2);
+
+    const [setSql, setParams] = query.mock.calls[0];
+    expect(setSql).toContain("COALESCE(plugin_annotations -> $3, '{}'::jsonb) || jsonb_build_object($4::text, $5::jsonb)");
+    expect(setParams).toEqual(['account-1', 'thread-1', 'gtd', 'delegation', JSON.stringify(snapshot)]);
+    const [clearSql, clearParams] = query.mock.calls[1];
+    expect(clearSql).toContain('(plugin_annotations -> $3) - $4');
+    expect(clearParams).toEqual(['account-1', 'thread-1', 'gtd', 'delegation']);
+  });
+});

--- a/backend/src/services/mailAccess.js
+++ b/backend/src/services/mailAccess.js
@@ -22,6 +22,30 @@ export async function loadOwnedMessage(userId, messageId) {
   return rows[0] || null;
 }
 
+export async function loadOwnedMessages(userId, messageIds) {
+  if (!messageIds?.length) return [];
+  const { rows } = await query(
+    `SELECT m.*
+       FROM messages m
+       JOIN email_accounts a ON a.id = m.account_id
+      WHERE a.user_id = $1
+        AND m.id = ANY($2::uuid[])
+        AND m.is_deleted = false`,
+    [userId, messageIds]
+  );
+  return rows;
+}
+
+export async function loadOwnedContact(userId, contactId) {
+  const { rows } = await query(
+    `SELECT c.id, c.display_name, c.primary_email
+       FROM contacts c
+      WHERE c.id = $1 AND c.user_id = $2`,
+    [contactId, userId]
+  );
+  return rows[0] || null;
+}
+
 // One of the user's accounts by id (ownership enforced), or null. Full row.
 export async function getOwnedAccount(userId, accountId) {
   const { rows } = await query(
@@ -99,6 +123,37 @@ export async function getMessagesByThreadKeys(accountId, threadKeys) {
     [accountId, threadKeys]
   );
   return rows;
+}
+
+export async function getThreadAnnotationRows(accountId, threadKeys) {
+  if (!threadKeys?.length) return [];
+  const { rows } = await query(
+    `SELECT id, thread_key, plugin_annotations FROM messages
+      WHERE account_id = $1
+        AND thread_key = ANY($2::text[])
+        AND is_deleted = false`,
+    [accountId, threadKeys]
+  );
+  return rows;
+}
+
+export async function getAnnotatedThreadKeysMissingFolder(accountId, folder, pluginId, key) {
+  const { rows } = await query(
+    `SELECT DISTINCT annotated.thread_key
+       FROM messages annotated
+      WHERE annotated.account_id = $1
+        AND annotated.is_deleted = false
+        AND annotated.plugin_annotations -> $3 -> $4 IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM messages label
+           WHERE label.account_id = annotated.account_id
+             AND label.thread_key = annotated.thread_key
+             AND label.folder = $2
+             AND label.is_deleted = false
+        )`,
+    [accountId, folder, pluginId, key]
+  );
+  return rows.map(row => row.thread_key);
 }
 
 // The thread key of a single message identified by its (uid, folder) within an account, or null.
@@ -186,6 +241,33 @@ export async function setMessageAnnotation(accountId, messageId, pluginId, patch
               true)
       WHERE id = $2 AND account_id = $1`,
     [accountId, messageId, pluginId, JSON.stringify(patch)]
+  );
+  return rowCount;
+}
+
+export async function setThreadAnnotation(accountId, threadKey, pluginId, key, value) {
+  if (value === null) {
+    const { rowCount } = await query(
+      `UPDATE messages
+          SET plugin_annotations = jsonb_set(
+                COALESCE(plugin_annotations, '{}'::jsonb),
+                ARRAY[$3::text],
+                COALESCE((plugin_annotations -> $3) - $4, '{}'::jsonb),
+                true)
+        WHERE account_id = $1 AND thread_key = $2 AND is_deleted = false`,
+      [accountId, threadKey, pluginId, key]
+    );
+    return rowCount;
+  }
+  const { rowCount } = await query(
+    `UPDATE messages
+        SET plugin_annotations = jsonb_set(
+              COALESCE(plugin_annotations, '{}'::jsonb),
+              ARRAY[$3::text],
+              COALESCE(plugin_annotations -> $3, '{}'::jsonb) || jsonb_build_object($4::text, $5::jsonb),
+              true)
+      WHERE account_id = $1 AND thread_key = $2 AND is_deleted = false`,
+    [accountId, threadKey, pluginId, key, JSON.stringify(value)]
   );
   return rowCount;
 }

--- a/backend/src/services/mailAccess.js
+++ b/backend/src/services/mailAccess.js
@@ -147,6 +147,32 @@ export async function getMessageAnnotations(accountId, ids, pluginId) {
   return out;
 }
 
+// Label-folder membership for a bounded set of message rows. Targets are scoped to one account;
+// their live siblings are joined by the stored thread key so plugins can decorate existing rows
+// without adding feature-specific joins to the core message-list query.
+export async function getLabelMetadata(accountId, messageIds, labelFolders) {
+  if (!messageIds?.length || !labelFolders?.length) return [];
+  const { rows } = await query(
+    `SELECT target.id AS message_id, sibling.folder, MAX(sibling.date) AS date
+       FROM messages target
+       JOIN messages sibling
+         ON sibling.account_id = target.account_id
+        AND sibling.thread_key = target.thread_key
+        AND sibling.folder = ANY($3::text[])
+        AND sibling.is_deleted = false
+      WHERE target.account_id = $1
+        AND target.id = ANY($2::uuid[])
+      GROUP BY target.id, sibling.folder
+      ORDER BY target.id, sibling.folder`,
+    [accountId, messageIds, labelFolders]
+  );
+  return rows.map(row => ({
+    messageId: row.message_id,
+    folder: row.folder,
+    date: row.date == null ? null : new Date(row.date).toISOString(),
+  }));
+}
+
 // Merge `patch` into a plugin's namespace of a message's annotations (creating the namespace if
 // absent). Only ever touches plugin_annotations -> pluginId. Returns rows updated (0 if the
 // message isn't in the account). The annotation cache is cleaned with the message row on delete.

--- a/backend/src/services/mailAccess.labelMetadata.test.js
+++ b/backend/src/services/mailAccess.labelMetadata.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./db.js', () => ({ query: vi.fn() }));
+import { query } from './db.js';
+import { getLabelMetadata } from './mailAccess.js';
+
+const ACCOUNT = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const M1 = '11111111-1111-4111-8111-111111111111';
+const M2 = '22222222-2222-4222-8222-222222222222';
+
+beforeEach(() => query.mockReset());
+
+describe('getLabelMetadata', () => {
+  it('maps requested rows to live same-thread label folders', async () => {
+    query.mockResolvedValueOnce({ rows: [
+      { message_id: M1, folder: 'Todo', date: new Date('2026-08-01T00:00:00.000Z') },
+      { message_id: M2, folder: 'Watch', date: new Date('2026-07-01T00:00:00.000Z') },
+    ] });
+
+    const result = await getLabelMetadata(ACCOUNT, [M1, M2], ['Todo', 'Watch']);
+
+    expect(result).toEqual([
+      { messageId: M1, folder: 'Todo', date: '2026-08-01T00:00:00.000Z' },
+      { messageId: M2, folder: 'Watch', date: '2026-07-01T00:00:00.000Z' },
+    ]);
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/target\.account_id = \$1/);
+    expect(sql).toMatch(/target\.id = ANY\(\$2::uuid\[\]\)/);
+    expect(sql).toMatch(/sibling\.account_id = target\.account_id/);
+    expect(sql).toMatch(/sibling\.thread_key = target\.thread_key/);
+    expect(sql).toMatch(/sibling\.folder = ANY\(\$3::text\[\]\)/);
+    expect(sql).toMatch(/sibling\.is_deleted = false/);
+    expect(sql).toMatch(/MAX\(sibling\.date\)/);
+    expect(params).toEqual([ACCOUNT, [M1, M2], ['Todo', 'Watch']]);
+  });
+
+  it('returns no metadata without querying when ids or folders are empty', async () => {
+    expect(await getLabelMetadata(ACCOUNT, [], ['Todo'])).toEqual([]);
+    expect(await getLabelMetadata(ACCOUNT, [M1], [])).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -34,6 +34,7 @@ import {
   unreadCountsByAccount,
 } from '../utils/threadedArchive.js';
 import { createUndoableCommit, UNDO_COMMIT_DELAY_MS, UNDO_WINDOW_MS } from '../utils/undoableAction.js';
+import { PluginSlot } from '../plugins/PluginSlot.jsx';
 
 // Folder icon for move picker
 function FolderIcon({ specialUse, size = 13 }) {
@@ -4313,9 +4314,13 @@ function ThreadRow({ message, isExpanded, threadMsgs, isLoadingThread, selectedM
           <div style={{
             fontSize: 12, fontWeight: unreadCount > 0 ? 500 : 400,
             color: unreadCount > 0 ? 'var(--text-primary)' : 'var(--text-secondary)',
-            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginBottom: 2,
+            overflow: 'hidden', whiteSpace: 'nowrap', marginBottom: 2,
+            display: 'flex', alignItems: 'center', gap: 5,
           }}>
-            {message.subject || t('common.noSubject')}
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', flex: 1, minWidth: 0 }}>
+              {message.subject || t('common.noSubject')}
+            </span>
+            <PluginSlot name="message-row-meta" ctx={{ message, surface: 'thread' }} />
           </div>
           {/* Row 3: snippet */}
           {showMessagePreviews && (
@@ -4632,10 +4637,14 @@ function MessageRow({ message, selected, lastViewed, isChecked, selectionMode, s
         <div style={{
           fontSize: 13, fontWeight: message.is_read ? 400 : 500,
           color: message.is_read ? 'var(--text-secondary)' : 'var(--text-primary)',
-          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          overflow: 'hidden', whiteSpace: 'nowrap',
           marginBottom: 3,
+          display: 'flex', alignItems: 'center', gap: 5,
         }}>
-          {message.subject || t('message.noSubject')}
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', flex: 1, minWidth: 0 }}>
+            {message.subject || t('message.noSubject')}
+          </span>
+          <PluginSlot name="message-row-meta" ctx={{ message, surface: 'message' }} />
         </div>
 
         {/* Row 3: Snippet */}

--- a/frontend/src/hooks/useGtdTriage.js
+++ b/frontend/src/hooks/useGtdTriage.js
@@ -9,6 +9,7 @@ import {
 import { openReplyFromMessage, openForwardFromMessage } from '../utils/composeFromMessage.js';
 import { resolveContextMenuMessage } from '../utils/contextMenuPolicy.js';
 import { doneGtdRow } from '../utils/gtdDone.js';
+import { invalidateGtdMetadata } from '../plugins/gtd/metadataStore.js';
 
 // One pending delayed auto-read across ALL GTD surfaces (module scope, not per hook
 // instance): the sidebar and the tab browse list are mounted together in desktop row
@@ -88,6 +89,7 @@ export function useGtdTriage() {
       removeGtdThread,
       restoreGtdThread,
       addNotification,
+      invalidateGtdMetadata,
       scheduleGtdSectionsFetch,
       t,
     });

--- a/frontend/src/plugins/gtd/GtdContextMenu.jsx
+++ b/frontend/src/plugins/gtd/GtdContextMenu.jsx
@@ -3,6 +3,7 @@ import { GTD_STATES, GTD_COLORS, resolveAccountGtdFolders, gtdStatesInFolders, u
 import { useStore } from '../../store/index.js';
 import { api } from '../../utils/api.js';
 import { classifyWithUndo } from './classification.js';
+import { invalidateGtdMetadata, removeGtdMetadataState } from './metadataStore.js';
 
 // GTD's context-menu contributions, injected into core's 'context-menu-actions' collector so the
 // menu itself carries no GTD-specific code. Placement is preserved: core splices these items into
@@ -22,14 +23,27 @@ function GtdContextSubmenu({ message, account, onClose, onBack }) {
   // Classify = COPY into the state's label folder (message stays put); remove = strip that label.
   // Store-based, so they run the same on every surface — no dependency on the caller's onAction.
   const classify = (state) => {
-    void classifyWithUndo(message.id, state, {
+    void classifyWithUndo(message, state, {
       api,
       store: { addNotification, scheduleGtdSectionsFetch },
       t,
     });
     onClose();
   };
-  const removeFrom = (state) => { unclassifyThread(message.id, state, { gtdUnclassify: api.gtdUnclassify, addNotification, scheduleGtdSectionsFetch, t }); onClose(); };
+  const removeFrom = (state) => {
+    void unclassifyThread(message.id, state, {
+      gtdUnclassify: api.gtdUnclassify,
+      addNotification,
+      scheduleGtdSectionsFetch,
+      t,
+    }).then(removed => {
+      if (removed) {
+        removeGtdMetadataState(message, state);
+        invalidateGtdMetadata();
+      }
+    });
+    onClose();
+  };
   return (
     <>
       <div

--- a/frontend/src/plugins/gtd/GtdInboxIndicators.jsx
+++ b/frontend/src/plugins/gtd/GtdInboxIndicators.jsx
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from 'react';
+import { useTranslation } from 'react-i18next';
+import { getGtdMetadata, subscribeGtdMetadata } from './metadataStore.js';
+import { buildInboxGtdIndicators } from './indicators.js';
+
+export default function GtdInboxIndicators({ message }) {
+  const { t } = useTranslation();
+  const metadata = useSyncExternalStore(
+    subscribeGtdMetadata,
+    () => getGtdMetadata(message.id),
+    () => null,
+  );
+  const indicators = buildInboxGtdIndicators(metadata, t);
+  if (!indicators.length) return null;
+
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, minWidth: 0, overflow: 'hidden', flexShrink: 0 }}>
+      {indicators.map(indicator => (
+        <span key={indicator.state} style={{
+          color: indicator.color,
+          background: indicator.background,
+          borderRadius: 7,
+          padding: '0 5px',
+          fontSize: 10,
+          fontWeight: 600,
+          whiteSpace: 'nowrap',
+        }}>
+          {indicator.label}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/plugins/gtd/GtdRowDone.jsx
+++ b/frontend/src/plugins/gtd/GtdRowDone.jsx
@@ -3,6 +3,7 @@ import { useStore } from '../../store/index.js';
 import { api } from '../../utils/api.js';
 import { advanceSelectionAfterRemoval } from '../../utils/listSelection.js';
 import { ActionBtn } from '../../components/RowHoverActions.jsx';
+import { invalidateGtdMetadata } from './metadataStore.js';
 
 // The GTD "done" checkmark for the row hover cluster, rendered via the 'row-hover-action' slot.
 //
@@ -29,6 +30,7 @@ export default function GtdRowDone({ message, done }) {
     if (unreadDelta > 0) decrementUnread(message.account_id, unreadDelta);
     try {
       const res = await api.gtdDone(message.id);
+      invalidateGtdMetadata();
       // Labels stripped but the archive step failed: the optimistic removal is still correct, but
       // the email is still in the inbox — say so rather than leave a gap.
       if (res?.archiveFailed) {

--- a/frontend/src/plugins/gtd/GtdRuntime.jsx
+++ b/frontend/src/plugins/gtd/GtdRuntime.jsx
@@ -1,10 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../../store/index.js';
 import { gtdActiveForContext } from '../../utils/gtd.js';
 import { api } from '../../utils/api.js';
 import { shortcutBus } from '../../utils/shortcutBus.js';
 import { classifyWithUndo, undoLatestGtdNotification } from './classification.js';
+import {
+  getGtdMetadataRefreshGeneration,
+  startGtdMetadataFetch,
+  subscribeGtdMetadataRefresh,
+} from './metadataStore.js';
+import { shouldShowInboxGtdMetadata } from './indicators.js';
 
 // GTD's headless runtime: the single owner of the GTD sections fetch. Reloads whenever the context
 // (unified vs a single account) changes and GTD is active there; both the rail and the tab list read
@@ -14,7 +20,11 @@ export default function GtdRuntime() {
   const { t } = useTranslation();
   const accounts = useStore(s => s.accounts);
   const selectedAccountId = useStore(s => s.selectedAccountId);
+  const selectedFolder = useStore(s => s.selectedFolder);
   const fetchGtdSections = useStore(s => s.fetchGtdSections);
+  const messages = useStore(s => s.messages);
+  const searchResults = useStore(s => s.searchResults);
+  const searchQuery = useStore(s => s.searchQuery);
 
   const gtdActive = gtdActiveForContext(accounts, selectedAccountId, true);
   // Also key on the set of GTD-enabled accounts so enabling a second account refetches the unified
@@ -23,6 +33,25 @@ export default function GtdRuntime() {
   useEffect(() => {
     if (gtdActive) fetchGtdSections();
   }, [gtdActive, selectedAccountId, gtdEnabledKey, fetchGtdSections]);
+
+  const metadataSurfaceActive = shouldShowInboxGtdMetadata({ selectedFolder, searchQuery });
+  const renderedPool = metadataSurfaceActive ? (searchQuery.trim() ? searchResults : messages) : [];
+  const enabledAccountIds = new Set(accounts.filter(account => account.gtd_enabled).map(account => account.id));
+  const metadataMessages = renderedPool.filter(message => enabledAccountIds.has(message.account_id));
+  const metadataKey = metadataMessages.map(message => `${message.account_id}:${message.id}`).join(',');
+  const metadataConfigKey = accounts
+    .filter(account => account.gtd_enabled)
+    .map(account => `${account.id}:${JSON.stringify(account.gtd_folders || {})}`)
+    .sort()
+    .join(',');
+  const metadataRefreshGeneration = useSyncExternalStore(
+    subscribeGtdMetadataRefresh,
+    getGtdMetadataRefreshGeneration,
+  );
+  useEffect(() => {
+    if (!gtdActive || !metadataSurfaceActive) return;
+    return startGtdMetadataFetch(metadataMessages, { api });
+  }, [gtdActive, metadataSurfaceActive, metadataKey, metadataConfigKey, metadataRefreshGeneration]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // GTD classify keys (t/w/d): COPY the selected message into a state's label folder. Silent no-op
   // unless the selected message's account has GTD enabled. Only wired while GTD is activated (this
@@ -35,7 +64,7 @@ export default function GtdRuntime() {
       const msg = pool.find(m => m.id === selectedMessageId);
       if (!msg) return;
       if (!accts.find(a => a.id === msg.account_id)?.gtd_enabled) return;
-      void classifyWithUndo(msg.id, state, {
+      void classifyWithUndo(msg, state, {
         api,
         store: { addNotification, scheduleGtdSectionsFetch },
         t,

--- a/frontend/src/plugins/gtd/classification.js
+++ b/frontend/src/plugins/gtd/classification.js
@@ -1,10 +1,19 @@
-export async function classifyWithUndo(messageId, state, {
+import {
+  invalidateGtdMetadata,
+  patchGtdMetadata,
+  removeGtdMetadataState,
+} from './metadataStore.js';
+
+export async function classifyWithUndo(message, state, {
   api,
   store,
   t,
 }) {
+  const messageId = typeof message === 'string' ? message : message?.id;
   try {
     const result = await api.gtdClassify(messageId, state);
+    patchGtdMetadata(message, state, typeof message === 'object' ? message.date : null);
+    invalidateGtdMetadata();
     store.scheduleGtdSectionsFetch();
 
     const notification = {
@@ -20,6 +29,8 @@ export async function classifyWithUndo(messageId, state, {
         consumed = true;
         try {
           await api.gtdUndoClassify(result.undoToken);
+          removeGtdMetadataState(message, state);
+          invalidateGtdMetadata();
           store.scheduleGtdSectionsFetch();
           return true;
         } catch (err) {

--- a/frontend/src/plugins/gtd/classification.test.js
+++ b/frontend/src/plugins/gtd/classification.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { classifyWithUndo, undoLatestGtdNotification } from './classification.js';
+import { getGtdMetadata, getGtdMetadataRefreshGeneration } from './metadataStore.js';
 
 function createHarness(classifyResult = {}) {
   const notifications = [];
@@ -86,6 +87,51 @@ describe('classifyWithUndo', () => {
     assert.equal(harness.calls.refresh, 0);
     assert.equal(harness.notifications[0].type, 'error');
     assert.equal(harness.notifications[0].title, 'gtd.classifyFailed');
+  });
+
+  it('optimistically patches metadata for the classified visible message', async () => {
+    const message = {
+      id: 'metadata-message',
+      date: '2026-08-04T00:00:00.000Z',
+    };
+    const harness = createHarness({ ok: true, applied: true, undoToken: null });
+
+    const refreshBefore = getGtdMetadataRefreshGeneration();
+    await classifyWithUndo(message, 'reference', harness);
+
+    assert.deepEqual(harness.calls.classify, [[message.id, 'reference']]);
+    assert.deepEqual(getGtdMetadata(message.id), {
+      states: ['reference'],
+      dates: { reference: message.date },
+      date: message.date,
+    });
+    assert.equal(getGtdMetadataRefreshGeneration(), refreshBefore + 1);
+  });
+
+  it('removes the optimistic state after a successful undo', async () => {
+    const message = {
+      id: 'metadata-undo-message',
+      date: '2026-08-05T00:00:00.000Z',
+    };
+    const harness = createHarness({
+      ok: true,
+      applied: true,
+      undoToken: {
+        messageId: message.id,
+        state: 'todo',
+        folder: 'GTD/Todo',
+        uid: 904,
+      },
+    });
+
+    const refreshBefore = getGtdMetadataRefreshGeneration();
+    await classifyWithUndo(message, 'todo', harness);
+    assert.deepEqual(getGtdMetadata(message.id)?.states, ['todo']);
+
+    await harness.notifications[0].onUndo();
+
+    assert.equal(getGtdMetadata(message.id), null);
+    assert.equal(getGtdMetadataRefreshGeneration(), refreshBefore + 2);
   });
 });
 

--- a/frontend/src/plugins/gtd/index.jsx
+++ b/frontend/src/plugins/gtd/index.jsx
@@ -14,6 +14,9 @@ import { buildGtdContextItems } from './GtdContextMenu.jsx';
 import { gtdActiveForContext } from '../../utils/gtd.js';
 import { accountAffectsUnifiedInbox } from '../../utils/unifiedInbox.js';
 import { useStore } from '../../store/index.js';
+import GtdInboxIndicators from './GtdInboxIndicators.jsx';
+import { shouldShowInboxGtdMetadata } from './indicators.js';
+import { invalidateGtdMetadata } from './metadataStore.js';
 
 // Right-sidebar panel: GTD's triage rail. Live when GTD is on for the current account scope
 // (per-user activation is already checked by the slot registry, so pass `true` here).
@@ -54,6 +57,16 @@ registerSlot('row-hover-action', {
   render: (ctx) => <GtdRowDone message={ctx.message} done={ctx.done} />,
 });
 
+registerSlot('message-row-meta', {
+  pluginId: 'gtd',
+  isActive: (ctx) => {
+    const store = useStore.getState();
+    return gtdActiveForContext(store.accounts, ctx.message.account_id, true)
+      && shouldShowInboxGtdMetadata(store);
+  },
+  render: (ctx) => <GtdInboxIndicators message={ctx.message} />,
+});
+
 // WS: a GTD label folder changed (tick / classify copy-remove / transition strip). Refetch the
 // rail+tab sections when the event's account is in the current rail scope (debounced in the store).
 registerWsHandler('gtd_sections_updated', {
@@ -65,6 +78,7 @@ registerWsHandler('gtd_sections_updated', {
       store.selectedAccountId === data.accountId
     ) {
       store.scheduleGtdSectionsFetch();
+      invalidateGtdMetadata();
     }
   },
 });
@@ -76,6 +90,9 @@ registerReconnectHandler({
   pluginId: 'gtd',
   handler: () => {
     const { accounts, selectedAccountId, scheduleGtdSectionsFetch } = useStore.getState();
-    if (gtdActiveForContext(accounts, selectedAccountId, true)) scheduleGtdSectionsFetch();
+    if (gtdActiveForContext(accounts, selectedAccountId, true)) {
+      scheduleGtdSectionsFetch();
+      invalidateGtdMetadata();
+    }
   },
 });

--- a/frontend/src/plugins/gtd/indicators.js
+++ b/frontend/src/plugins/gtd/indicators.js
@@ -1,0 +1,49 @@
+const STATE_ORDER = ['todo', 'watch', 'delegated', 'reference', 'someday'];
+const WAITING_STATES = new Set(['watch', 'delegated']);
+const STALE_DAYS = 14;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const COLORS = {
+  todo: '#4A9EDD',
+  watch: '#D9B430',
+  delegated: '#E08B3D',
+  reference: '#7157d9',
+  someday: 'var(--text-tertiary)',
+};
+
+const BACKGROUNDS = {
+  todo: 'rgba(74,158,221,0.16)',
+  watch: 'rgba(217,180,48,0.15)',
+  delegated: 'rgba(224,139,61,0.15)',
+  reference: 'rgba(113,87,217,0.16)',
+  someday: 'rgba(139,139,155,0.16)',
+};
+
+export function shouldShowInboxGtdMetadata({ selectedFolder, searchQuery }) {
+  return Boolean(searchQuery?.trim()) || selectedFolder === 'INBOX';
+}
+
+function wholeDays(date, now) {
+  const timestamp = new Date(date).getTime();
+  if (!date || !Number.isFinite(timestamp)) return null;
+  return Math.max(0, Math.floor((now - timestamp) / DAY_MS));
+}
+
+export function buildInboxGtdIndicators(metadata, t, now = Date.now()) {
+  if (!Array.isArray(metadata?.states)) return [];
+  const states = new Set(metadata.states.filter(state => STATE_ORDER.includes(state)));
+  return STATE_ORDER.filter(state => states.has(state)).map(state => {
+    const waiting = WAITING_STATES.has(state);
+    const hasStateDate = Object.hasOwn(metadata.dates || {}, state);
+    const stateDate = hasStateDate ? metadata.dates[state] : metadata.date;
+    const days = waiting ? wholeDays(stateDate, now) : null;
+    const stale = waiting && days != null && days > STALE_DAYS;
+    return {
+      state,
+      label: waiting && days != null ? `⏱ ${days}d` : t(`gtd.state.${state}`),
+      stale,
+      color: stale ? '#ff9b9b' : COLORS[state],
+      background: stale ? 'rgba(248,113,113,.16)' : BACKGROUNDS[state],
+    };
+  });
+}

--- a/frontend/src/plugins/gtd/indicators.test.js
+++ b/frontend/src/plugins/gtd/indicators.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildInboxGtdIndicators, shouldShowInboxGtdMetadata } from './indicators.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse('2026-08-20T00:00:00.000Z');
+const t = key => key;
+
+describe('buildInboxGtdIndicators', () => {
+  it('deduplicates valid states into canonical display order', () => {
+    const result = buildInboxGtdIndicators({
+      states: ['someday', 'watch', 'todo', 'watch', 'reference', 'delegated'],
+      dates: {},
+      date: null,
+    }, t, NOW);
+
+    assert.deepEqual(result.map(item => item.state), ['todo', 'watch', 'delegated', 'reference', 'someday']);
+    assert.equal(result[0].label, 'gtd.state.todo');
+  });
+
+  it('shows whole-day aging for waiting states and turns stale after 14 days', () => {
+    const fourteen = new Date(NOW - 14 * DAY).toISOString();
+    const fifteen = new Date(NOW - 15 * DAY).toISOString();
+    const result = buildInboxGtdIndicators({
+      states: ['watch', 'delegated'],
+      dates: { watch: fourteen, delegated: fifteen },
+      date: fifteen,
+    }, t, NOW);
+
+    assert.deepEqual(result.map(item => ({ state: item.state, label: item.label, stale: item.stale })), [
+      { state: 'watch', label: '⏱ 14d', stale: false },
+      { state: 'delegated', label: '⏱ 15d', stale: true },
+    ]);
+    assert.notEqual(result[0].color, result[1].color);
+  });
+
+  it('uses a ten-day aging label without marking the waiting state stale', () => {
+    const result = buildInboxGtdIndicators({
+      states: ['watch'],
+      dates: { watch: new Date(NOW - 10 * DAY).toISOString() },
+    }, t, NOW);
+    assert.equal(result[0].label, '⏱ 10d');
+    assert.equal(result[0].stale, false);
+  });
+
+  it('preserves an explicit unknown waiting date instead of borrowing another state date', () => {
+    const result = buildInboxGtdIndicators({
+      states: ['watch', 'todo'],
+      dates: { watch: null, todo: new Date(NOW - 20 * DAY).toISOString() },
+      date: new Date(NOW - 20 * DAY).toISOString(),
+    }, t, NOW);
+
+    assert.equal(result.find(item => item.state === 'watch').label, 'gtd.state.watch');
+    assert.equal(result.find(item => item.state === 'watch').stale, false);
+  });
+
+  it('returns no indicators for malformed metadata', () => {
+    assert.deepEqual(buildInboxGtdIndicators(null, t, NOW), []);
+    assert.deepEqual(buildInboxGtdIndicators({ states: 'todo' }, t, NOW), []);
+    assert.deepEqual(buildInboxGtdIndicators({ states: ['invalid'] }, t, NOW), []);
+  });
+});
+
+describe('shouldShowInboxGtdMetadata', () => {
+  it('shows metadata in Inbox and active search results only', () => {
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'INBOX', searchQuery: '' }), true);
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'Sent', searchQuery: 'casey' }), true);
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'Sent', searchQuery: '' }), false);
+    assert.equal(shouldShowInboxGtdMetadata({ selectedFolder: 'Trash', searchQuery: '   ' }), false);
+  });
+});

--- a/frontend/src/plugins/gtd/metadataStore.js
+++ b/frontend/src/plugins/gtd/metadataStore.js
@@ -1,0 +1,148 @@
+const STATE_ORDER = ['todo', 'watch', 'delegated', 'reference', 'someday'];
+const metadata = new Map();
+const listeners = new Set();
+const refreshListeners = new Set();
+let requestGeneration = 0;
+let refreshGeneration = 0;
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeGtdMetadata(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getGtdMetadata(messageId) {
+  return metadata.get(messageId) ?? null;
+}
+
+export function subscribeGtdMetadataRefresh(listener) {
+  refreshListeners.add(listener);
+  return () => refreshListeners.delete(listener);
+}
+
+export function getGtdMetadataRefreshGeneration() {
+  return refreshGeneration;
+}
+
+export function invalidateGtdMetadata() {
+  requestGeneration += 1;
+  refreshGeneration += 1;
+  for (const listener of refreshListeners) listener();
+}
+
+export async function fetchVisibleGtdMetadata(messages, { api }) {
+  const generation = ++requestGeneration;
+  const idsByAccount = new Map();
+  for (const message of messages || []) {
+    if (!message?.id || !message.account_id) continue;
+    if (!idsByAccount.has(message.account_id)) idsByAccount.set(message.account_id, new Set());
+    idsByAccount.get(message.account_id).add(message.id);
+  }
+
+  const batches = [];
+  for (const [accountId, idSet] of idsByAccount) {
+    const ids = [...idSet];
+    for (let offset = 0; offset < ids.length; offset += 100) {
+      const chunk = ids.slice(offset, offset + 100);
+      let request;
+      try {
+        request = Promise.resolve(api.gtdMetadata(accountId, chunk));
+      } catch (error) {
+        request = Promise.reject(error);
+      }
+      batches.push({
+        ids: chunk,
+        request,
+      });
+    }
+  }
+  const responses = await Promise.allSettled(batches.map(batch => batch.request));
+  if (generation !== requestGeneration) return 'stale';
+
+  let failed = false;
+  for (const [index, response] of responses.entries()) {
+    if (response.status === 'rejected') {
+      failed = true;
+      continue;
+    }
+    const fresh = new Map(Object.entries(response.value?.messages || {}));
+    for (const id of batches[index].ids) {
+      if (fresh.has(id)) metadata.set(id, fresh.get(id));
+      else metadata.delete(id);
+    }
+  }
+  emit();
+  return failed ? 'partial' : 'complete';
+}
+
+export function startGtdMetadataFetch(messages, {
+  api,
+  delay = 2000,
+  schedule = setTimeout,
+  cancelSchedule = clearTimeout,
+  onError = error => console.error('GTD metadata fetch failed:', error),
+}) {
+  let cancelled = false;
+  let retryTimer;
+  const fetchMetadata = async (allowRetry) => {
+    if (cancelled) return;
+    try {
+      const status = await fetchVisibleGtdMetadata(messages, { api });
+      if (!cancelled && status === 'partial' && allowRetry) {
+        retryTimer = schedule(() => { void fetchMetadata(false); }, delay);
+      }
+    } catch (error) {
+      if (!cancelled) onError(error);
+    }
+  };
+  void fetchMetadata(true);
+  return () => {
+    cancelled = true;
+    if (retryTimer !== undefined) cancelSchedule(retryTimer);
+  };
+}
+
+export function patchGtdMetadata(message, state, date) {
+  const messageId = typeof message === 'string' ? message : message?.id;
+  if (!messageId || !STATE_ORDER.includes(state)) return;
+  const current = metadata.get(messageId) || { states: [], dates: {}, date: null };
+  const states = [...new Set([...current.states, state])]
+    .sort((a, b) => STATE_ORDER.indexOf(a) - STATE_ORDER.indexOf(b));
+  const dates = { ...current.dates };
+  if (!(state in dates)) dates[state] = date ?? null;
+  const dated = Object.values(dates).filter(Boolean).sort();
+  metadata.set(messageId, {
+    ...current,
+    states,
+    dates,
+    date: dated.at(-1) ?? null,
+  });
+  requestGeneration += 1;
+  emit();
+}
+
+export function removeGtdMetadataState(message, state) {
+  const messageId = typeof message === 'string' ? message : message?.id;
+  const current = messageId ? metadata.get(messageId) : null;
+  if (!current?.states?.includes(state)) return;
+
+  const states = current.states.filter(item => item !== state);
+  if (states.length === 0) {
+    metadata.delete(messageId);
+  } else {
+    const dates = { ...current.dates };
+    delete dates[state];
+    const dated = Object.values(dates).filter(Boolean).sort();
+    metadata.set(messageId, {
+      ...current,
+      states,
+      dates,
+      date: dated.at(-1) ?? null,
+    });
+  }
+  requestGeneration += 1;
+  emit();
+}

--- a/frontend/src/plugins/gtd/metadataStore.test.js
+++ b/frontend/src/plugins/gtd/metadataStore.test.js
@@ -1,0 +1,170 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  fetchVisibleGtdMetadata,
+  getGtdMetadata,
+  getGtdMetadataRefreshGeneration,
+  invalidateGtdMetadata,
+  patchGtdMetadata,
+  startGtdMetadataFetch,
+  subscribeGtdMetadataRefresh,
+} from './metadataStore.js';
+
+const A1 = 'account-1';
+const A2 = 'account-2';
+const M1 = '11111111-1111-4111-8111-111111111111';
+const M2 = '22222222-2222-4222-8222-222222222222';
+const flushMicrotasks = async () => {
+  for (let index = 0; index < 4; index += 1) await Promise.resolve();
+};
+
+describe('fetchVisibleGtdMetadata', () => {
+  it('groups by account, deduplicates, and chunks requests at 100 ids', async () => {
+    const calls = [];
+    const messages = Array.from({ length: 101 }, (_, i) => ({ id: `m-${i}`, account_id: A1 }));
+    messages.push(messages[0], { id: M2, account_id: A2 });
+    const api = { gtdMetadata: async (accountId, ids) => {
+      calls.push([accountId, ids]);
+      return { messages: {} };
+    } };
+
+    await fetchVisibleGtdMetadata(messages, { api });
+
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls.map(([accountId, ids]) => [accountId, ids.length]), [
+      [A1, 100], [A1, 1], [A2, 1],
+    ]);
+  });
+
+  it('ignores a slow response superseded by a newer fetch', async () => {
+    let resolveSlow;
+    const slowApi = { gtdMetadata: () => new Promise(resolve => { resolveSlow = resolve; }) };
+    const fastApi = { gtdMetadata: async () => ({ messages: {
+      [M1]: { states: ['watch'], dates: { watch: '2026-08-01T00:00:00.000Z' }, date: '2026-08-01T00:00:00.000Z' },
+    } }) };
+
+    const slow = fetchVisibleGtdMetadata([{ id: M1, account_id: A1 }], { api: slowApi });
+    await fetchVisibleGtdMetadata([{ id: M1, account_id: A1 }], { api: fastApi });
+    resolveSlow({ messages: {
+      [M1]: { states: ['todo'], dates: { todo: '2026-07-01T00:00:00.000Z' }, date: '2026-07-01T00:00:00.000Z' },
+    } });
+    await slow;
+
+    assert.deepEqual(getGtdMetadata(M1).states, ['watch']);
+  });
+
+  it('clears cached labels omitted by a fresh response', async () => {
+    patchGtdMetadata(M2, 'todo', '2026-08-01T00:00:00.000Z');
+    await fetchVisibleGtdMetadata([{ id: M2, account_id: A1 }], {
+      api: { gtdMetadata: async () => ({ messages: {} }) },
+    });
+    assert.equal(getGtdMetadata(M2), null);
+  });
+
+  it('applies successful account responses without clearing data from a failed request', async () => {
+    patchGtdMetadata(M2, 'todo', '2026-08-01T00:00:00.000Z');
+    const result = await fetchVisibleGtdMetadata([
+      { id: M1, account_id: A1 },
+      { id: M2, account_id: A2 },
+    ], {
+      api: { gtdMetadata: async (accountId) => {
+        if (accountId === A2) throw new Error('account offline');
+        return { messages: {
+          [M1]: { states: ['watch'], dates: { watch: '2026-08-02T00:00:00.000Z' }, date: '2026-08-02T00:00:00.000Z' },
+        } };
+      } },
+    });
+
+    assert.equal(result, 'partial');
+    assert.deepEqual(getGtdMetadata(M1)?.states, ['watch']);
+    assert.deepEqual(getGtdMetadata(M2)?.states, ['todo']);
+  });
+
+  it('does not let an older fetch overwrite an optimistic classification', async () => {
+    const id = 'optimistic-race-message';
+    let resolveFetch;
+    const pending = fetchVisibleGtdMetadata([{ id, account_id: A1 }], {
+      api: { gtdMetadata: () => new Promise(resolve => { resolveFetch = resolve; }) },
+    });
+
+    patchGtdMetadata(id, 'todo', '2026-08-04T00:00:00.000Z');
+    resolveFetch({ messages: {} });
+
+    assert.equal(await pending, 'stale');
+    assert.deepEqual(getGtdMetadata(id)?.states, ['todo']);
+  });
+});
+
+describe('startGtdMetadataFetch', () => {
+  it('does not schedule a late partial retry after cancellation', async () => {
+    let rejectRequest;
+    const scheduled = [];
+    const cancel = startGtdMetadataFetch([{ id: M1, account_id: A1 }], {
+      api: { gtdMetadata: () => new Promise((_resolve, reject) => { rejectRequest = reject; }) },
+      schedule: callback => { scheduled.push(callback); return callback; },
+      cancelSchedule: () => {},
+      onError: () => {},
+    });
+
+    cancel();
+    rejectRequest(new Error('offline'));
+    await flushMicrotasks();
+
+    assert.equal(scheduled.length, 0);
+  });
+
+  it('schedules at most one retry for a partial response', async () => {
+    const scheduled = [];
+    let calls = 0;
+    const cancel = startGtdMetadataFetch([{ id: M1, account_id: A1 }], {
+      api: { gtdMetadata: async () => { calls += 1; throw new Error('offline'); } },
+      schedule: callback => { scheduled.push(callback); return callback; },
+      cancelSchedule: () => {},
+      onError: () => {},
+    });
+    await flushMicrotasks();
+
+    assert.equal(scheduled.length, 1);
+    scheduled[0]();
+    await flushMicrotasks();
+
+    assert.equal(calls, 2);
+    assert.equal(scheduled.length, 1);
+    cancel();
+  });
+});
+
+describe('invalidateGtdMetadata', () => {
+  it('advances the refresh generation and notifies runtime subscribers', () => {
+    const before = getGtdMetadataRefreshGeneration();
+    let calls = 0;
+    const unsubscribe = subscribeGtdMetadataRefresh(() => { calls += 1; });
+
+    invalidateGtdMetadata();
+    unsubscribe();
+    invalidateGtdMetadata();
+
+    assert.equal(getGtdMetadataRefreshGeneration(), before + 2);
+    assert.equal(calls, 1);
+  });
+});
+
+describe('patchGtdMetadata', () => {
+  it('inserts states canonically without overwriting older state dates', () => {
+    const id = 'patch-message';
+    patchGtdMetadata(id, 'someday', '2026-08-03T00:00:00.000Z');
+    patchGtdMetadata(id, 'watch', '2026-08-02T00:00:00.000Z');
+    patchGtdMetadata(id, 'todo', '2026-08-01T00:00:00.000Z');
+    patchGtdMetadata(id, 'watch', '2026-08-09T00:00:00.000Z');
+
+    assert.deepEqual(getGtdMetadata(id), {
+      states: ['todo', 'watch', 'someday'],
+      dates: {
+        todo: '2026-08-01T00:00:00.000Z',
+        watch: '2026-08-02T00:00:00.000Z',
+        someday: '2026-08-03T00:00:00.000Z',
+      },
+      date: '2026-08-03T00:00:00.000Z',
+    });
+  });
+});

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -399,6 +399,7 @@ export const api = {
     return request('GET', `/gtd/sections${qs ? '?' + qs : ''}`);
   },
   gtdClassify: (messageId, state) => request('POST', '/gtd/classify', { messageId, state }),
+  gtdMetadata: (accountId, messageIds) => request('POST', '/gtd/metadata', { accountId, messageIds }),
   gtdUndoClassify: (undoToken) => request('POST', '/gtd/classify/undo', undoToken),
   gtdUnclassify: (messageId, state) => request('DELETE', '/gtd/classify', { messageId, state }),
   // GTD "done": strip the row's label(s) for these states, mark read, archive the INBOX

--- a/frontend/src/utils/gtd.js
+++ b/frontend/src/utils/gtd.js
@@ -572,9 +572,11 @@ export async function unclassifyThread(id, state, { gtdUnclassify, addNotificati
     await gtdUnclassify(id, state);
     scheduleGtdSectionsFetch();
     addNotification({ title: t('gtd.removed'), body: t(`gtd.state.${state}`) });
+    return true;
   } catch (err) {
     console.error('GTD unclassify failed:', err.message);
     addNotification({ title: t('gtd.removeFailed'), body: t(`gtd.state.${state}`) });
+    return false;
   }
 }
 

--- a/frontend/src/utils/gtd.test.js
+++ b/frontend/src/utils/gtd.test.js
@@ -1211,7 +1211,8 @@ describe('unclassifyThread', () => {
       scheduleGtdSectionsFetch: () => calls.push(['schedule']),
       t,
     };
-    await unclassifyThread('m1', 'todo', deps);
+    const removed = await unclassifyThread('m1', 'todo', deps);
+    assert.equal(removed, true);
     assert.deepEqual(calls, [
       ['unclassify', 'm1', 'todo'],
       ['schedule'],
@@ -1227,7 +1228,8 @@ describe('unclassifyThread', () => {
       scheduleGtdSectionsFetch: () => calls.push(['schedule']),
       t,
     };
-    await unclassifyThread('m1', 'todo', deps);
+    const removed = await unclassifyThread('m1', 'todo', deps);
+    assert.equal(removed, false);
     assert.deepEqual(calls, [['notify', 'gtd.removeFailed', 'gtd.state.todo']]);
   });
 });

--- a/frontend/src/utils/gtdDone.js
+++ b/frontend/src/utils/gtdDone.js
@@ -9,6 +9,7 @@ export async function doneGtdRow(thread, states, {
   removeGtdThread,
   restoreGtdThread,
   addNotification,
+  invalidateGtdMetadata,
   scheduleGtdSectionsFetch,
   t,
 }) {
@@ -19,6 +20,7 @@ export async function doneGtdRow(thread, states, {
   try {
     const result = await gtdDone(thread.id, states);
     setCompletedGtdRemoval(identity, states);
+    invalidateGtdMetadata?.();
     if (result?.archiveFailed) {
       addNotification({ title: t('gtd.doneArchiveFailed'), body: thread.subject || t('common.noSubject') });
     }

--- a/frontend/src/utils/gtdDone.test.js
+++ b/frontend/src/utils/gtdDone.test.js
@@ -99,4 +99,14 @@ describe('doneGtdRow', () => {
     ]);
     assert.equal(completedGtdRemovalMap.size, 1);
   });
+
+  it('invalidates visible GTD metadata after a successful mutation', async () => {
+    const calls = [];
+    await doneGtdRow(thread, states, deps({
+      invalidateGtdMetadata: () => calls.push('invalidate'),
+      scheduleGtdSectionsFetch: () => calls.push('schedule'),
+    }));
+
+    assert.deepEqual(calls, ['invalidate', 'schedule']);
+  });
 });


### PR DESCRIPTION
## Summary

Ports the backend half of delegated-contact GTD state from closed PR #343 onto the plugin boundary described in #368. A caller can now label one or more owned threads as Delegated and attach a durable contact snapshot without adding a GTD table, migration, or command-engine dependency.

This PR is stacked on #371 and includes that predecessor commit until it lands.

## Changes

- Add `POST /api/gtd/delegations` for 1–100 unique, owned message IDs and an owned contact or `null`.
- Store contact details and a durable delegation boundary under `messages.plugin_annotations.gtd.delegation` on every live row in the thread.
- Serialize delegation, transition, and cleanup work per account and thread so concurrent requests cannot create duplicate copies or undo a successful explicit delegation.
- Reconcile non-UIDPLUS copies through one fresh destination sync and a strict UID set difference. Ambiguous outcomes are reported without guessing.
- Compensate annotation failures only when this request can identify the exact label copy it created. Pre-existing labels are never removed.
- Inherit delegation snapshots onto newly synced rows and clear them only after the final Delegated copy disappears.
- Keep personless delegation public metadata unchanged while retaining the internal boundary needed to distinguish an older message from a newer reply.

Blocked by #371.

Refs #343 and #368

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
