### PR TITLE
fix: preserve mail sync and GTD thread integrity

### DIFF
--- a/backend/migrations/0051_folder_backfill_incomplete.sql
+++ b/backend/migrations/0051_folder_backfill_incomplete.sql
@@ -1,0 +1,26 @@
+ALTER TABLE folders
+  ADD COLUMN IF NOT EXISTS backfill_incomplete BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS metadata_complete BOOLEAN NOT NULL DEFAULT true;
+
+-- Rows created from UID-only FETCH records before the envelope guard have this exact
+-- manufactured shape. Hide and re-fetch them; a legitimate all-NIL envelope is marked
+-- complete by the guarded upsert after verification.
+UPDATE messages
+   SET metadata_complete = false
+ WHERE message_id IS NULL
+   AND subject = '(no subject)'
+   AND COALESCE(snippet, '') = '';
+
+-- Every existing folder starts pending an exact UID verification pass. Complete rows remain in
+-- the diff set, so only legacy hollow rows (metadata_complete=false) are fetched again. Runtime
+-- backfill clears this marker without fetching for intentional provider skip views.
+UPDATE folders f
+   SET backfill_incomplete = true,
+       total_count = (SELECT COUNT(*) FROM messages m
+                       WHERE m.account_id = f.account_id AND m.folder = f.path
+                         AND m.is_deleted = false AND m.metadata_complete = true),
+       unread_count = (SELECT COUNT(*) FILTER (WHERE NOT m.is_read) FROM messages m
+                        WHERE m.account_id = f.account_id AND m.folder = f.path
+                          AND m.is_deleted = false AND m.metadata_complete = true);

--- a/backend/migrations/0052_folder_observation_generation.sql
+++ b/backend/migrations/0052_folder_observation_generation.sql
@@ -1,0 +1,68 @@
+ALTER TABLE folders
+  ADD COLUMN IF NOT EXISTS observation_generation BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS is_present BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS topology_identity UUID NOT NULL DEFAULT gen_random_uuid();
+
+ALTER TABLE email_accounts
+  ADD COLUMN IF NOT EXISTS mailbox_topology_generation BIGINT NOT NULL DEFAULT 0;
+
+-- Bind legacy snoozes while the last known folder/message identities are still actionable.
+-- The quarantine below deliberately invalidates every historical folder observation, so this
+-- exact, unambiguous association must happen before that reset. Headerless, ambiguous, or
+-- already-unverified rows remain nullable for manual reconciliation.
+ALTER TABLE snoozed_messages
+  ADD COLUMN message_row_id UUID REFERENCES messages(id) ON DELETE SET NULL,
+  ADD COLUMN resolution_state TEXT NOT NULL DEFAULT 'active'
+    CHECK (resolution_state IN ('active', 'manual_intervention')),
+  ADD COLUMN resolution_error JSONB;
+
+WITH candidate_message_rows AS (
+  SELECT sm.id AS snooze_id, m.id AS message_row_id,
+         COUNT(*) OVER (PARTITION BY sm.id) AS match_count
+    FROM snoozed_messages sm
+    JOIN messages m ON m.account_id = sm.account_id
+                   AND m.message_id = sm.message_id_header
+                   AND m.folder = sm.snoozed_folder
+                   AND m.is_deleted = false
+                   AND m.metadata_complete = true
+    JOIN folders f ON f.account_id = m.account_id
+                  AND f.path = m.folder
+                  AND f.is_present = true
+                  AND f.uid_validity IS NOT NULL
+   WHERE sm.message_row_id IS NULL
+     AND sm.resolution_state = 'active'
+), unique_message_rows AS (
+  SELECT snooze_id, message_row_id
+    FROM candidate_message_rows
+   WHERE match_count = 1
+)
+UPDATE snoozed_messages sm
+   SET message_row_id = unique_message_rows.message_row_id
+  FROM unique_message_rows
+ WHERE sm.id = unique_message_rows.snooze_id;
+
+CREATE INDEX snoozed_messages_message_row_idx
+  ON snoozed_messages (message_row_id)
+  WHERE message_row_id IS NOT NULL;
+
+-- Historical rows have not yet been confirmed by a complete post-rollout LIST.
+UPDATE folders
+   SET is_present = false,
+       uid_validity = NULL,
+       highest_modseq = NULL,
+       observation_generation = observation_generation + 1,
+       topology_identity = gen_random_uuid();
+
+-- A message is actionable only when its provider folder identity is known. Existing
+-- orphaned rows and rows from an unknown UID epoch are retained for reconciliation,
+-- but quarantined from every normal read/mutation surface.
+UPDATE messages m
+   SET metadata_complete = false
+ WHERE NOT EXISTS (
+   SELECT 1
+     FROM folders f
+    WHERE f.account_id = m.account_id
+      AND f.path = m.folder
+      AND f.is_present = true
+      AND f.uid_validity IS NOT NULL
+ );

--- a/backend/migrations/0053_provider_operations.sql
+++ b/backend/migrations/0053_provider_operations.sql
@@ -1,0 +1,33 @@
+CREATE TABLE provider_operations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  operation_key TEXT NOT NULL UNIQUE,
+  account_id UUID NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL CHECK (kind IN ('move', 'copy', 'append')),
+  state TEXT NOT NULL DEFAULT 'ready'
+    CHECK (state IN (
+      'ready', 'provider_started', 'provider_applied', 'completed', 'manual_intervention'
+    )),
+  marker TEXT NOT NULL UNIQUE,
+  source_folder VARCHAR(500),
+  source_uid BIGINT,
+  destination_folder VARCHAR(500) NOT NULL,
+  source_observation JSONB,
+  destination_observation JSONB NOT NULL,
+  attempt_generation BIGINT NOT NULL DEFAULT 0,
+  attempt_owner UUID,
+  receipt JSONB,
+  uncertainty JSONB,
+  marker_cleanup_state TEXT NOT NULL DEFAULT 'pending'
+    CHECK (marker_cleanup_state IN ('pending', 'completed')),
+  marker_cleanup_error JSONB,
+  marker_cleanup_completed_at TIMESTAMPTZ,
+  provider_started_at TIMESTAMPTZ,
+  provider_applied_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX provider_operations_recovery_idx
+  ON provider_operations (state, updated_at)
+  WHERE state IN ('provider_started', 'provider_applied');

--- a/backend/migrations/0054_desired_message_flags.sql
+++ b/backend/migrations/0054_desired_message_flags.sql
@@ -1,0 +1,32 @@
+ALTER TABLE messages
+  ADD COLUMN IF NOT EXISTS read_revision BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS star_revision BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS provider_modseq NUMERIC(20,0);
+
+CREATE TABLE message_flag_deliveries (
+  message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+  flag TEXT NOT NULL CHECK (flag IN ('read', 'star')),
+  account_id UUID NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  folder VARCHAR(500) NOT NULL,
+  uid BIGINT NOT NULL,
+  uid_validity BIGINT NOT NULL,
+  folder_generation BIGINT NOT NULL,
+  revision BIGINT NOT NULL,
+  desired_value BOOLEAN NOT NULL,
+  state TEXT NOT NULL DEFAULT 'pending'
+    CHECK (state IN ('pending', 'delivering', 'uncertain', 'confirmed')),
+  captured_modseq NUMERIC(20,0),
+  condstore BOOLEAN,
+  uncertainty_tombstones JSONB NOT NULL DEFAULT '[]'::jsonb,
+  attempt_generation BIGINT NOT NULL DEFAULT 0,
+  attempt_owner UUID,
+  provider_started_at TIMESTAMPTZ,
+  confirmed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (message_id, flag)
+);
+
+CREATE INDEX message_flag_deliveries_reconcile_idx
+  ON message_flag_deliveries (state, updated_at)
+  WHERE state IN ('pending', 'delivering', 'uncertain');

--- a/backend/migrations/0055_desired_flag_leases.sql
+++ b/backend/migrations/0055_desired_flag_leases.sql
@@ -1,0 +1,7 @@
+ALTER TABLE message_flag_deliveries
+  ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ;
+
+DROP INDEX IF EXISTS message_flag_deliveries_reconcile_idx;
+CREATE INDEX message_flag_deliveries_reconcile_idx
+  ON message_flag_deliveries (state, lease_expires_at, updated_at)
+  WHERE state IN ('pending', 'delivering', 'uncertain');

--- a/backend/migrations/0056_provider_delete_operations.sql
+++ b/backend/migrations/0056_provider_delete_operations.sql
@@ -1,0 +1,6 @@
+ALTER TABLE provider_operations
+  DROP CONSTRAINT provider_operations_kind_check;
+
+ALTER TABLE provider_operations
+  ADD CONSTRAINT provider_operations_kind_check
+  CHECK (kind IN ('move', 'copy', 'append', 'delete'));

--- a/backend/migrations/0057_send_operations.sql
+++ b/backend/migrations/0057_send_operations.sql
@@ -1,0 +1,29 @@
+CREATE TABLE send_operations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  operation_key VARCHAR(128) NOT NULL,
+  payload_digest CHAR(64) NOT NULL,
+  state VARCHAR(24) NOT NULL DEFAULT 'ready'
+    CHECK (state IN ('ready', 'provider_started', 'provider_applied', 'completed', 'uncertain')),
+  message_id TEXT,
+  sent_folder TEXT,
+  sent_metadata JSONB,
+  raw_message BYTEA,
+  server_auto_saves BOOLEAN,
+  smtp_message BYTEA,
+  smtp_envelope JSONB,
+  prepared_payload_digest CHAR(64),
+  source_snapshots JSONB,
+  response JSONB,
+  prepared_at TIMESTAMPTZ,
+  provider_started_at TIMESTAMPTZ,
+  provider_applied_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, operation_key)
+);
+
+CREATE INDEX send_operations_pending_idx
+  ON send_operations (state, updated_at)
+  WHERE state IN ('provider_started', 'provider_applied', 'uncertain');

--- a/backend/migrations/0058_rule_forward_lifecycle.sql
+++ b/backend/migrations/0058_rule_forward_lifecycle.sql
@@ -1,0 +1,21 @@
+ALTER TABLE inbox_rule_forwards
+  DROP CONSTRAINT inbox_rule_forwards_status_check;
+
+-- Legacy `pending` covered the entire SMTP call. A surviving row may therefore mean DATA was
+-- accepted and only the success write crashed; it is never safe to make these rows retryable.
+UPDATE inbox_rule_forwards SET status = 'uncertain' WHERE status = 'pending';
+
+ALTER TABLE inbox_rule_forwards
+  ADD COLUMN IF NOT EXISTS recipient TEXT,
+  ADD COLUMN IF NOT EXISTS payload_digest CHAR(64),
+  ADD COLUMN IF NOT EXISTS smtp_message BYTEA,
+  ADD COLUMN IF NOT EXISTS smtp_envelope JSONB,
+  ADD COLUMN IF NOT EXISTS source_snapshot JSONB,
+  ADD COLUMN IF NOT EXISTS prepared_at TIMESTAMPTZ;
+
+ALTER TABLE inbox_rule_forwards
+  ALTER COLUMN status SET DEFAULT 'ready';
+
+ALTER TABLE inbox_rule_forwards
+  ADD CONSTRAINT inbox_rule_forwards_status_check
+  CHECK (status IN ('ready', 'provider_started', 'sent', 'uncertain'));

--- a/backend/migrations/0059_gtd_done_operations.sql
+++ b/backend/migrations/0059_gtd_done_operations.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS gtd_done_operations (
+  operation_key TEXT PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  account_id UUID NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  acted_message_id UUID NOT NULL,
+  thread_key TEXT NOT NULL,
+  intent JSONB NOT NULL,
+  plan_digest TEXT NOT NULL,
+  plan JSONB NOT NULL,
+  phase TEXT NOT NULL CHECK (phase IN ('seen', 'archive', 'labels', 'completed')) DEFAULT 'seen',
+  item_index INTEGER NOT NULL DEFAULT 0 CHECK (item_index >= 0),
+  outcomes JSONB NOT NULL DEFAULT '[]'::jsonb,
+  response JSONB,
+  claim_owner UUID,
+  claim_expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  UNIQUE (operation_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gtd_done_operations_owner
+  ON gtd_done_operations (user_id, account_id, acted_message_id, updated_at DESC);

--- a/backend/migrations/0060_completed_operation_privacy.sql
+++ b/backend/migrations/0060_completed_operation_privacy.sql
@@ -1,0 +1,38 @@
+UPDATE send_operations
+   SET message_id = NULL,
+       sent_folder = NULL,
+       sent_metadata = NULL,
+       raw_message = NULL,
+       server_auto_saves = NULL,
+       smtp_message = NULL,
+       smtp_envelope = NULL,
+       prepared_payload_digest = NULL,
+       source_snapshots = NULL
+ WHERE state = 'completed';
+
+ALTER TABLE send_operations
+  ADD CONSTRAINT send_operations_completed_payload_redacted
+  CHECK (
+    state <> 'completed' OR (
+      message_id IS NULL AND sent_folder IS NULL AND sent_metadata IS NULL
+      AND raw_message IS NULL AND server_auto_saves IS NULL
+      AND smtp_message IS NULL AND smtp_envelope IS NULL
+      AND prepared_payload_digest IS NULL AND source_snapshots IS NULL
+    )
+  );
+
+UPDATE inbox_rule_forwards
+   SET recipient = NULL,
+       smtp_message = NULL,
+       smtp_envelope = NULL,
+       source_snapshot = NULL
+ WHERE status = 'sent';
+
+ALTER TABLE inbox_rule_forwards
+  ADD CONSTRAINT inbox_rule_forwards_sent_payload_redacted
+  CHECK (
+    status <> 'sent' OR (
+      recipient IS NULL AND smtp_message IS NULL
+      AND smtp_envelope IS NULL AND source_snapshot IS NULL
+    )
+  );

--- a/backend/migrations/0061_provider_operation_request_identity.sql
+++ b/backend/migrations/0061_provider_operation_request_identity.sql
@@ -1,0 +1,16 @@
+ALTER TABLE provider_operations
+  ADD COLUMN IF NOT EXISTS request_key TEXT,
+  ADD COLUMN IF NOT EXISTS source_message_id UUID;
+
+CREATE INDEX IF NOT EXISTS provider_operations_source_recovery_idx
+  ON provider_operations (account_id, source_message_id, updated_at DESC)
+  WHERE kind = 'move'
+    AND state IN ('provider_started', 'provider_applied', 'completed');
+
+CREATE INDEX IF NOT EXISTS provider_operations_request_replay_idx
+  ON provider_operations (account_id, request_key, updated_at DESC)
+  WHERE kind = 'move' AND state = 'completed';
+
+CREATE INDEX IF NOT EXISTS provider_operations_cleanup_pending_idx
+  ON provider_operations (updated_at, operation_key)
+  WHERE state = 'completed' AND marker_cleanup_state = 'pending';

--- a/backend/src/plugins/api.js
+++ b/backend/src/plugins/api.js
@@ -31,16 +31,30 @@ export { notifyOnLabelTouch } from '../services/labelsRead.js';
 // Apply/remove a label (a message copy in a label folder) and mark a thread read. The mail
 // engine is bound in by the platform (getMailEngine) so a plugin performs these mail actions
 // without ever holding the engine itself. resolveLabelCopyUid is pure (no engine).
-export const applyLabel = (account, message, labelFolder) => labelsWrite.applyLabel(getMailEngine(), account, message, labelFolder);
+export const applyLabel = (account, message, labelFolder, options) => labelsWrite.applyLabel(
+  getMailEngine(), account, message, labelFolder, options,
+);
 export const removeLabel = (message, labelFolder) => labelsWrite.removeLabel(getMailEngine(), message, labelFolder);
 export const removeExactLabelCopy = (message, labelFolder, uid) => labelsWrite.removeExactLabelCopy(getMailEngine(), message, labelFolder, uid);
+export const removeLabelRow = (message, options) => labelsWrite.removeLabelRow(getMailEngine(), message, options);
 export const markThreadRead = (account, message) => labelsWrite.markThreadRead(getMailEngine(), account, message);
+export const markThreadRowsRead = (account, rows) => labelsWrite.markThreadRowsRead(getMailEngine(), account, rows);
 export const ensureLabelFolders = (account, folderPaths) => labelsWrite.ensureLabelFolders(getMailEngine(), account, folderPaths);
 export const resolveLabelCopyUid = labelsWrite.resolveLabelCopyUid;
 
 // ── Archive ───────────────────────────────────────────────────────────────────
 // Archive a message's INBOX copy (used by GTD "done"). Engine bound by the platform.
-export const archiveInboxCopy = (account, inboxCopy) => _archiveInboxCopy(getMailEngine(), account, inboxCopy);
+export const archiveInboxCopy = (account, inboxCopy, options) => _archiveInboxCopy(
+  getMailEngine(), account, inboxCopy, options,
+);
+
+export {
+  createOrLoadGtdDoneOperation,
+  claimGtdDoneOperation,
+  renewGtdDoneOperation,
+  advanceGtdDoneOperation,
+  releaseGtdDoneOperation,
+} from '../services/gtdDoneOperations.js';
 
 // ── Realtime broadcast ────────────────────────────────────────────────────────
 // Push a payload to a specific user's live sessions. A plugin can notify its own clients; it
@@ -91,9 +105,12 @@ export {
   getThreadKeysInFolders,
   getThreadKeysForMessageIdHeaders,
   getMessagesByThreadKeys,
+  listLiveThreadRows,
   getThreadKeyForUid,
   getMessageCopyFolders,
   getMessageFields,
+  validateMessageFieldsSnapshot,
   getMessageAnnotations,
   setMessageAnnotation,
+  setMessageAnnotationForSnapshot,
 } from '../services/mailAccess.js';

--- a/backend/src/plugins/gtd/gtdDonePhases.js
+++ b/backend/src/plugins/gtd/gtdDonePhases.js
@@ -1,0 +1,184 @@
+function conclusiveArchive(outcome) {
+  return outcome?.archived === true || outcome?.alreadyGone === true;
+}
+
+function conclusiveRemoval(outcome) {
+  return outcome?.removed === true || outcome?.alreadyGone === true;
+}
+
+function classifyStructuralSupersession(error) {
+  const terminalCodes = new Set([
+    'MESSAGE_SNAPSHOT_SUPERSEDED',
+    'MESSAGE_SNAPSHOT_NOT_ACTIONABLE',
+    'DESIRED_FLAG_ROW_SUPERSEDED',
+    'SNAPSHOT_UIDVALIDITY_CHANGED',
+    'FOLDER_OBSERVATION_SUPERSEDED',
+    'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED',
+    'FOLDER_OBSERVATION_UNSAFE',
+    'PROVIDER_MAILBOX_SUPERSEDED',
+    'PROVIDER_NATIVE_MOVE_UNSUPPORTED',
+    'PROVIDER_RECOVERY_MARKER_UNSUPPORTED',
+  ]);
+  if (terminalCodes.has(error?.code)) {
+    error.retryable = false;
+  }
+  return error;
+}
+
+async function persist(operation, actions, phase, itemIndex, outcome = null, metadata = {}, plan) {
+  try {
+    return await actions.advance(operation, phase, itemIndex, outcome, plan);
+  } catch (error) {
+    error.gtdDonePhase = metadata.phase || phase;
+    error.inboxCleared = metadata.inboxCleared === true;
+    error.gtdDoneOperation = operation;
+    throw error;
+  }
+}
+
+function rebasePlanRows(plan, postSeenRows) {
+  const byId = new Map(postSeenRows.map(row => [row.id, row]));
+  const replace = rows => (rows || []).map(row => byId.get(row.id) || row);
+  return {
+    ...plan,
+    rows: replace(plan.rows),
+    inboxRows: replace(plan.inboxRows),
+    labelRows: replace(plan.labelRows),
+  };
+}
+
+// Execute one durable GTD Done plan. The repository-backed `advance` callback records each
+// conclusive item before the next provider mutation starts. Re-entry therefore resumes the first
+// unrecorded item; the exact row primitives make a provider-success/ledger-crash replay safe.
+export async function executeGtdDonePhases(initialOperation, actions) {
+  if (initialOperation.phase === 'completed') {
+    return {
+      complete: true,
+      phase: 'completed',
+      seenFailedCount: 0,
+      archiveUnconfirmedCount: 0,
+      operation: initialOperation,
+    };
+  }
+  let operation = actions.claim ? await actions.claim(initialOperation) : initialOperation;
+  const result = {
+    complete: false,
+    phase: operation.phase,
+    seenFailedCount: 0,
+    archiveUnconfirmedCount: 0,
+  };
+
+  try {
+    if (operation.phase === 'seen') {
+      const postSeenRows = [];
+      for (const current of operation.plan.rows) {
+        operation = actions.renew ? await actions.renew(operation) : operation;
+        let seen;
+        try {
+          seen = await actions.markSeen([current]);
+        } catch (error) {
+          classifyStructuralSupersession(error);
+          error.gtdDonePhase = 'seen';
+          error.inboxCleared = false;
+          throw error;
+        }
+        const confirmedRows = seen?.postSeenRows || [];
+        const failedCount = Number(seen?.seenFailedCount || 0);
+        if (failedCount > 0 || confirmedRows.length !== 1) {
+          result.seenFailedCount += Math.max(failedCount, 1 - confirmedRows.length);
+          return { ...result, operation };
+        }
+        postSeenRows.push(...confirmedRows);
+      }
+      const postSeenPlan = rebasePlanRows(operation.plan, postSeenRows);
+      operation = await persist(
+        operation, actions, 'archive', 0,
+        { phase: 'seen', seen: 'confirmed' },
+        { phase: 'seen', inboxCleared: false },
+        postSeenPlan,
+      );
+    }
+
+    if (operation.phase === 'archive') {
+      const inboxRows = operation.plan.inboxRows || [];
+      for (let index = Number(operation.itemIndex || 0); index < inboxRows.length; index++) {
+        let outcome;
+        try {
+          operation = actions.renew ? await actions.renew(operation) : operation;
+          outcome = await actions.archive(inboxRows[index]);
+        } catch (error) {
+          classifyStructuralSupersession(error);
+          error.gtdDonePhase = 'archive';
+          error.inboxCleared = false;
+          error.gtdDoneOperation = operation;
+          throw error;
+        }
+        if (!conclusiveArchive(outcome)) {
+          return {
+            ...result,
+            phase: 'archive',
+            archiveUnconfirmedCount: 1,
+            noArchiveFolder: outcome?.noArchiveFolder === true,
+            operation,
+          };
+        }
+        const inboxCleared = index + 1 === inboxRows.length;
+        operation = await persist(
+          operation, actions, 'archive', index + 1,
+          { phase: 'archive', itemIndex: index, rowId: inboxRows[index].id, ...outcome },
+          { phase: 'archive', inboxCleared },
+        );
+      }
+      operation = await persist(
+        operation, actions, 'labels', 0,
+        { phase: 'archive', inboxCleared: true },
+        { phase: 'labels', inboxCleared: true },
+      );
+    }
+
+    if (operation.phase === 'labels') {
+      const labelRows = operation.plan.labelRows || [];
+      for (let index = Number(operation.itemIndex || 0); index < labelRows.length; index++) {
+        let outcome;
+        try {
+          operation = actions.renew ? await actions.renew(operation) : operation;
+          outcome = await actions.removeLabel(labelRows[index]);
+        } catch (error) {
+          classifyStructuralSupersession(error);
+          error.gtdDonePhase = 'labels';
+          error.inboxCleared = true;
+          error.gtdDoneOperation = operation;
+          throw error;
+        }
+        if (!conclusiveRemoval(outcome)) {
+          return { ...result, phase: 'labels', labelUnconfirmedCount: 1, operation };
+        }
+        operation = await persist(
+          operation, actions, 'labels', index + 1,
+          { phase: 'labels', itemIndex: index, rowId: labelRows[index].id, ...outcome },
+          { phase: 'labels', inboxCleared: true },
+        );
+      }
+      operation = await persist(
+        operation, actions, 'completed', 0,
+        { phase: 'labels', complete: true },
+        { phase: 'labels', inboxCleared: true },
+      );
+    }
+
+    return {
+      ...result,
+      complete: operation.phase === 'completed',
+      phase: operation.phase,
+      operation,
+    };
+  } finally {
+    if (operation.phase !== 'completed') {
+      try {
+        await actions.release?.(operation);
+      } catch (error) {
+        console.warn(`GTD Done claim release failed for ${operation.key}:`, error.message);
+      }
+    }
+  }
+}

--- a/backend/src/plugins/gtd/gtdDonePhases.test.js
+++ b/backend/src/plugins/gtd/gtdDonePhases.test.js
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { executeGtdDonePhases } from './gtdDonePhases.js';
+
+const row = (id, folder, uid) => ({
+  id, account_id: 'acct-1', thread_key: 'thread-1', folder, uid,
+  is_read: true, read_revision: 1, star_revision: 0,
+  folder_uid_validity: folder === 'INBOX' ? 10 : 20,
+  folder_observation_generation: 3,
+});
+
+function operation(overrides = {}) {
+  return {
+    key: 'done-key', phase: 'seen', itemIndex: 0,
+    plan: {
+      rows: [
+        row('label-other', 'Delegated', 2), row('label-anchor', 'Watch', 1),
+        row('inbox-a', 'INBOX', 10), row('inbox-z', 'INBOX', 11),
+      ],
+      inboxRows: [row('inbox-z', 'INBOX', 11), row('inbox-a', 'INBOX', 10)],
+      labelRows: [row('label-other', 'Delegated', 2), row('label-anchor', 'Watch', 1)],
+      labelAnchorId: 'label-anchor', inboxAnchorId: 'inbox-a', targetFolders: ['Watch', 'Delegated'],
+    },
+    ...overrides,
+  };
+}
+
+function deps(overrides = {}) {
+  return {
+    claim: vi.fn(async op => ({ ...op, claimOwner: 'owner-1' })),
+    renew: vi.fn(async op => op),
+    release: vi.fn(async () => {}),
+    markSeen: vi.fn(async rows => ({
+      seenFailedCount: 0,
+      postSeenRows: rows.map(current => ({ ...current, read_revision: current.read_revision + 1 })),
+    })),
+    archive: vi.fn(async () => ({ archived: true })),
+    removeLabel: vi.fn(async () => ({ removed: true, alreadyGone: false })),
+    advance: vi.fn(async (op, phase, itemIndex) => ({ ...op, phase, itemIndex })),
+    ...overrides,
+  };
+}
+
+describe('executeGtdDonePhases', () => {
+  it('stops immediately after the first nonconclusive Seen delivery and reports only observed failures', async () => {
+    const actions = deps({ markSeen: vi.fn(async () => ({ seenFailedCount: 1 })) });
+    const result = await executeGtdDonePhases(operation(), actions);
+    expect(result).toMatchObject({ complete: false, phase: 'seen', seenFailedCount: 1 });
+    expect(actions.markSeen).toHaveBeenCalledTimes(1);
+    expect(actions.markSeen).toHaveBeenCalledWith([expect.objectContaining({ id: 'label-other' })]);
+    expect(actions.archive).not.toHaveBeenCalled();
+    expect(actions.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it('archives deterministic non-anchor rows before the fallback Inbox anchor and stops on the first uncertainty', async () => {
+    const calls = [];
+    const actions = deps({
+      archive: vi.fn(async current => {
+        calls.push(current.id);
+        return current.id === 'inbox-z' ? { archived: false } : { archived: true };
+      }),
+    });
+    const result = await executeGtdDonePhases(operation(), actions);
+    expect(calls).toEqual(['inbox-z']);
+    expect(result).toMatchObject({ complete: false, phase: 'archive', archiveUnconfirmedCount: 1 });
+    expect(actions.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it('removes non-anchor labels only after every archive is conclusive and removes the label anchor last', async () => {
+    const calls = [];
+    const actions = deps({
+      archive: vi.fn(async current => { calls.push(`archive:${current.id}`); return { alreadyGone: true }; }),
+      removeLabel: vi.fn(async current => { calls.push(`label:${current.id}`); return { removed: true }; }),
+    });
+    const result = await executeGtdDonePhases(operation(), actions);
+    expect(result.complete).toBe(true);
+    expect(calls).toEqual([
+      'archive:inbox-z', 'archive:inbox-a',
+      'label:label-other', 'label:label-anchor',
+    ]);
+  });
+
+  it('keeps the label anchor retryable when a non-anchor label removal fails', async () => {
+    const actions = deps({
+      removeLabel: vi.fn(async current => {
+        if (current.id === 'label-other') throw new Error('provider failed');
+        return { removed: true };
+      }),
+    });
+    await expect(executeGtdDonePhases(operation(), actions)).rejects.toThrow('provider failed');
+    expect(actions.removeLabel).toHaveBeenCalledTimes(1);
+    expect(actions.removeLabel.mock.calls[0][0].id).toBe('label-other');
+  });
+
+  it('completes a no-label Inbox Done after the deterministic Inbox anchor is archived', async () => {
+    const op = operation({
+      plan: {
+        rows: [row('inbox-only', 'INBOX', 8)], inboxRows: [row('inbox-only', 'INBOX', 8)],
+        labelRows: [], labelAnchorId: null, inboxAnchorId: 'inbox-only', targetFolders: ['Todo'],
+      },
+    });
+    const actions = deps();
+    const result = await executeGtdDonePhases(op, actions);
+    expect(result.complete).toBe(true);
+    expect(actions.archive).toHaveBeenCalledOnce();
+    expect(actions.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it('resumes at the first unrecorded item without replaying completed same-folder ledger entries', async () => {
+    const op = operation({ phase: 'labels', itemIndex: 1 });
+    const actions = deps();
+    const result = await executeGtdDonePhases(op, actions);
+    expect(result.complete).toBe(true);
+    expect(actions.markSeen).not.toHaveBeenCalled();
+    expect(actions.archive).not.toHaveBeenCalled();
+    expect(actions.removeLabel).toHaveBeenCalledTimes(1);
+    expect(actions.removeLabel.mock.calls[0][0].id).toBe('label-anchor');
+  });
+
+  it('resumes two exact label items in the same physical folder at the independent anchor cursor', async () => {
+    const sameFolderA = row('same-folder-a', 'Waiting', 20);
+    const sameFolderAnchor = row('same-folder-anchor', 'Waiting', 21);
+    const op = operation({
+      phase: 'labels',
+      itemIndex: 1,
+      plan: {
+        rows: [sameFolderA, sameFolderAnchor],
+        inboxRows: [],
+        labelRows: [sameFolderA, sameFolderAnchor],
+        labelAnchorId: sameFolderAnchor.id,
+        inboxAnchorId: null,
+        targetFolders: ['Waiting'],
+      },
+    });
+    const actions = deps();
+
+    await expect(executeGtdDonePhases(op, actions)).resolves.toMatchObject({ complete: true });
+    expect(actions.removeLabel).toHaveBeenCalledTimes(1);
+    expect(actions.removeLabel).toHaveBeenCalledWith(sameFolderAnchor);
+    expect(actions.advance).toHaveBeenCalledWith(
+      expect.objectContaining({ itemIndex: 1 }), 'labels', 2,
+      expect.objectContaining({ rowId: sameFolderAnchor.id, itemIndex: 1 }), undefined,
+    );
+  });
+
+  it('reports Inbox cleared when the archive-to-label cursor transition cannot be persisted', async () => {
+    const actions = deps({
+      advance: vi.fn(async (op, phase, itemIndex) => {
+        if (phase === 'labels') throw new Error('ledger unavailable');
+        return { ...op, phase, itemIndex };
+      }),
+    });
+
+    await expect(executeGtdDonePhases(operation(), actions)).rejects.toMatchObject({
+      message: 'ledger unavailable',
+      gtdDonePhase: 'labels',
+      inboxCleared: true,
+    });
+  });
+
+  it('tags a failed final archive outcome write as Inbox-cleared uncertainty', async () => {
+    const actions = deps({
+      advance: vi.fn(async (op, phase, itemIndex) => {
+        if (phase === 'archive' && itemIndex === 2) throw new Error('ledger unavailable');
+        return { ...op, phase, itemIndex };
+      }),
+    });
+
+    await expect(executeGtdDonePhases(operation(), actions)).rejects.toMatchObject({
+      message: 'ledger unavailable',
+      gtdDonePhase: 'archive',
+      inboxCleared: true,
+    });
+  });
+
+  it('records phase, row, and cursor identity with every durable provider outcome', async () => {
+    const actions = deps();
+    await executeGtdDonePhases(operation(), actions);
+
+    expect(actions.advance).toHaveBeenCalledWith(
+      expect.anything(), 'archive', 1,
+      expect.objectContaining({ phase: 'archive', itemIndex: 0, rowId: 'inbox-z', archived: true }),
+      undefined,
+    );
+    expect(actions.advance).toHaveBeenCalledWith(
+      expect.anything(), 'labels', 1,
+      expect.objectContaining({ phase: 'labels', itemIndex: 0, rowId: 'label-other', removed: true }),
+      undefined,
+    );
+  });
+
+  it('durably rebases every destructive worklist to the exact post-Seen revision', async () => {
+    const actions = deps();
+    await executeGtdDonePhases(operation(), actions);
+
+    const seenAdvance = actions.advance.mock.calls.find(([, phase, index]) => phase === 'archive' && index === 0);
+    expect(seenAdvance[4].rows.every(current => current.read_revision >= 2)).toBe(true);
+    expect(seenAdvance[4].inboxRows.map(current => current.read_revision)).toEqual([2, 2]);
+    expect(seenAdvance[4].labelRows.map(current => current.read_revision)).toEqual([2, 2]);
+  });
+
+  it('does not let a release failure mask an archive-incomplete durable outcome', async () => {
+    const actions = deps({
+      archive: vi.fn(async () => ({ archived: false })),
+      release: vi.fn(async () => { throw new Error('release unavailable'); }),
+    });
+
+    await expect(executeGtdDonePhases(operation(), actions)).resolves.toMatchObject({
+      complete: false, phase: 'archive', archiveUnconfirmedCount: 1,
+    });
+  });
+
+  it('terminates a frozen lifecycle when an exact row snapshot is structurally superseded', async () => {
+    const superseded = Object.assign(new Error('row moved'), {
+      code: 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable: true,
+    });
+    const actions = deps({ archive: vi.fn(async () => { throw superseded; }) });
+
+    await expect(executeGtdDonePhases(operation(), actions)).rejects.toMatchObject({
+      code: 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable: false, gtdDonePhase: 'archive',
+    });
+  });
+});

--- a/backend/src/plugins/gtd/gtdGist.js
+++ b/backend/src/plugins/gtd/gtdGist.js
@@ -1,4 +1,11 @@
-import { summarizeMessage, summarizeAvailable, getMessageFields, getMessageAnnotations, setMessageAnnotation } from '../api.js';
+import {
+  summarizeMessage,
+  summarizeAvailable,
+  getMessageFields,
+  validateMessageFieldsSnapshot,
+  getMessageAnnotations,
+  setMessageAnnotationForSnapshot,
+} from '../api.js';
 
 // AI-condensed one-line gist for GTD "waiting" entries. The client shows the raw
 // message snippet by default; when a gist has been generated for a waiting thread's
@@ -69,14 +76,16 @@ async function generateForAccount(accountId, ids) {
   const rows = await getMessageFields(accountId, need);
   let wrote = 0;
   await runPool(rows, GIST_CONCURRENCY, async (row) => {
+    if (!await validateMessageFieldsSnapshot(accountId, row)) return;
     const gist = await summarizeMessage({
       subject: row.subject,
       from: row.from_name || row.from_email,
       content: row.content,
     });
     if (!gist) return;
+    if (!await validateMessageFieldsSnapshot(accountId, row)) return;
     // Store under GTD's annotation namespace on the message (cleaned with the message on delete).
-    const n = await setMessageAnnotation(accountId, row.id, 'gtd', { gist });
+    const n = await setMessageAnnotationForSnapshot(accountId, row, 'gtd', { gist });
     if (n > 0) wrote++;
   });
   return wrote;

--- a/backend/src/plugins/gtd/gtdGist.test.js
+++ b/backend/src/plugins/gtd/gtdGist.test.js
@@ -83,20 +83,31 @@ describe('queueGistGeneration — provider gating', () => {
 });
 
 describe('queueGistGeneration — write path', () => {
-  const isBodySelect = (sql) => /FROM messages/i.test(sql) && /SELECT id, subject/i.test(sql);
+  const isBodySelect = (sql) => /SELECT m\.id, m\.uid, m\.folder/i.test(sql);
+  const isSnapshotValidation = (sql) => /SELECT 1[\s\S]*FROM messages m/i.test(sql);
   // The gist is now stored as a plugin annotation on the message (jsonb_set into plugin_annotations).
-  const isGistUpdate = (sql) => /UPDATE messages\s+SET plugin_annotations/i.test(sql);
+  const isGistUpdate = (sql) => /UPDATE messages(?:\s+m)?\s+SET plugin_annotations/i.test(sql);
 
   // Route query() by SQL rather than by call order: GIST_CONCURRENCY runs UPDATEs from
   // the pool concurrently, so their relative ordering isn't deterministic. The body
   // SELECT echoes one row per requested id so the pool has real work to do.
-  function mockDb({ updateRowCount = 1 } = {}) {
+  function mockDb({ updateRowCount = 1, snapshotMatches = null } = {}) {
+    const pendingSnapshotMatches = snapshotMatches ? [...snapshotMatches] : null;
     query.mockImplementation((sql, params) => {
       if (isBodySelect(sql)) {
         const ids = params[0];
         return Promise.resolve({
-          rows: ids.map((id) => ({ id, subject: `S ${id}`, from_name: 'Alice', from_email: 'a@x', content: `body ${id}` })),
+          rows: ids.map((id) => ({
+            id, uid: '11', folder: 'Watch', subject: `S ${id}`,
+            from_name: 'Alice', from_email: 'a@x', content: `body ${id}`,
+            read_revision: '2', star_revision: '3',
+            folder_uid_validity: '44', folder_observation_generation: '5',
+          })),
         });
+      }
+      if (isSnapshotValidation(sql)) {
+        const matches = pendingSnapshotMatches ? pendingSnapshotMatches.shift() : true;
+        return Promise.resolve({ rows: matches ? [{ matches: 1 }] : [] });
       }
       if (isGistUpdate(sql)) return Promise.resolve({ rowCount: updateRowCount });
       return Promise.resolve({ rows: [] });
@@ -134,14 +145,51 @@ describe('queueGistGeneration — write path', () => {
     const selectCall = query.mock.calls.find((c) => isBodySelect(c[0]));
     // The body read (getMessageFields) is scoped to the account, not just the id list.
     expect(selectCall[0]).toMatch(/account_id = \$2/);
+    expect(selectCall[0]).toMatch(/JOIN folders f/);
+    expect(selectCall[0]).toMatch(/m\.metadata_complete = true/);
+    expect(selectCall[0]).toMatch(/f\.is_present = true/);
+    expect(selectCall[0]).toMatch(/f\.uid_validity IS NOT NULL/);
     expect(selectCall[1]).toEqual([['w1'], 'a1']);
+
+    const validationCalls = query.mock.calls.filter((c) => isSnapshotValidation(c[0]));
+    expect(validationCalls).toHaveLength(2);
+    expect(validationCalls[0][1]).toEqual([
+      'a1', 'w1', '11', 'Watch', '2', '3', '44', '5',
+      'S w1', 'Alice', 'a@x', 'body w1',
+    ]);
 
     // Persists the sanitised gist under the message's GTD annotation namespace (account-scoped).
     const updateCall = query.mock.calls.find((c) => isGistUpdate(c[0]));
-    expect(updateCall[1]).toEqual(['a1', 'w1', 'gtd', JSON.stringify({ gist: 'waiting on their reply' })]);
+    expect(updateCall[0]).toMatch(/FROM folders f/);
+    expect(updateCall[0]).toMatch(/m\.read_revision = \$7/);
+    expect(updateCall[0]).toMatch(/f\.observation_generation = \$10/);
+    expect(updateCall[1]).toEqual([
+      'a1', 'w1', 'gtd', JSON.stringify({ gist: 'waiting on their reply' }),
+      '11', 'Watch', '2', '3', '44', '5', 'S w1', 'Alice', 'a@x', 'body w1',
+    ]);
 
     expect(broadcast).toHaveBeenCalledTimes(1);
     expect(broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'a1' }, 'u1');
+  });
+
+  it('does not send message text to AI when the live snapshot is superseded before generation', async () => {
+    mockDb({ snapshotMatches: [false] });
+
+    await queueGistGeneration({ sections: waitingHeads(['w1']), userId: 'u1', broadcast: vi.fn() });
+
+    expect(completeText).not.toHaveBeenCalled();
+    expect(query.mock.calls.some((c) => isGistUpdate(c[0]))).toBe(false);
+  });
+
+  it('does not annotate or broadcast when the snapshot is superseded while AI is running', async () => {
+    mockDb({ snapshotMatches: [true, false] });
+    const broadcast = vi.fn();
+
+    await queueGistGeneration({ sections: waitingHeads(['w1']), userId: 'u1', broadcast });
+
+    expect(completeText).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls.some((c) => isGistUpdate(c[0]))).toBe(false);
+    expect(broadcast).not.toHaveBeenCalled();
   });
 
   it('does not broadcast when the UPDATE writes nothing (wrote === 0 — a newer head won the race)', async () => {
@@ -179,8 +227,13 @@ describe('queueGistGeneration — write path', () => {
     query.mockImplementation((sql, params) => {
       if (isBodySelect(sql)) {
         const ids = params[0];
-        return Promise.resolve({ rows: ids.map((id) => ({ id, subject: 'S', from_name: 'A', from_email: 'a@x', content: 'b' })) });
+        return Promise.resolve({ rows: ids.map((id) => ({
+          id, uid: '11', folder: 'Watch', subject: 'S', from_name: 'A', from_email: 'a@x', content: 'b',
+          read_revision: '2', star_revision: '3',
+          folder_uid_validity: '44', folder_observation_generation: '5',
+        })) });
       }
+      if (isSnapshotValidation(sql)) return Promise.resolve({ rows: [{ matches: 1 }] });
       if (isGistUpdate(sql)) return Promise.resolve({ rowCount: 1 });
       return Promise.resolve({ rows: [] });
     });

--- a/backend/src/plugins/gtd/gtdTransitions.js
+++ b/backend/src/plugins/gtd/gtdTransitions.js
@@ -1,5 +1,5 @@
 import { getGtdConfig } from './gtdConfig.js';
-import { resolveAllDraftsPaths, logger, getAccountAddresses, getThreadKeysForMessageIds as _threadKeysForIds, getThreadKeysInFolders as _threadKeysInFolders, getThreadKeysForMessageIdHeaders, getMessagesByThreadKeys } from '../api.js';
+import { resolveAllDraftsPaths, getAccountAddresses, getThreadKeysForMessageIds as _threadKeysForIds, getThreadKeysInFolders as _threadKeysInFolders, getThreadKeysForMessageIdHeaders, getMessagesByThreadKeys } from '../api.js';
 
 // Transition rules for auto-stripping a GTD label once a thread's state has moved on,
 // evaluated per thread against its LAST non-draft message. Designed to match the
@@ -140,15 +140,20 @@ export async function runGtdTransitions(imapManager, account, threadKeys) {
       if (!shouldStrip) continue;
 
       for (const copy of threadRows.filter((r) => r.folder === folder)) {
+        const snapshot = {
+          id: copy.id, accountId: account.id, uid: Number(copy.uid), folder: copy.folder,
+          uidValidity: String(copy.folder_uid_validity),
+          folderGeneration: String(copy.folder_observation_generation),
+          readRevision: Number(copy.read_revision || 0),
+          starRevision: Number(copy.star_revision || 0),
+        };
+        await imapManager.removeMessageCopy(account.id, copy.uid, copy.folder, {
+          expectedId: copy.id,
+          expectedUidValidity: copy.folder_uid_validity,
+          snapshot,
+          operationKey: `gtd-transition:${copy.id}`,
+        });
         anyStripped = true;
-        try {
-          await imapManager.removeMessageCopy(account.id, copy.uid, copy.folder);
-        } catch (err) {
-          // An external automation may strip the same label concurrently, so the copy
-          // can already be gone on the server. Treat a failed removal as a successful
-          // strip and move on; the stale DB row reconciles on the next sync.
-          logger.debug(`gtdTransitions: tolerated removeMessageCopy failure uid=${copy.uid} ${copy.folder}: ${err.message}`);
-        }
       }
     }
   }

--- a/backend/src/plugins/gtd/gtdTransitions.test.js
+++ b/backend/src/plugins/gtd/gtdTransitions.test.js
@@ -29,7 +29,10 @@ function mockQuery({ owner = [{ addr: 'me@example.com' }], rows = [], sent = [] 
   query.mockImplementation((sql) => {
     if (sql.includes('message_id = ANY')) return Promise.resolve({ rows: sent });
     if (sql.includes('account_aliases')) return Promise.resolve({ rows: owner });
-    if (sql.includes('thread_key = ANY')) return Promise.resolve({ rows });
+    if (sql.includes('thread_key = ANY')) return Promise.resolve({ rows: rows.map(row => ({
+      folder_uid_validity: '101', folder_observation_generation: '7',
+      read_revision: 0, star_revision: 0, ...row,
+    })) });
     return Promise.resolve({ rows: [] });
   });
 }
@@ -102,7 +105,7 @@ describe('runGtdTransitions', () => {
     ] });
     const mgr = fakeManager();
     await runGtdTransitions(mgr, account, ['t1']);
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 11, 'Todo');
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 11, 'Todo', expect.objectContaining({ expectedId: 'r2' }));
     expect(mgr.removeMessageCopy).not.toHaveBeenCalledWith('acct-1', 12, 'Watch');
     expect(mgr.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'acct-1' }, 'user-1');
   });
@@ -116,8 +119,8 @@ describe('runGtdTransitions', () => {
     ] });
     const mgr = fakeManager();
     await runGtdTransitions(mgr, account, ['t1']);
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 22, 'Watch');
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 23, 'Delegated');
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 22, 'Watch', expect.objectContaining({ expectedId: 'r3' }));
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 23, 'Delegated', expect.objectContaining({ expectedId: 'r4' }));
     expect(mgr.removeMessageCopy).not.toHaveBeenCalledWith('acct-1', 21, 'Todo');
   });
 
@@ -131,7 +134,7 @@ describe('runGtdTransitions', () => {
     });
     const mgr = fakeManager();
     await runGtdTransitions(mgr, account, ['t1']);
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 31, 'Todo');
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 31, 'Todo', expect.objectContaining({ expectedId: 'r2' }));
   });
 
   it('keeps Watch when the newest message is from a configured Fastmail masked alias', async () => {
@@ -157,7 +160,7 @@ describe('runGtdTransitions', () => {
     });
     const mgr = fakeManager();
     await runGtdTransitions(mgr, account, ['t1']);
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 35, 'Watch');
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 35, 'Watch', expect.objectContaining({ expectedId: 'r2' }));
   });
 
   it('never strips Reference, whoever sent last', async () => {
@@ -190,7 +193,7 @@ describe('runGtdTransitions', () => {
     ] });
     const mgr = fakeManager();
     await runGtdTransitions(mgr, account, ['t1']);
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 51, 'Watch');
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 51, 'Watch', expect.objectContaining({ expectedId: 'r2' }));
   });
 
   it('is fully inert when GTD is disabled — no rows query, no strips, no broadcast', async () => {
@@ -229,16 +232,16 @@ describe('runGtdTransitions', () => {
     expect(mgr.broadcast).toHaveBeenCalledTimes(1);
   });
 
-  it('tolerates a removeMessageCopy rejection (concurrent external strip) as success', async () => {
+  it('propagates a provider rejection instead of broadcasting a false successful strip', async () => {
     mockQuery({ rows: [
       { thread_key: 't1', uid: 70, folder: 'INBOX', from_email: 'me@example.com', date: '2026-07-09T10:00:00Z', id: 'r1' },
       { thread_key: 't1', uid: 71, folder: 'Todo',  from_email: 'me@example.com', date: '2026-07-09T10:00:00Z', id: 'r2' },
     ] });
     const mgr = fakeManager();
     mgr.removeMessageCopy.mockRejectedValue(new Error('NO [TRYCREATE] no such UID'));
-    await expect(runGtdTransitions(mgr, account, ['t1'])).resolves.toBeUndefined();
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 71, 'Todo');
-    expect(mgr.broadcast).toHaveBeenCalledTimes(1);
+    await expect(runGtdTransitions(mgr, account, ['t1'])).rejects.toThrow('no such UID');
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 71, 'Todo', expect.any(Object));
+    expect(mgr.broadcast).not.toHaveBeenCalled();
   });
 });
 
@@ -278,7 +281,7 @@ describe('runTransitionsForSentMessage', () => {
 
     const midCall = query.mock.calls.find(([sql]) => sql.includes('message_id = ANY'));
     expect(midCall[1]).toEqual(['acct-1', ['abc@example.com', '<abc@example.com>']]);
-    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 81, 'Todo');
+    expect(mgr.removeMessageCopy).toHaveBeenCalledWith('acct-1', 81, 'Todo', expect.objectContaining({ expectedId: 'r2' }));
     expect(mgr.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: 'acct-1' }, 'user-1');
   });
 

--- a/backend/src/plugins/gtd/routes.classify.test.js
+++ b/backend/src/plugins/gtd/routes.classify.test.js
@@ -46,18 +46,37 @@ const inboxMsg = {
   message_id: '<m@x>',
   thread_key: 'thread-1',
   is_read: false,
+  read_revision: 2,
+  star_revision: 0,
+  folder_uid_validity: 123,
+  folder_observation_generation: 4,
 };
+const labelCopy = {
+  id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  account_id: ACCT_ID,
+  uid: 42,
+  folder: 'Todo',
+  read_revision: 2,
+  star_revision: 0,
+  folder_uid_validity: 456,
+  folder_observation_generation: 8,
+};
+const exactCopy = { ...labelCopy, uid: 77 };
 const account = { id: ACCT_ID, user_id: 'u1', folder_mappings: {} };
 
 // Route every query classify issues: the ownership-scoped message load, the account fetch
 // (POST copy path), and resolveCopyUid's sibling lookup (DELETE). Each is individually swappable
 // so a test can drive the not-owned (msg:null) / no-sibling (sibling:null) branches.
-function stubQueries({ msg = inboxMsg, acct = account, sibling = null, exact = { uid: 77 } } = {}) {
+function stubQueries({ msg = inboxMsg, acct = account, sibling = null, exact = exactCopy } = {}) {
   query.mockImplementation(async (sql) => {
     if (sql.includes('FROM messages m') && sql.includes('JOIN email_accounts')) return { rows: msg ? [msg] : [] };
     if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: acct ? [acct] : [] };
-    if (sql.includes('thread_key = $4') || sql.includes('message_id = $4')) return { rows: exact ? [exact] : [] };
-    if (sql.startsWith('SELECT uid FROM messages')) return { rows: sibling ? [sibling] : [] };
+    if (sql.includes('m.uid = $3') && sql.includes('m.message_id = $4')) {
+      return { rows: exact ? [exact] : [] };
+    }
+    if (sql.includes('WHERE m.account_id = $1 AND m.folder = $2 AND m.message_id = $3')) {
+      return { rows: sibling ? [sibling] : [] };
+    }
     return { rows: [] };
   });
 }
@@ -70,7 +89,9 @@ function buildApp() {
 }
 
 const classify = (body) => fetch(`${base}/api/gtd/classify`, {
-  method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'X-Idempotency-Key': 'classify-1' },
+  body: JSON.stringify(body),
 });
 const unclassify = (body) => fetch(`${base}/api/gtd/classify`, {
   method: 'DELETE', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
@@ -128,7 +149,22 @@ describe('POST /api/gtd/classify — apply a GTD label (COPY)', () => {
     });
     // Callers own folder existence, so classify ensures then copies — the message stays in INBOX.
     expect(imapManager.ensureFolder).toHaveBeenCalledWith(account, 'Todo');
-    expect(imapManager.copyMessage).toHaveBeenCalledWith(ACCT_ID, 10, 'INBOX', 'Todo');
+    expect(imapManager.copyMessage).toHaveBeenCalledWith(
+      ACCT_ID, 10, 'INBOX', 'Todo',
+      {
+        operationKey: 'gtd-classify:u1:classify-1',
+        snapshot: {
+          id: MSG_ID,
+          accountId: ACCT_ID,
+          uid: 10,
+          folder: 'INBOX',
+          uidValidity: '123',
+          folderGeneration: '4',
+          readRevision: 2,
+          starRevision: 0,
+        },
+      },
+    );
   });
 
   it('succeeds without advertising an unsafe inverse for non-UIDPLUS', async () => {
@@ -172,6 +208,8 @@ describe('POST /api/gtd/classify — apply a GTD label (COPY)', () => {
     const res = await classify({ messageId: MSG_ID, state: 'todo' });
     expect(res.status).toBe(404);
     expect((await res.json()).error).toMatch(/not found/i);
+    expect(query.mock.calls[0][0]).toMatch(/m\.is_deleted = false/);
+    expect(query.mock.calls[0][0]).toMatch(/m\.metadata_complete = true/);
     expect(imapManager.copyMessage).not.toHaveBeenCalled();
   });
 
@@ -185,12 +223,25 @@ describe('POST /api/gtd/classify — apply a GTD label (COPY)', () => {
 
 describe('DELETE /api/gtd/classify — remove a GTD label', () => {
   it('removes the sibling copy in the state folder and returns removed:true', async () => {
-    stubQueries({ sibling: { uid: 42 } });
+    stubQueries({ sibling: labelCopy });
     const res = await unclassify({ messageId: MSG_ID, state: 'todo' });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, removed: true, folder: 'Todo' });
     // resolveCopyUid found the state-folder copy (uid 42) via the shared Message-ID join.
-    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 42, 'Todo');
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 42, 'Todo', {
+      expectedId: labelCopy.id,
+      expectedUidValidity: labelCopy.folder_uid_validity,
+      snapshot: {
+        id: labelCopy.id,
+        accountId: ACCT_ID,
+        uid: 42,
+        folder: 'Todo',
+        uidValidity: '456',
+        folderGeneration: '8',
+        readRevision: 2,
+        starRevision: 0,
+      },
+    });
   });
 
   it('returns removed:false when no copy exists in the state folder (nothing to delete)', async () => {
@@ -217,18 +268,33 @@ describe('DELETE /api/gtd/classify — remove a GTD label', () => {
     const res = await unclassify({ messageId: MSG_ID, state: 'todo' });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, removed: true, folder: 'Todo' });
-    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 10, 'Todo');
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 10, 'Todo', {
+      expectedId: MSG_ID,
+      expectedUidValidity: inboxMsg.folder_uid_validity,
+      snapshot: {
+        id: MSG_ID,
+        accountId: ACCT_ID,
+        uid: 10,
+        folder: 'Todo',
+        uidValidity: '123',
+        folderGeneration: '4',
+        readRevision: 2,
+        starRevision: 0,
+      },
+    });
   });
 
   it("404s a message the caller doesn't own", async () => {
     stubQueries({ msg: null });
     const res = await unclassify({ messageId: MSG_ID, state: 'todo' });
     expect(res.status).toBe(404);
+    expect(query.mock.calls[0][0]).toMatch(/m\.is_deleted = false/);
+    expect(query.mock.calls[0][0]).toMatch(/m\.metadata_complete = true/);
     expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
   });
 
   it('maps an IMAP delete failure to 500', async () => {
-    stubQueries({ sibling: { uid: 42 } });
+    stubQueries({ sibling: labelCopy });
     imapManager.removeMessageCopy.mockRejectedValue(new Error('IMAP delete failed'));
     const res = await unclassify({ messageId: MSG_ID, state: 'todo' });
     expect(res.status).toBe(500);
@@ -240,10 +306,25 @@ describe('POST /api/gtd/classify/undo — remove only the request-owned copy', (
   const token = { messageId: MSG_ID, state: 'todo', folder: 'Todo', uid: 77 };
 
   it('removes the exact copy identified by the classify response', async () => {
+    imapManager.removeMessageCopy.mockResolvedValueOnce(1);
     const res = await undoClassify(token);
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, removed: true, folder: 'Todo' });
-    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 77, 'Todo');
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 77, 'Todo', {
+      expectedId: labelCopy.id,
+      expectedUidValidity: labelCopy.folder_uid_validity,
+      notify: true,
+      snapshot: {
+        id: labelCopy.id,
+        accountId: ACCT_ID,
+        uid: 77,
+        folder: 'Todo',
+        uidValidity: '456',
+        folderGeneration: '8',
+        readRevision: 2,
+        starRevision: 0,
+      },
+    });
   });
 
   it('is replay-safe when the exact copy no longer exists', async () => {

--- a/backend/src/plugins/gtd/routes.done.test.js
+++ b/backend/src/plugins/gtd/routes.done.test.js
@@ -6,7 +6,10 @@ import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vites
 // stubbed; mailUtils' side-effecting helpers (archive resolution, count adjust, read fan-out)
 // are mocked so the archive DB write's rowCount is the only thing under test. getGtdConfig is
 // mocked to a fixed enabled config; requireAuth is a passthrough injecting a session.
-vi.mock('../../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../../services/db.js', () => {
+  const query = vi.fn();
+  return { query, withTransaction: vi.fn(callback => callback({ query })) };
+});
 vi.mock('../../middleware/auth.js', () => ({
   requireAuth: (req, _res, next) => { req.session = { userId: 'u1' }; next(); },
 }));
@@ -24,19 +27,41 @@ vi.mock('./gtdConfig.js', async (importOriginal) => {
   const actual = await importOriginal();
   return { ...actual, getGtdConfig: vi.fn() };
 });
+vi.mock('../../services/gtdDoneOperations.js', () => ({
+  createOrLoadGtdDoneOperation: vi.fn(),
+  claimGtdDoneOperation: vi.fn(),
+  renewGtdDoneOperation: vi.fn(),
+  advanceGtdDoneOperation: vi.fn(),
+  releaseGtdDoneOperation: vi.fn(),
+}));
 
 import express from 'express';
 import { query } from '../../services/db.js';
 import { setMailEngine } from '../mailEngine.js';
 import { resolveArchiveFolder, isAllMailFolder, adjustFolderCounts, fanOutReadToSiblings } from '../../utils/mailUtils.js';
 import { getGtdConfig, DEFAULT_GTD_FOLDERS } from './gtdConfig.js';
+import {
+  createOrLoadGtdDoneOperation,
+  claimGtdDoneOperation,
+  renewGtdDoneOperation,
+  advanceGtdDoneOperation,
+  releaseGtdDoneOperation,
+} from '../../services/gtdDoneOperations.js';
 
 // The done route's mail actions (label strip, mark-read, archive, broadcast) go through the bound
 // plugin-api capabilities; inject a mock engine, asserted on directly below.
 const imapManager = {
   moveMessage: vi.fn(),
+  moveMessageWithReceipt: vi.fn(),
+  findUidByRecoveryKeyword: vi.fn(),
+  clearMoveRecoveryKeyword: vi.fn(),
+  setDesiredFlag: vi.fn(),
   setFlag: vi.fn(),
+  messageExists: vi.fn(),
+  reconcileMissingMessageCopy: vi.fn(),
   removeMessageCopy: vi.fn(),
+  _enqueueFlagPush: vi.fn(),
+  _resolveFlagPush: vi.fn(),
   _guardMoveUid: vi.fn(),
   _unguardMoveUid: vi.fn(),
   broadcast: vi.fn(),
@@ -49,9 +74,11 @@ const ACCT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 // The rail acts on the Watch-folder copy; a distinct INBOX sibling is what the archive step
 // moves. is_read true on both keeps the mark-read path off the IMAP setFlag mock.
-const msg = { id: MSG_ID, account_id: ACCT_ID, uid: 10, folder: 'Watch', message_id: '<m@x>', is_read: true };
+const msg = { id: MSG_ID, account_id: ACCT_ID, thread_key: 'thread-1', uid: 10, folder: 'Watch', message_id: '<m@x>', is_read: true, is_deleted: false, metadata_complete: true, folder_uid_validity: 321, folder_observation_generation: 6, folder_topology_identity: 'watch-incarnation', read_revision: 2, star_revision: 0 };
 const account = { id: ACCT_ID, user_id: 'u1', folder_mappings: {} };
-const inboxCopy = { id: 'ib-1', uid: 77, is_read: true };
+const inboxCopy = { id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', account_id: ACCT_ID, thread_key: 'thread-1', uid: 77, folder: 'INBOX', message_id: '<m@x>', is_read: true, is_deleted: false, metadata_complete: true, folder_uid_validity: 123, folder_observation_generation: 4, folder_topology_identity: 'inbox-incarnation', read_revision: 3, star_revision: 0 };
+let archiveRowsByUid = new Map();
+let currentSnapshot = [];
 
 function buildApp() {
   const app = express();
@@ -62,19 +89,61 @@ function buildApp() {
 
 // Route every query /done issues; archiveWrite is the swappable rowCount of the INBOX row's
 // archive UPDATE/DELETE — the authority for whether this call or a concurrent /done won the race.
-function stubQueries({ inbox = inboxCopy, archiveWrite = { rowCount: 1 } } = {}) {
+function stubQueries({
+  acted = msg,
+  threadRows,
+  archiveWrite = { rowCount: 1 },
+  readRows = [],
+  readError = null,
+  ownedAccount = account,
+  inboxRowPresent = true,
+} = {}) {
+  const snapshot = (threadRows || [acted, ...(inboxCopy ? [inboxCopy] : [])]).map(row => ({
+    is_deleted: false,
+    metadata_complete: true,
+    folder_uid_validity: row.folder === 'INBOX' ? 123 : (row.folder_uid_validity ?? 321),
+    folder_observation_generation: row.folder === 'INBOX' ? 4 : (row.folder_observation_generation ?? 6),
+    folder_topology_identity: row.folder === 'INBOX'
+      ? 'inbox-incarnation'
+      : (row.folder_topology_identity ?? `${row.folder}-incarnation`),
+    read_revision: row.read_revision ?? 0,
+    star_revision: row.star_revision ?? 0,
+    ...row,
+  }));
+  currentSnapshot = snapshot;
+  archiveRowsByUid = new Map(snapshot
+    .filter(row => row.folder === 'INBOX')
+    .map(row => [Number(row.uid), {
+      is_deleted: false, metadata_complete: true, folder_uid_validity: 123, ...row,
+    }]));
   query.mockImplementation(async (sql) => {
-    if (sql.includes('FROM messages m') && sql.includes('JOIN email_accounts')) return { rows: [msg] };
-    if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [account] };
-    if (sql.startsWith('SELECT id, uid, is_read FROM messages')) return { rows: inbox ? [inbox] : [] };
+    if (sql.includes('FROM messages m') && sql.includes('JOIN email_accounts')) return { rows: acted ? [acted] : [] };
+    if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: ownedAccount ? [ownedAccount] : [] };
+    if (sql.includes('f.uid_validity AS folder_uid_validity')) return { rows: snapshot };
+    if (sql.includes('SELECT path, uid_validity')) {
+      return { rows: [
+        { path: 'Archive', uid_validity: 456, observation_generation: 8 },
+        { path: 'INBOX', uid_validity: 123, observation_generation: 4 },
+      ] };
+    }
+    if (sql.includes('UPDATE messages') && sql.includes('jsonb_to_recordset')) {
+      if (readError) throw readError;
+      return { rows: readRows };
+    }
+    // Legacy route seam, retained while the new thread-snapshot tests drive replacement.
+    if (sql.startsWith('SELECT id, uid, is_read FROM messages')) return { rows: snapshot.filter(r => r.folder === 'INBOX').slice(0, 1) };
     if (sql.startsWith('SELECT uid FROM messages')) return { rows: [{ uid: 10 }] };
     if (sql.startsWith('DELETE FROM messages') || sql.startsWith('UPDATE messages SET folder')) return archiveWrite;
+    if (sql.startsWith('SELECT id FROM messages WHERE id')) {
+      return { rows: inboxRowPresent ? [{ id: inboxCopy.id }] : [] };
+    }
+    if (sql.startsWith('SELECT 1 FROM messages')) return { rows: [{ '?column?': 1 }] };
     return { rows: [] };
   });
 }
 
 const done = (body) => fetch(`${base}/api/gtd/done`, {
-  method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Idempotency-Key': 'done-test-key' }, body: JSON.stringify(body),
 });
 
 let server;
@@ -91,12 +160,104 @@ afterAll(async () => {
 
 beforeEach(() => {
   query.mockReset();
+  archiveRowsByUid = new Map([[Number(inboxCopy.uid), inboxCopy]]);
   Object.values(imapManager).forEach(fn => fn.mockReset());
   [resolveArchiveFolder, isAllMailFolder, adjustFolderCounts, fanOutReadToSiblings, getGtdConfig].forEach(fn => fn.mockReset());
   getGtdConfig.mockResolvedValue({ enabled: true, folders: DEFAULT_GTD_FOLDERS });
   resolveArchiveFolder.mockResolvedValue('Archive');
   isAllMailFolder.mockResolvedValue(false);
   fanOutReadToSiblings.mockResolvedValue(undefined);
+  imapManager.removeMessageCopy.mockResolvedValue(1);
+  createOrLoadGtdDoneOperation.mockReset().mockImplementation(async ({
+    userId, actedMessageId, intent, deriveTargetFolders,
+  }) => {
+    const acted = currentSnapshot.find(row => row.id === actedMessageId);
+    if (!acted || acted.is_deleted || acted.metadata_complete === false) {
+      throw Object.assign(new Error('Message not found'), { status: 404, retryable: false });
+    }
+    const config = await getGtdConfig(ACCT_ID);
+    const target = deriveTargetFolders({
+      enabled: config.enabled, folders: config.folders, states: intent,
+      existing: currentSnapshot.map(row => row.folder),
+    });
+    if (target.error) throw Object.assign(new Error(target.error), { status: target.status });
+    const sorted = [...currentSnapshot].sort((a, b) => String(a.folder).localeCompare(String(b.folder)) || a.uid - b.uid || String(a.id).localeCompare(String(b.id)));
+    const inbox = sorted.filter(row => row.folder === 'INBOX');
+    const labels = sorted.filter(row => target.folders.includes(row.folder));
+    const inboxAnchor = inbox.find(row => row.id === actedMessageId) || inbox[0];
+    const labelAnchor = labels.find(row => row.id === actedMessageId) || labels[0];
+    const last = (rows, anchor) => [...rows.filter(row => row.id !== anchor?.id), ...rows.filter(row => row.id === anchor?.id)];
+    return {
+      key: `test:${userId}:${actedMessageId}`, accountId: ACCT_ID, phase: 'seen', itemIndex: 0,
+      plan: {
+        rows: sorted, inboxRows: last(inbox, inboxAnchor), labelRows: last(labels, labelAnchor),
+        inboxAnchorId: inboxAnchor?.id || null, labelAnchorId: labelAnchor?.id || null,
+        targetFolders: target.folders, archiveFolder: await resolveArchiveFolder(),
+        archiveAllMail: false,
+        archiveObservation: {
+          folder: 'Archive', uidValidity: '456', generation: '8',
+          topologyIdentity: 'archive-incarnation', isPresent: true,
+        },
+      },
+    };
+  });
+  claimGtdDoneOperation.mockReset().mockImplementation(async op => ({ ...op, claimOwner: 'owner-1' }));
+  renewGtdDoneOperation.mockReset().mockImplementation(async op => op);
+  advanceGtdDoneOperation.mockReset().mockImplementation(async (op, phase, itemIndex, outcome, plan) => ({
+    ...op,
+    phase,
+    itemIndex,
+    plan: plan || op.plan,
+    outcomes: [...(op.outcomes || []), ...(outcome ? [outcome] : [])],
+  }));
+  releaseGtdDoneOperation.mockReset().mockResolvedValue(undefined);
+  imapManager.setDesiredFlag.mockImplementation(async (_account, _id, _flag, _value, options) => ({
+    changed: false,
+    acceptance: { delivery: { revision: Number(options.snapshot.readRevision) + 1 } },
+    delivery: { state: 'confirmed' },
+  }));
+  imapManager.moveMessageWithReceipt.mockImplementation(async (...args) => {
+    const uid = await imapManager.moveMessage(...args);
+    const receipt = {
+      folder: args[3], uid, uidValidity: '456', marker: '$MailFlowOp-test',
+      sourceToken: {
+        folder: args[2], uid: args[1], uidValidity: '123', generation: '4',
+      },
+      destinationToken: { folder: args[3], uidValidity: '456', generation: '8' },
+    };
+    const operation = {
+      kind: 'move', accountId: ACCT_ID, marker: receipt.marker,
+      source: receipt.sourceToken, destination: receipt.destinationToken,
+    };
+    const tx = {
+      query: async (sql, params) => {
+        if (/SELECT path, uid_validity, observation_generation, is_present/.test(sql)) {
+          return { rows: [
+            { path: 'Archive', uid_validity: 456, observation_generation: 8, is_present: true },
+            { path: 'INBOX', uid_validity: 123, observation_generation: 4, is_present: true },
+          ] };
+        }
+        if (/SELECT m\.\*/.test(sql)) {
+          const source = archiveRowsByUid.get(Number(args[1]));
+          return { rows: source ? [source] : [] };
+        }
+        if (/^UPDATE messages/.test(sql)) {
+          const write = await query('UPDATE messages SET folder = $1', params);
+          return write.rowCount > 0
+            ? { rowCount: write.rowCount, rows: [{
+                ...archiveRowsByUid.get(Number(args[1])), folder: args[3], uid,
+              }] }
+            : write;
+        }
+        if (/SELECT id, account_id, folder, uid/.test(sql)) return { rows: [] };
+        return query(sql, params);
+      },
+    };
+    await args[4]?.materialize?.(receipt, operation, tx);
+    return receipt;
+  });
+  imapManager.findUidByRecoveryKeyword.mockResolvedValue(88);
+  imapManager.clearMoveRecoveryKeyword.mockResolvedValue(true);
 });
 
 describe('POST /api/gtd/done — id validation', () => {
@@ -106,9 +267,47 @@ describe('POST /api/gtd/done — id validation', () => {
     expect((await res.json()).error).toMatch(/invalid message id/i);
     expect(query).not.toHaveBeenCalled();
   });
+
+  it('rejects a soft-deleted anchor before loading or mutating its live thread', async () => {
+    stubQueries({ acted: { ...msg, is_deleted: true } });
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/message not found/i);
+    expect(getGtdConfig).not.toHaveBeenCalled();
+    expect(imapManager.setFlag).not.toHaveBeenCalled();
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(imapManager.moveMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an incomplete-metadata anchor before loading or mutating its live thread', async () => {
+    stubQueries({ acted: { ...msg, metadata_complete: false } });
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/message not found/i);
+    expect(getGtdConfig).not.toHaveBeenCalled();
+    expect(imapManager.setFlag).not.toHaveBeenCalled();
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(imapManager.moveMessage).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /api/gtd/done — archive count-adjust race', () => {
+  it('returns durable completion even when the terminal broadcast fails', async () => {
+    stubQueries({ archiveWrite: { rowCount: 1 } });
+    imapManager.moveMessage.mockResolvedValue(88);
+    imapManager.broadcast.mockImplementationOnce(() => { throw new Error('socket down'); });
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, phase: 'completed', inboxCleared: true });
+    expect(imapManager.broadcast).toHaveBeenCalledTimes(1);
+  });
+
   it('archives + adjusts both counts when the INBOX-scoped write applied (rowCount 1)', async () => {
     stubQueries({ archiveWrite: { rowCount: 1 } });
     imapManager.moveMessage.mockResolvedValue(88); // UIDPLUS newUid
@@ -118,44 +317,445 @@ describe('POST /api/gtd/done — archive count-adjust race', () => {
     expect(adjustFolderCounts).toHaveBeenCalledTimes(2);
     // The terminal refresh so the rail converges post-done.
     expect(imapManager.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: ACCT_ID }, 'u1');
+    expect(imapManager.moveMessageWithReceipt).toHaveBeenCalledWith(
+      account, inboxCopy.uid, 'INBOX', 'Archive',
+      expect.objectContaining({
+        operationTokens: [
+          {
+            folder: 'INBOX',
+            uidValidity: String(inboxCopy.folder_uid_validity),
+            generation: String(inboxCopy.folder_observation_generation),
+            topologyIdentity: inboxCopy.folder_topology_identity,
+            isPresent: true,
+          },
+          {
+            folder: 'Archive', uidValidity: '456', generation: '8',
+            topologyIdentity: 'archive-incarnation', isPresent: true,
+          },
+        ],
+        snapshot: expect.objectContaining({
+          id: inboxCopy.id, uid: inboxCopy.uid, folder: 'INBOX',
+          uidValidity: String(inboxCopy.folder_uid_validity),
+          folderGeneration: String(inboxCopy.folder_observation_generation),
+        }),
+      }),
+    );
+    expect(resolveArchiveFolder).toHaveBeenCalledTimes(1);
   });
 
   it('no count drift, archived=false when a concurrent /done already moved the INBOX row (rowCount 0)', async () => {
-    stubQueries({ archiveWrite: { rowCount: 0 } });
+    stubQueries({ archiveWrite: { rowCount: 0 }, inboxRowPresent: false });
     imapManager.moveMessage.mockResolvedValue(null); // silent server-side no-op
     const res = await done({ id: MSG_ID, states: ['watch'] });
-    expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ ok: true, archived: false, archiveFailed: false });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ phase: 'archive', inboxCleared: false, uncertain: true });
     expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it('terminates the lifecycle when the frozen Archive epoch is superseded', async () => {
+    stubQueries();
+    imapManager.moveMessage.mockRejectedValue(Object.assign(
+      new Error('Archive UIDVALIDITY changed'),
+      { code: 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED', retryable: true },
+    ));
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toMatchObject({
+      phase: 'archive', inboxCleared: false, retryable: false, uncertain: true,
+      code: 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED',
+    });
+    expect(resolveArchiveFolder).toHaveBeenCalledTimes(1);
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['deleted source', 'FOLDER_OBSERVATION_UNSAFE'],
+    ['deleted destination', 'FOLDER_OBSERVATION_SUPERSEDED'],
+    ['missing native MOVE', 'PROVIDER_NATIVE_MOVE_UNSUPPORTED'],
+    ['unsupported recovery keyword', 'PROVIDER_RECOVERY_MARKER_UNSUPPORTED'],
+  ])('returns terminal lifecycle truth for %s', async (_case, code) => {
+    stubQueries();
+    imapManager.moveMessage.mockRejectedValue(Object.assign(
+      new Error(_case), { code, retryable: true },
+    ));
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({
+      code, phase: 'archive', inboxCleared: false, retryable: false,
+    });
+  });
+
+  it('keeps a transient provider transport failure retryable', async () => {
+    stubQueries();
+    imapManager.moveMessage.mockRejectedValue(Object.assign(
+      new Error('socket timeout'), { code: 'ETIMEDOUT', retryable: true },
+    ));
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+
+    expect(await res.json()).toMatchObject({
+      code: 'ETIMEDOUT', phase: 'archive', inboxCleared: false, retryable: true,
+    });
+  });
+});
+
+describe('POST /api/gtd/done — thread-wide snapshot contract', () => {
+  it('removes every requested-label copy and archives every INBOX member even when the head is another message/state', async () => {
+    const todoA = { id: '11111111-1111-4111-8111-111111111111', account_id: ACCT_ID, thread_key: 'thread-1', uid: 21, folder: 'Todo', message_id: '<old@x>', is_read: true };
+    const todoB = { id: '22222222-2222-4222-8222-222222222222', account_id: ACCT_ID, thread_key: 'thread-1', uid: 22, folder: 'Todo', message_id: '<new@x>', is_read: true };
+    const inboxB = { id: '33333333-3333-4333-8333-333333333333', account_id: ACCT_ID, thread_key: 'thread-1', uid: 78, folder: 'INBOX', message_id: '<new@x>', is_read: true };
+    stubQueries({ threadRows: [msg, todoA, todoB, inboxCopy, inboxB] });
+    imapManager.moveMessage.mockResolvedValueOnce(87).mockResolvedValueOnce(88);
+
+    const res = await done({ id: MSG_ID, states: ['todo'] });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 21, 'Todo', expect.objectContaining({
+      expectedId: todoA.id,
+      notify: false,
+    }));
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, 22, 'Todo', expect.objectContaining({
+      expectedId: todoB.id,
+      notify: false,
+    }));
+    expect(imapManager.moveMessage.mock.calls.map(call => call[1])).toEqual([78, 77]);
+    expect(body).toMatchObject({
+      removed: ['Todo'],
+      labelTargetCount: 2,
+      removedCount: 2,
+      archiveTargetCount: 2,
+      archivedCount: 2,
+      archiveAlreadyGoneCount: 0,
+      archiveFailedCount: 0,
+      archiveUnconfirmedCount: 0,
+      archiveSkippedNoFolderCount: 0,
+      archived: true,
+      inboxCleared: true,
+    });
+  });
+
+  it('allows a null Message-ID because the authorized thread key is the mutation identity', async () => {
+    const noHeader = { ...msg, message_id: null };
+    stubQueries({ acted: noHeader, threadRows: [noHeader, inboxCopy] });
+    imapManager.moveMessage.mockResolvedValue(88);
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, inboxCleared: true });
+  });
+
+  it('stops at the first nonconclusive Seen push and reports only the observed failure', async () => {
+    const unreadTodo = { ...msg, is_read: false };
+    const unreadInbox = { ...inboxCopy, is_read: false };
+    stubQueries({ threadRows: [unreadTodo, unreadInbox], readRows: [unreadTodo, unreadInbox] });
+    imapManager.setDesiredFlag
+      .mockRejectedValueOnce(Object.assign(new Error('flag failed'), { uncertain: true }))
+      .mockImplementationOnce(async (_account, _id, _flag, _value, options) => ({
+        changed: true,
+        acceptance: { delivery: { revision: Number(options.snapshot.readRevision) + 1 } },
+        delivery: { state: 'confirmed' },
+      }));
+    imapManager.moveMessage.mockResolvedValue(88);
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    expect(res.status).toBe(503);
+    expect(imapManager.setDesiredFlag).toHaveBeenCalledTimes(1);
+    expect(imapManager.setDesiredFlag.mock.calls[0][1]).toBe(unreadInbox.id);
+    expect(imapManager.setDesiredFlag.mock.calls[0][4]?.snapshot?.folder).toBe(unreadInbox.folder);
+    expect(imapManager.setDesiredFlag.mock.calls.some(call => call[1] === unreadTodo.id)).toBe(false);
+    expect(await res.json()).toMatchObject({ seenFailedCount: 1 });
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(imapManager.moveMessage).not.toHaveBeenCalled();
+    expect(imapManager.broadcast).toHaveBeenCalledTimes(1);
+  });
+
+  it('all-states removes every concrete row in deduped configured folders', async () => {
+    const sharedA = { id: '11111111-1111-4111-8111-111111111111', account_id: ACCT_ID, thread_key: 'thread-1', uid: 21, folder: 'Shared', message_id: '<a@x>', is_read: true };
+    const sharedB = { id: '22222222-2222-4222-8222-222222222222', account_id: ACCT_ID, thread_key: 'thread-1', uid: 22, folder: 'Shared', message_id: '<b@x>', is_read: true };
+    getGtdConfig.mockResolvedValueOnce({
+      enabled: true,
+      folders: { ...DEFAULT_GTD_FOLDERS, todo: 'Shared', watch: 'Shared' },
+    });
+    stubQueries({ threadRows: [msg, sharedA, sharedB, inboxCopy] });
+    imapManager.moveMessage.mockResolvedValue(88);
+
+    const res = await done({ id: MSG_ID, states: 'all' });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledTimes(2);
+    expect(body).toMatchObject({ labelTargetCount: 2, removedCount: 2, removed: ['Shared'] });
+  });
+
+  it('derives omitted Inbox Done intent from every actual frozen GTD label', async () => {
+    const delegated = {
+      ...msg,
+      id: '11111111-1111-4111-8111-111111111111',
+      uid: 21,
+      folder: 'Delegated',
+    };
+    const someday = {
+      ...msg,
+      id: '22222222-2222-4222-8222-222222222222',
+      uid: 22,
+      folder: 'Someday',
+    };
+    stubQueries({ acted: inboxCopy, threadRows: [inboxCopy, delegated, someday] });
+    imapManager.moveMessage.mockResolvedValue(88);
+
+    const res = await done({ id: inboxCopy.id });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ removed: ['Someday', 'Delegated'], removedCount: 2 });
+    expect(imapManager.removeMessageCopy.mock.calls.map(call => call[2])).toEqual(['Someday', 'Delegated']);
+  });
+
+  it('stops on the first archive failure without touching later archive or label rows', async () => {
+    const inboxB = { id: '33333333-3333-4333-8333-333333333333', account_id: ACCT_ID, thread_key: 'thread-1', uid: 78, folder: 'INBOX', message_id: '<new@x>', is_read: true };
+    stubQueries({ threadRows: [msg, inboxCopy, inboxB] });
+    imapManager.moveMessage
+      .mockRejectedValueOnce(new Error('first move failed'))
+      .mockResolvedValueOnce(88);
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(imapManager.moveMessage).toHaveBeenCalledTimes(1);
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalledWith(
+      ACCT_ID, msg.uid, msg.folder, expect.anything()
+    );
+    expect(body).toMatchObject({ phase: 'archive', inboxCleared: false, uncertain: true });
+  });
+
+  it('returns durable completed and pending counts after a partial archive throws', async () => {
+    const inboxB = {
+      ...inboxCopy,
+      id: '33333333-3333-4333-8333-333333333333',
+      uid: 78,
+      message_id: '<new@x>',
+    };
+    stubQueries({ threadRows: [msg, inboxCopy, inboxB] });
+    imapManager.moveMessage
+      .mockResolvedValueOnce(88)
+      .mockRejectedValueOnce(new Error('second move failed'));
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toMatchObject({
+      phase: 'archive',
+      inboxCleared: false,
+      archiveTargetCount: 2,
+      archivedCount: 1,
+      archiveAlreadyGoneCount: 0,
+      archiveFailedCount: 0,
+      archiveUnconfirmedCount: 0,
+      archivePendingCount: 1,
+      labelTargetCount: 1,
+      removedCount: 0,
+      labelAlreadyGoneCount: 0,
+      labelUnconfirmedCount: 0,
+      labelPendingCount: 1,
+    });
+    expect(imapManager.moveMessage).toHaveBeenCalledTimes(2);
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+  });
+
+  it('returns durable completed and pending counts after a partial label removal throws', async () => {
+    const delegated = {
+      ...msg,
+      id: '11111111-1111-4111-8111-111111111111',
+      uid: 21,
+      folder: 'Delegated',
+    };
+    stubQueries({ threadRows: [msg, delegated, inboxCopy] });
+    imapManager.moveMessage.mockResolvedValue(88);
+    imapManager.removeMessageCopy
+      .mockResolvedValueOnce(1)
+      .mockRejectedValueOnce(new Error('anchor label removal failed'));
+
+    const res = await done({ id: MSG_ID, states: ['watch', 'delegated'] });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toMatchObject({
+      phase: 'labels',
+      inboxCleared: true,
+      archiveTargetCount: 1,
+      archivedCount: 1,
+      archiveAlreadyGoneCount: 0,
+      archiveFailedCount: 0,
+      archiveUnconfirmedCount: 0,
+      archivePendingCount: 0,
+      labelTargetCount: 2,
+      removedCount: 1,
+      labelAlreadyGoneCount: 0,
+      labelUnconfirmedCount: 0,
+      labelPendingCount: 1,
+    });
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledTimes(2);
+  });
+
+  it('partitions an explicit unconfirmed label outcome separately from pending targets', async () => {
+    const delegated = {
+      ...msg,
+      id: '11111111-1111-4111-8111-111111111111',
+      uid: 21,
+      folder: 'Delegated',
+    };
+    stubQueries({ threadRows: [msg, delegated, inboxCopy] });
+    imapManager.moveMessage.mockResolvedValue(88);
+    imapManager.removeMessageCopy
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(undefined);
+
+    const res = await done({ id: MSG_ID, states: ['watch', 'delegated'] });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      ok: false,
+      phase: 'labels',
+      inboxCleared: true,
+      labelTargetCount: 2,
+      removedCount: 1,
+      labelAlreadyGoneCount: 0,
+      labelUnconfirmedCount: 1,
+      labelPendingCount: 0,
+    });
+  });
+
+  it('partitions every target as skipped when no Archive folder is configured', async () => {
+    const inboxB = { ...inboxCopy, id: '33333333-3333-4333-8333-333333333333', uid: 78 };
+    stubQueries({ threadRows: [msg, inboxCopy, inboxB] });
+    resolveArchiveFolder.mockResolvedValue(null);
+
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    expect(await res.json()).toMatchObject({
+      archiveTargetCount: 2,
+      archiveSkippedNoFolderCount: 1,
+      noArchiveFolder: true,
+      archived: false,
+      inboxCleared: false,
+    });
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalledWith(
+      ACCT_ID, msg.uid, msg.folder, expect.anything()
+    );
+    expect(imapManager.moveMessage).not.toHaveBeenCalled();
+  });
+
+  it('fails before destructive work when durable desired-read acceptance fails', async () => {
+    stubQueries();
+    imapManager.setDesiredFlag.mockRejectedValue(new Error('db down'));
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    expect(res.status).toBe(503);
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(imapManager.moveMessage).not.toHaveBeenCalled();
+    expect(imapManager.broadcast).toHaveBeenCalledWith(
+      { type: 'gtd_sections_updated', accountId: ACCT_ID }, 'u1',
+    );
+  });
+
+  it('rejects an account that disappeared after the owned row load', async () => {
+    stubQueries({ ownedAccount: null });
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    expect(res.status).toBe(404);
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(imapManager.broadcast).not.toHaveBeenCalled();
   });
 });
 
 describe('POST /api/gtd/done — strip-ok + archive-fail', () => {
-  it('returns 200 archived=false archiveFailed=true when only the archive step throws', async () => {
-    stubQueries();
-    imapManager.moveMessage.mockRejectedValue(new Error('IMAP move failed'));
-    const res = await done({ id: MSG_ID, states: ['watch'] });
-    expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ ok: true, archived: false, archiveFailed: true });
-    expect(imapManager.removeMessageCopy).toHaveBeenCalled(); // step (b) still ran
-    expect(adjustFolderCounts).not.toHaveBeenCalled();
-  });
-
-  it('releases both move guards when the non-UIDPLUS archive write throws', async () => {
+  it('does not infer archive success from source disappearance after a DB failure', async () => {
+    let archiveWriteFailed = false;
+    let inboxPresent = true;
+    let archivePresent = false;
     query.mockImplementation(async (sql) => {
       if (sql.includes('FROM messages m') && sql.includes('JOIN email_accounts')) return { rows: [msg] };
       if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [account] };
-      if (sql.startsWith('SELECT id, uid, is_read FROM messages')) return { rows: [inboxCopy] };
-      if (sql.startsWith('SELECT uid FROM messages')) return { rows: [{ uid: 10 }] };
+      if (sql.includes('f.uid_validity AS folder_uid_validity')) {
+        return { rows: inboxPresent ? [msg, inboxCopy] : [msg, ...(archivePresent ? [{ ...inboxCopy, folder: 'Archive', uid: 88 }] : [])] };
+      }
+      if (sql.includes('UPDATE messages') && sql.includes('id = ANY')) return { rows: [] };
+      if (sql.includes('SELECT path, uid_validity')) return { rows: [
+        { path: 'Archive', uid_validity: 456, observation_generation: 8 },
+        { path: 'INBOX', uid_validity: 123, observation_generation: 4 },
+      ] };
+      if (sql.startsWith('UPDATE messages SET folder')) {
+        if (!archiveWriteFailed) {
+          archiveWriteFailed = true;
+          throw new Error('archive write failed');
+        }
+        return { rowCount: 0 };
+      }
+      if (sql.startsWith('SELECT id FROM messages WHERE id')) {
+        return { rows: inboxPresent ? [{ id: inboxCopy.id }] : [] };
+      }
+      return { rows: [] };
+    });
+    imapManager.moveMessage
+      .mockResolvedValueOnce(88)
+      .mockRejectedValueOnce(new Error('no matching message'));
+    imapManager.setFlag
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('no matching message'));
+    imapManager.messageExists.mockResolvedValueOnce(false);
+    imapManager.reconcileMissingMessageCopy.mockImplementationOnce(async () => {
+      inboxPresent = false;
+      archivePresent = true;
+      return { reconciled: true, changed: 1 };
+    });
+
+    const first = await done({ id: MSG_ID, states: ['watch'] });
+    expect(first.status).toBe(500);
+    expect(await first.json()).toMatchObject({ phase: 'archive', inboxCleared: false });
+
+    const second = await done({ id: MSG_ID, states: ['watch'] });
+    expect(second.status).toBe(500);
+    expect(await second.json()).toMatchObject({ inboxCleared: false, phase: 'archive' });
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalledWith(
+      ACCT_ID, msg.uid, msg.folder, expect.anything(),
+    );
+  });
+
+  it('returns a partial result and retains the acted GTD row when the archive step throws', async () => {
+    stubQueries();
+    imapManager.moveMessage.mockRejectedValue(new Error('IMAP move failed'));
+    const res = await done({ id: MSG_ID, states: ['watch'] });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ phase: 'archive', inboxCleared: false });
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it('retains the recovery marker and releases the source guard when the archive write throws', async () => {
+    query.mockImplementation(async (sql) => {
+      if (sql.includes('FROM messages m') && sql.includes('JOIN email_accounts')) return { rows: [msg] };
+      if (sql.startsWith('SELECT * FROM email_accounts')) return { rows: [account] };
+      if (sql.includes('f.uid_validity AS folder_uid_validity')) return { rows: [msg, inboxCopy] };
+      if (sql.includes('UPDATE messages') && sql.includes('id = ANY')) return { rows: [] };
+      if (sql.includes('SELECT path, uid_validity')) return { rows: [
+        { path: 'Archive', uid_validity: 456, observation_generation: 8 },
+        { path: 'INBOX', uid_validity: 123, observation_generation: 4 },
+      ] };
       if (sql.startsWith('UPDATE messages SET folder')) throw new Error('archive write failed');
       return { rows: [] };
     });
-    imapManager.moveMessage.mockResolvedValue(null);
+    imapManager.moveMessage.mockResolvedValue(88);
     const res = await done({ id: MSG_ID, states: ['watch'] });
-    expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ ok: true, archived: false, archiveFailed: true });
-    expect(imapManager._unguardMoveUid).toHaveBeenCalledWith(ACCT_ID, 'Archive', inboxCopy.uid);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ phase: 'archive', inboxCleared: false });
     expect(imapManager._unguardMoveUid).toHaveBeenCalledWith(ACCT_ID, 'INBOX', inboxCopy.uid);
+    expect(imapManager.clearMoveRecoveryKeyword).not.toHaveBeenCalled();
   });
 
   it('full success: archived=true, archiveFailed=false, noArchiveFolder=false', async () => {
@@ -164,20 +764,37 @@ describe('POST /api/gtd/done — strip-ok + archive-fail', () => {
     const res = await done({ id: MSG_ID, states: ['watch'] });
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({ ok: true, archived: true, archiveFailed: false, noArchiveFolder: false });
+    expect(imapManager.moveMessage.mock.invocationCallOrder[0])
+      .toBeLessThan(imapManager.removeMessageCopy.mock.invocationCallOrder[0]);
     // The terminal refresh so the rail converges post-done.
     expect(imapManager.broadcast).toHaveBeenCalledWith({ type: 'gtd_sections_updated', accountId: ACCT_ID }, 'u1');
   });
 
-  it('strip failure still 500s — the contract only softens the archive step, not the label strip', async () => {
+  it('final acted-label failure still 500s after archive while preserving the retry row', async () => {
     stubQueries();
+    imapManager.moveMessage.mockResolvedValue(88);
     imapManager.removeMessageCopy.mockRejectedValue(new Error('IMAP delete failed'));
     const res = await done({ id: MSG_ID, states: ['watch'] });
     expect(res.status).toBe(500);
-    expect(imapManager.moveMessage).not.toHaveBeenCalled(); // never reached the archive step
+    expect(imapManager.moveMessage).toHaveBeenCalledOnce();
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(ACCT_ID, msg.uid, msg.folder, expect.objectContaining({
+      expectedId: MSG_ID,
+      notify: false,
+    }));
   });
 
   it('strips the acted folder LAST, so an earlier strip failure leaves the acted row retryable', async () => {
-    stubQueries();
+    const delegated = {
+      id: '44444444-4444-4444-8444-444444444444',
+      account_id: ACCT_ID,
+      thread_key: 'thread-1',
+      uid: 44,
+      folder: 'Delegated',
+      message_id: '<other@x>',
+      is_read: true,
+    };
+    stubQueries({ threadRows: [delegated, msg, inboxCopy] });
+    imapManager.moveMessage.mockResolvedValue(88);
     // msg.folder is 'Watch' (the acted head). A merged Waiting done strips watch+delegated;
     // fail the NON-acted folder's removal so the loop throws before reaching the acted copy.
     imapManager.removeMessageCopy.mockImplementation(async (_acct, _uid, folder) => {
@@ -191,6 +808,7 @@ describe('POST /api/gtd/done — strip-ok + archive-fail', () => {
     // alive, so a same-id retry still resolves it via loadOwnedMessage (no 404, no orphan).
     const strippedFolders = imapManager.removeMessageCopy.mock.calls.map(c => c[2]);
     expect(strippedFolders).not.toContain('Watch');
-    expect(imapManager.moveMessage).not.toHaveBeenCalled(); // never reached the archive step
+    expect(imapManager.moveMessage).toHaveBeenCalledOnce(); // archive completed before label stripping
+    expect(imapManager.broadcast).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/plugins/gtd/routes.js
+++ b/backend/src/plugins/gtd/routes.js
@@ -4,7 +4,26 @@ import { getGtdSections } from './gtdSections.js';
 import { queueGistGeneration } from './gtdGist.js';
 import { importPet, decodeUploadedSheet, getPetMeta, getPetSheet, parsePetSlug, customPetSlug } from './gtdPet.js';
 import { getGtdConfig, resolveGtdStateFolder, sanitizeGtdFolders, sanitizeGtdFoldersDetailed, DEFAULT_GTD_FOLDERS, planGtdFolderPersist, invalidateGtdConfigCache } from './gtdConfig.js';
-import { applyLabel, removeExactLabelCopy, removeLabel, markThreadRead, ensureLabelFolders, archiveInboxCopy, broadcast, loadOwnedMessage, getOwnedAccount, getMessageCopyFolders, getAccountConfig, setAccountConfig } from '../api.js';
+import {
+  applyLabel,
+  removeExactLabelCopy,
+  removeLabel,
+  removeLabelRow,
+  markThreadRowsRead,
+  ensureLabelFolders,
+  archiveInboxCopy,
+  broadcast,
+  loadOwnedMessage,
+  getOwnedAccount,
+  getAccountConfig,
+  setAccountConfig,
+  createOrLoadGtdDoneOperation,
+  claimGtdDoneOperation,
+  renewGtdDoneOperation,
+  advanceGtdDoneOperation,
+  releaseGtdDoneOperation,
+} from '../api.js';
+import { executeGtdDonePhases } from './gtdDonePhases.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -55,6 +74,52 @@ export function resolveDoneFolders({ enabled, folders, states, existing }) {
     if (!resolved.includes(folder)) resolved.push(folder);
   }
   return { folders: resolved };
+}
+
+function summarizeDoneOperation(operation, outcome = {}) {
+  const plan = operation.plan;
+  const entries = operation.outcomes || [];
+  const archiveUnconfirmedCount = Number(outcome.archiveUnconfirmedCount || 0);
+  const labelUnconfirmedCount = Number(outcome.labelUnconfirmedCount || 0);
+  const archiveEntries = entries.filter(entry => entry.phase === 'archive' && entry.rowId);
+  const labelEntries = entries.filter(entry => entry.phase === 'labels' && entry.rowId);
+  const archivedCount = archiveEntries.filter(entry => entry.archived === true).length;
+  const archiveAlreadyGoneCount = archiveEntries.filter(entry => entry.alreadyGone === true).length;
+  const removedEntries = labelEntries.filter(entry => entry.removed === true);
+  const labelAlreadyGoneEntries = labelEntries.filter(entry => entry.alreadyGone === true);
+  const removedIds = new Set([...removedEntries, ...labelAlreadyGoneEntries]
+    .filter(entry => entry.removed === true || entry.alreadyGone === true)
+    .map(entry => entry.rowId));
+  const removed = [...new Set(plan.labelRows
+    .filter(row => removedIds.has(row.id))
+    .map(row => row.folder))];
+  const inboxCleared = outcome.inboxCleared === true
+    || plan.inboxRows.length === 0
+    || archiveEntries.length === plan.inboxRows.length
+    || outcome.phase === 'labels'
+    || outcome.phase === 'completed';
+  return {
+    inboxCleared,
+    archiveTargetCount: plan.inboxRows.length,
+    archivedCount,
+    archiveAlreadyGoneCount,
+    archiveFailedCount: 0,
+    archiveUnconfirmedCount,
+    archivePendingCount: Math.max(
+      0,
+      plan.inboxRows.length - archiveEntries.length - archiveUnconfirmedCount,
+    ),
+    labelTargetCount: plan.labelRows.length,
+    removed,
+    removedCount: removedEntries.length,
+    labelAlreadyGoneCount: labelAlreadyGoneEntries.length,
+    labelUnconfirmedCount,
+    labelPendingCount: Math.max(
+      0,
+      plan.labelRows.length - labelEntries.length - labelUnconfirmedCount,
+    ),
+    archived: inboxCleared && plan.inboxRows.length > 0,
+  };
 }
 
 // GET /api/gtd/sections — thread heads + counts per GTD state for GTD display surfaces.
@@ -147,6 +212,8 @@ router.post('/classify', async (req, res) => {
   const { messageId, state } = req.body || {};
   if (!messageId || !state) return res.status(400).json({ error: 'messageId and state are required' });
   if (!UUID_RE.test(messageId)) return res.status(400).json({ error: 'Invalid message id' });
+  const requestKey = req.get('X-Idempotency-Key')?.trim();
+  if (!requestKey) return res.status(400).json({ error: 'X-Idempotency-Key required' });
 
   const msg = await loadOwnedMessage(req.session.userId, messageId);
   if (!msg) return res.status(404).json({ error: 'Message not found' });
@@ -160,7 +227,9 @@ router.post('/classify', async (req, res) => {
 
   let result;
   try {
-    result = await applyLabel(account, msg, toFolder);
+    result = await applyLabel(account, msg, toFolder, {
+      operationKey: `gtd-classify:${req.session.userId}:${requestKey}`,
+    });
   } catch (err) {
     console.error(`GTD classify failed for message ${messageId} -> ${toFolder}:`, err.message);
     return res.status(500).json({ error: 'Failed to apply GTD label' });
@@ -239,101 +308,99 @@ router.delete('/classify', async (req, res) => {
 });
 
 // POST /api/gtd/done { id, states? } — the GTD "done" action. Two callers: the GTD sidebar passes
-// an explicit `states` array (strip that section's labels); the inbox checkmark omits states
-// (or sends 'all') for "done from anywhere" — strip every GTD label the thread carries. The
-// id is its GTD-label-folder copy for the sidebar, or the INBOX copy from the inbox; either way
-// the archive step resolves the INBOX copy from the shared Message-ID rather than acting on
-// `id` directly. In one round trip this: (a) marks the whole thread read (DB fan-out across
-// sibling copies, \Seen on the INBOX copy so it rides the archive move); (b) strips the
-// row's own GTD label copies named in `states` — a merged Waiting row passes both
-// watch+delegated — leaving any GTD labels in OTHER sections intact; (c) archives the INBOX
-// copy if one exists (reusing resolveArchiveFolder + moveMessage, snooze's in-place UPDATE).
-// One terminal gtd_sections_updated broadcast makes the row disappear cleanly on refetch.
+// Thread-wide Done. GTD section rows are heads for (account, thread_key), so the displayed row's
+// Message-ID is not a safe mutation identity: another reply may own the requested label or still
+// live in INBOX. Authorize through the acted UUID, freeze all live rows for its account+thread,
+// then mutate only that immutable worklist. Late arrivals are deliberately left for the next
+// action/sync. Core capabilities own SQL/IMAP; this plugin only orchestrates them.
 router.post('/done', async (req, res) => {
   const { id, states } = req.body || {};
   if (!id) return res.status(400).json({ error: 'id is required' });
   if (!UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid message id' });
-
-  const msg = await loadOwnedMessage(req.session.userId, id);
-  if (!msg) return res.status(404).json({ error: 'Message not found' });
-  if (!msg.message_id) return res.status(400).json({ error: 'Message has no Message-ID — cannot mark done' });
-
-  const { enabled, folders } = await getGtdConfig(msg.account_id);
-
-  // All-states mode (inbox checkmark) resolves against the label copies that actually exist
-  // for this thread; the GTD sidebar's explicit-states path is untouched. Only look copies up when
-  // we'll use them (enabled + all-states); resolveDoneFolders still owns the gtd_enabled gate.
-  const allStates = states == null || states === 'all';
-  let existing;
-  if (allStates && enabled) {
-    existing = await getMessageCopyFolders(msg.account_id, msg.message_id);
-  }
-  const target = allStates
-    ? resolveDoneFolders({ enabled, folders, states: 'all', existing })
-    : resolveDoneFolders({ enabled, folders, states });
-  if (target.error) return res.status(target.status).json({ error: target.error });
-
-  const account = await getOwnedAccount(req.session.userId, msg.account_id);
-
-  // (a) Mark the whole thread read. The DB fan-out (by Message-ID) covers every sibling
-  // copy and adjusts each folder's unread count; \Seen is set on the durable INBOX copy
-  // only (it rides the archive move; Gmail propagates message-wide) — the same per-copy
-  // asymmetry the ordinary read route accepts. A best-effort flag push is never fatal.
-  const { inboxCopy, error: markReadError } = await markThreadRead(account, msg);
-  if (markReadError) console.warn(`GTD done: mark-read for ${id} degraded:`, markReadError.message);
-
-  // (b) Strip this row's GTD label copies. Each is a distinct folder copy resolved from
-  // the shared Message-ID; removeMessageCopy deletes the IMAP + DB copy and adjusts that
-  // label folder's counts, leaving INBOX and other-section labels untouched.
-  //
-  // Strip the acted row's OWN folder (msg.folder) LAST. A merged Waiting done passes both
-  // watch+delegated, and if an earlier copy's removal throws we 500 — but the same-id retry
-  // must still resolve the acted message via loadOwnedMessage. Deleting the acted row first
-  // would 404 that retry and orphan the copies not yet stripped, so keep it alive until every
-  // other copy is gone. (msg.folder is absent from target.folders in the inbox 'all' case —
-  // the acted INBOX row is never stripped anyway — so the ordering is a no-op there.)
-  const stripOrder = [
-    ...target.folders.filter(f => f !== msg.folder),
-    ...target.folders.filter(f => f === msg.folder),
-  ];
-  const removed = [];
+  const lifecycleKey = req.get('X-Idempotency-Key')?.trim();
+  if (!lifecycleKey) return res.status(400).json({ error: 'X-Idempotency-Key required' });
+  // Inbox Done has no section context, so the backend derives every actual GTD label from the
+  // frozen row set. Sidebar callers send their explicit section intent.
+  const intent = states == null ? 'all' : states;
+  let operation;
+  let account;
   try {
-    for (const folder of stripOrder) {
-      const { removed: didRemove } = await removeLabel(msg, folder);
-      if (didRemove) removed.push(folder);
-    }
-  } catch (err) {
-    console.error(`GTD done: label strip for ${id} failed:`, err.message);
-    return res.status(500).json({ error: 'Failed to mark done' });
-  }
+    operation = await createOrLoadGtdDoneOperation({
+      userId: req.session.userId,
+      actedMessageId: id,
+      intent,
+      lifecycleKey,
+      deriveTargetFolders: ({ enabled, folders, states: frozenStates, existing }) => {
+        const resolvedFolders = { ...DEFAULT_GTD_FOLDERS, ...(folders || {}) };
+        return resolveDoneFolders({
+          enabled,
+          folders: resolvedFolders,
+          states: frozenStates,
+          existing,
+        });
+      },
+    });
+    account = await getOwnedAccount(req.session.userId, operation.accountId);
+    if (!account) return res.status(404).json({ error: 'Account not found' });
 
-  // (c) Archive the INBOX copy if one is present, via the shared per-copy archive primitive
-  // (resolveArchiveFolder + guarded moveMessage + race-safe DB repoint + count adjust, with
-  // the Gmail All-Mail DELETE branch). No archive folder configured is a soft outcome, not a
-  // failure — the GTD labels are already gone, so the thread has left all GTD sections regardless.
-  let archived = false;
-  let noArchiveFolder = false;
-  let archiveFailed = false;
-  if (inboxCopy) {
+    const outcome = await executeGtdDonePhases(operation, {
+      claim: claimGtdDoneOperation,
+      renew: renewGtdDoneOperation,
+      release: releaseGtdDoneOperation,
+      advance: advanceGtdDoneOperation,
+      markSeen: rows => markThreadRowsRead(account, rows),
+      archive: row => archiveInboxCopy(account, row, {
+        archiveFolder: operation.plan.archiveFolder,
+        archiveAllMail: operation.plan.archiveAllMail,
+        archiveObservation: operation.plan.archiveObservation,
+      }),
+      removeLabel: row => removeLabelRow(row, { notify: false }),
+    });
+    const completedOperation = outcome.operation || operation;
+    const summary = summarizeDoneOperation(completedOperation, outcome);
     try {
-      const result = await archiveInboxCopy(account, inboxCopy);
-      archived = result.archived;
-      noArchiveFolder = result.noArchiveFolder;
-    } catch (err) {
-      // Step (b) already stripped the labels (or had nothing to strip). A failed archive must
-      // not 500: that misreports a mostly-successful action, and — with the label row now
-      // gone — a retry by the same id would 404. Report a partial success (200, archiveFailed
-      // true, archived false) so the client can surface it and the id stays retryable.
-      console.error(`GTD done: archive of INBOX copy for ${id} failed:`, err.message);
-      archiveFailed = true;
+      broadcast({ type: 'gtd_sections_updated', accountId: operation.accountId }, account.user_id);
+    } catch (error) {
+      console.warn(`GTD done terminal broadcast failed for ${operation.key}:`, error.message);
     }
+    const response = {
+      ok: outcome.complete,
+      phase: outcome.phase,
+      retryable: !outcome.complete,
+      uncertain: !outcome.complete,
+      ...summary,
+      seenFailedCount: outcome.seenFailedCount || 0,
+      noArchiveFolder: outcome.noArchiveFolder === true,
+      archiveFailed: !outcome.complete && outcome.phase === 'archive',
+      archiveSkippedNoFolderCount: outcome.noArchiveFolder === true ? 1 : 0,
+    };
+    return res.status(outcome.phase === 'seen' ? 503 : 200).json(response);
+  } catch (err) {
+    console.error(`GTD done for ${id} failed:`, err.message);
+    const failedOperation = err.gtdDoneOperation || operation;
+    const phase = err.gtdDonePhase || failedOperation?.phase || 'snapshot';
+    const summary = failedOperation?.plan
+      ? summarizeDoneOperation(failedOperation, {
+          phase,
+          inboxCleared: err.inboxCleared === true,
+        })
+      : { inboxCleared: err.inboxCleared === true };
+    if (operation && account) {
+      try {
+        broadcast({ type: 'gtd_sections_updated', accountId: operation.accountId }, account.user_id);
+      } catch (broadcastError) {
+        console.warn(`GTD done terminal broadcast failed for ${operation.key}:`, broadcastError.message);
+      }
+    }
+    return res.status(err.status || 500).json({
+      error: err.message || 'Failed to mark done',
+      code: err.code,
+      phase,
+      ...summary,
+      retryable: err.retryable !== false,
+      uncertain: true,
+    });
   }
-
-  // One terminal refresh so GTD section data converges to the post-done state (removeMessageCopy
-  // also emits mid-op, but this covers the archive that follows it).
-  broadcast({ type: 'gtd_sections_updated', accountId: msg.account_id }, account.user_id);
-
-  res.json({ ok: true, removed, archived, noArchiveFolder, archiveFailed });
 });
 
 // POST /api/gtd/folders/ensure { accountId, folders } — create any of the account's

--- a/backend/src/plugins/mailEngineFacade.js
+++ b/backend/src/plugins/mailEngineFacade.js
@@ -40,6 +40,6 @@ export function createPluginMailFacade(engine) {
     syncFolderOnDemand: (account, folder) => engine.syncFolderOnDemand(account, folder),
 
     // Remove a message's copy from a label folder (GTD transition strips).
-    removeMessageCopy: (accountId, uid, folder) => engine.removeMessageCopy(accountId, uid, folder),
+    removeMessageCopy: (accountId, uid, folder, options) => engine.removeMessageCopy(accountId, uid, folder, options),
   });
 }

--- a/backend/src/routes/categories.actions.test.js
+++ b/backend/src/routes/categories.actions.test.js
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => {
+    req.session = { userId: 'user-1' };
+    next();
+  },
+}));
+vi.mock('../services/categorizer.js', () => ({
+  invalidateSocialDomainCache: vi.fn(),
+  backfillCategories: vi.fn(),
+  aiClassifyMessage: vi.fn(),
+  BUILTIN_SETS: {},
+}));
+vi.mock('../services/hostValidation.js', () => ({ validateHost: vi.fn() }));
+vi.mock('../services/safeFetch.js', () => ({ safeFetch: vi.fn() }));
+
+import express from 'express';
+import categoryRoutes from './categories.js';
+import { query } from '../services/db.js';
+import { aiClassifyMessage } from '../services/categorizer.js';
+
+const MESSAGE_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('POST /api/mail/categories/ai-classify/:messageId integrity boundary', () => {
+  let server;
+  let base;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/mail', categoryRoutes);
+    await new Promise(resolve => { server = app.listen(0, resolve); });
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    query.mockReset();
+    aiClassifyMessage.mockReset();
+  });
+
+  it('does not classify a deleted or metadata-incomplete row', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+
+    const response = await fetch(`${base}/api/mail/categories/ai-classify/${MESSAGE_ID}`, { method: 'POST' });
+
+    expect(response.status).toBe(404);
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0][0]).toMatch(/m\.is_deleted = false/);
+    expect(query.mock.calls[0][0]).toMatch(/m\.metadata_complete = true/);
+    expect(query.mock.calls[0][0]).toMatch(/JOIN folders live_folder/);
+    expect(query.mock.calls[0][0]).toMatch(/live_folder\.is_present = true/);
+    expect(query.mock.calls[0][0]).toMatch(/live_folder\.uid_validity IS NOT NULL/);
+    expect(aiClassifyMessage).not.toHaveBeenCalled();
+  });
+
+  it('fails closed if the row becomes hidden before the category update', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ subject: 'Subject', from_email: 'sender@example.com', snippet: 'Snippet' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    aiClassifyMessage.mockResolvedValueOnce('promotion');
+
+    const response = await fetch(`${base}/api/mail/categories/ai-classify/${MESSAGE_ID}`, { method: 'POST' });
+
+    expect(response.status).toBe(404);
+    const updateSql = query.mock.calls[1][0];
+    expect(updateSql).toMatch(/messages\.is_deleted = false/);
+    expect(updateSql).toMatch(/messages\.metadata_complete = true/);
+    expect(updateSql).toMatch(/RETURNING messages\.id/);
+  });
+});

--- a/backend/src/routes/categories.js
+++ b/backend/src/routes/categories.js
@@ -236,7 +236,11 @@ router.post('/categories/ai-classify/:messageId', requireAuth, async (req, res) 
     SELECT m.subject, m.from_email, m.snippet
     FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
-    WHERE m.id = $1 AND a.user_id = $2 AND m.is_deleted = false
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
+    WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [messageId, req.session.userId]);
 
   if (!msgResult.rows.length) return res.status(404).json({ error: 'Message not found' });
@@ -246,12 +250,19 @@ router.post('/categories/ai-classify/:messageId', requireAuth, async (req, res) 
   if (!category) return res.status(503).json({ error: 'AI classification unavailable or failed' });
 
   // Persist the AI-assigned category.
-  await query(
+  const updateResult = await query(
     `UPDATE messages SET category = $1
      FROM email_accounts a
-     WHERE messages.id = $2 AND messages.account_id = a.id AND a.user_id = $3`,
+     JOIN folders live_folder ON live_folder.account_id = a.id
+     WHERE messages.id = $2 AND messages.account_id = a.id AND a.user_id = $3
+       AND live_folder.path = messages.folder
+       AND live_folder.is_present = true
+       AND live_folder.uid_validity IS NOT NULL
+       AND messages.is_deleted = false AND messages.metadata_complete = true
+     RETURNING messages.id`,
     [category === 'primary' ? null : category, messageId, req.session.userId]
   );
+  if (!updateResult.rows.length) return res.status(404).json({ error: 'Message not found' });
 
   res.json({ ok: true, category });
 });

--- a/backend/src/routes/draft.js
+++ b/backend/src/routes/draft.js
@@ -1,5 +1,5 @@
 import nodemailer from 'nodemailer';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes, randomUUID } from 'crypto';
 import { Router } from 'express';
 import { query } from '../services/db.js';
 import { requireAuth } from '../middleware/auth.js';
@@ -7,6 +7,7 @@ import sanitizeHtml from 'sanitize-html';
 import { sanitizeSignature, sanitizeComposeBody } from '../services/emailSanitizer.js';
 import { embedInlineDataImages } from '../utils/inlineImages.js';
 import { imapManager } from '../index.js';
+import { snapshotFromMessageRow } from '../services/messageSnapshots.js';
 
 const router = Router();
 router.use(requireAuth);
@@ -36,7 +37,10 @@ function textToHtml(text) {
     .join('');
 }
 
-async function buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml, quotedBody, quotedBodyHtml, editedSignature }) {
+async function buildRawDraft({
+  accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml, quotedBody,
+  quotedBodyHtml, editedSignature, messageIdToken,
+}) {
   const acctResult = await query(
     'SELECT * FROM email_accounts WHERE id = $1',
     [accountId]
@@ -83,7 +87,7 @@ async function buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, b
 
   // Stable Message-ID so the appended MIME and the local DB row reference the same
   // message (and a later sync reconciles cleanly).
-  const messageId = `<${randomBytes(16).toString('hex')}@${(fromEmail.split('@')[1] || 'mailflow.local')}>`;
+  const messageId = `<${messageIdToken || randomBytes(16).toString('hex')}@${(fromEmail.split('@')[1] || 'mailflow.local')}>`;
   const textBody = sigText ? `${bodyText}\n\n-- \n${sigText}${quotedBody || ''}` : `${bodyText}${quotedBody || ''}`;
 
   const mailOptions = {
@@ -129,6 +133,30 @@ async function resolveDraftsFolder(account) {
 router.post('/draft', async (req, res) => {
   const { accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml = false, quotedBody, quotedBodyHtml, editedSignature, existingUid, existingFolder } = req.body;
   if (!accountId) return res.status(400).json({ error: 'accountId required' });
+  const suppliedOperationKey = typeof req.headers['x-idempotency-key'] === 'string'
+    ? req.headers['x-idempotency-key'].trim().slice(0, 128)
+    : null;
+  const logicalOperationKey = suppliedOperationKey || `compat-${randomUUID()}`;
+  // A client key identifies one save attempt across process/network retries. Bind it to
+  // the exact editable payload so reusing that key after an edit cannot replay the old
+  // provider receipt and materialize stale draft contents.
+  const payloadDigest = createHash('sha256').update(JSON.stringify({
+    accountId,
+    aliasId: aliasId || null,
+    to: Array.isArray(to) ? to : [],
+    cc: Array.isArray(cc) ? cc : [],
+    bcc: Array.isArray(bcc) ? bcc : [],
+    subject: subject || '',
+    body: body || '',
+    bodyIsHtml: Boolean(bodyIsHtml),
+    quotedBody: quotedBody || '',
+    quotedBodyHtml: quotedBodyHtml || '',
+    editedSignature: editedSignature ?? null,
+    existingUid: existingUid ?? null,
+    existingFolder: existingFolder || null,
+  })).digest('hex');
+  const appendOperationKey = `draft:${req.session.userId}:${logicalOperationKey}:${payloadDigest}`;
+  const messageIdToken = createHash('sha256').update(appendOperationKey).digest('hex');
 
   const ownerCheck = await query(
     'SELECT id FROM email_accounts WHERE id = $1 AND user_id = $2',
@@ -137,43 +165,70 @@ router.post('/draft', async (req, res) => {
   if (!ownerCheck.rows.length) return res.status(404).json({ error: 'Account not found' });
 
   try {
-    const { rawMessage, account, meta } = await buildRawDraft({ accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml, quotedBody, quotedBodyHtml, editedSignature });
+    const { rawMessage, account, meta } = await buildRawDraft({
+      accountId, aliasId, to, cc, bcc, subject, body, bodyIsHtml, quotedBody,
+      quotedBodyHtml, editedSignature, messageIdToken,
+    });
 
     const draftsFolder = await resolveDraftsFolder(account);
     if (!draftsFolder) return res.status(422).json({ error: 'No Drafts folder found for this account' });
 
-    // APPEND the new draft first so we never lose the message
-    const { uid } = await imapManager.appendToFolder(account, draftsFolder, rawMessage, ['\\Draft', '\\Seen']);
-
-    // Persist a local Drafts row immediately so the composer can reopen this draft
-    // (recipient/subject/body) even if the folder re-sync is delayed or fails on a
-    // flaky connection. Non-fatal — the append already stored the message on IMAP.
-    if (uid != null) {
-      try {
-        await imapManager.upsertDraftMessageRecord(account, draftsFolder, uid, {
-          messageId: meta.messageId,
-          subject,
-          fromName: meta.fromName,
-          fromEmail: meta.fromEmail,
-          to: mapRecipientList(to),
-          cc: mapRecipientList(cc),
-          snippet: meta.snippet,
-          bodyHtml: meta.bodyHtml,
-          bodyText: meta.bodyText,
-        });
-      } catch (rowErr) {
-        console.error(`Draft: failed to persist local row uid=${uid}: ${rowErr.message}`);
-      }
-    }
+    // APPEND and local materialization share one durable operation receipt. If the process
+    // dies after the provider accepts APPEND, replay searches the causal marker and resumes
+    // this idempotent upsert without issuing APPEND again.
+    const { uid } = await imapManager.appendToFolder(
+      account,
+      draftsFolder,
+      rawMessage,
+      ['\\Draft', '\\Seen'],
+      {
+        operationKey: appendOperationKey,
+        materialize: async ({ uid: appendedUid }, tx) => {
+          const draftMeta = {
+            messageId: meta.messageId,
+            subject,
+            fromName: meta.fromName,
+            fromEmail: meta.fromEmail,
+            to: mapRecipientList(to),
+            cc: mapRecipientList(cc),
+            snippet: meta.snippet,
+            bodyHtml: meta.bodyHtml,
+            bodyText: meta.bodyText,
+          };
+          return tx
+            ? imapManager.upsertDraftMessageRecord(
+                account, draftsFolder, appendedUid, draftMeta, { tx },
+              )
+            : imapManager.upsertDraftMessageRecord(
+                account, draftsFolder, appendedUid, draftMeta,
+              );
+        },
+      },
+    );
 
     // Delete the old draft only after the new one is safely stored
     if (existingUid && existingFolder) {
       try {
-        await imapManager.permanentDeleteMessage(account, existingUid, existingFolder);
-        await query(
-          'DELETE FROM messages WHERE account_id = $1 AND uid = $2 AND folder = $3',
-          [account.id, existingUid, existingFolder]
+        const old = await query(
+          `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+                  f.uid_validity AS folder_uid_validity,
+                  f.observation_generation AS folder_observation_generation
+             FROM messages m
+             JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+               AND f.is_present = true AND f.uid_validity IS NOT NULL
+            WHERE m.account_id = $1 AND m.uid = $2 AND m.folder = $3
+              AND m.is_deleted = false AND m.metadata_complete = true
+            LIMIT 2`,
+          [account.id, existingUid, existingFolder],
         );
+        if (old.rows.length !== 1) throw new Error('Old draft coordinate is missing or ambiguous');
+        const row = old.rows[0];
+        await imapManager.removeMessageCopy(account.id, row.uid, row.folder, {
+          expectedId: row.id,
+          expectedUidValidity: row.folder_uid_validity,
+          snapshot: snapshotFromMessageRow(row),
+          operationKey: `draft-replace:${row.id}:${appendOperationKey}`,
+        });
       } catch (delErr) {
         console.error(`Draft: failed to delete old uid=${existingUid}: ${delErr.message}`);
       }
@@ -201,11 +256,26 @@ router.delete('/draft/:uid', async (req, res) => {
 
   try {
     const account = ownerCheck.rows[0];
-    await imapManager.permanentDeleteMessage(account, uid, folder);
-    await query(
-      'DELETE FROM messages WHERE account_id = $1 AND uid = $2 AND folder = $3',
-      [account.id, uid, folder]
+    const exact = await query(
+      `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+              f.uid_validity AS folder_uid_validity,
+              f.observation_generation AS folder_observation_generation
+         FROM messages m
+         JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+           AND f.is_present = true AND f.uid_validity IS NOT NULL
+        WHERE m.account_id = $1 AND m.uid = $2 AND m.folder = $3
+          AND m.is_deleted = false AND m.metadata_complete = true
+        LIMIT 2`,
+      [account.id, uid, folder],
     );
+    if (exact.rows.length !== 1) return res.status(404).json({ error: 'Draft not found' });
+    const row = exact.rows[0];
+    await imapManager.removeMessageCopy(account.id, row.uid, row.folder, {
+      expectedId: row.id,
+      expectedUidValidity: row.folder_uid_validity,
+      snapshot: snapshotFromMessageRow(row),
+      operationKey: `draft-delete:${row.id}`,
+    });
     res.json({ ok: true });
   } catch (err) {
     console.error('Delete draft failed:', err.message);

--- a/backend/src/routes/draft.test.js
+++ b/backend/src/routes/draft.test.js
@@ -8,6 +8,7 @@ const imapManager = vi.hoisted(() => ({
   appendToFolder: vi.fn(),
   upsertDraftMessageRecord: vi.fn(),
   permanentDeleteMessage: vi.fn(),
+  removeMessageCopy: vi.fn(),
 }));
 vi.mock('../index.js', () => ({ imapManager }));
 
@@ -19,6 +20,10 @@ const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
 const ACCOUNT_ROW = {
   id: ACCOUNT_ID, email_address: 'matthias@mailflow.sh', name: 'Matt',
   sender_name: null, signature: null, folder_mappings: {},
+};
+const DRAFT_HEADERS = {
+  'content-type': 'application/json',
+  'x-idempotency-key': 'draft-save-1',
 };
 
 function buildApp() {
@@ -40,18 +45,22 @@ describe('POST /api/mail/draft — local row persistence', () => {
     imapManager.appendToFolder.mockReset();
     imapManager.upsertDraftMessageRecord.mockReset();
     imapManager.permanentDeleteMessage.mockReset();
+    imapManager.removeMessageCopy.mockReset();
     // 1) owner check, 2) buildRawDraft account load, 3) resolveDraftsFolder lookup
     query.mockResolvedValueOnce({ rows: [{ id: ACCOUNT_ID }] });
     query.mockResolvedValueOnce({ rows: [ACCOUNT_ROW] });
     query.mockResolvedValueOnce({ rows: [{ path: 'Drafts' }] });
-    imapManager.appendToFolder.mockResolvedValue({ uid: 5, folder: 'Drafts' });
+    imapManager.appendToFolder.mockImplementation(async (_account, folder, _raw, _flags, options) => {
+      await options.materialize({ uid: 5, uidValidity: '202', folder });
+      return { uid: 5, uidValidity: '202', folder };
+    });
     imapManager.upsertDraftMessageRecord.mockResolvedValue(undefined);
   });
 
   it('persists a Drafts row with parsed recipient, subject and body after append', async () => {
     const res = await fetch(`${base}/api/mail/draft`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: DRAFT_HEADERS,
       body: JSON.stringify({
         accountId: ACCOUNT_ID,
         to: ['Mike Scanlan <mike@scanlan.ai>'],
@@ -77,25 +86,120 @@ describe('POST /api/mail/draft — local row persistence', () => {
     expect(meta.messageId).toMatch(/^<[0-9a-f]+@mailflow\.sh>$/);
   });
 
-  it('still returns success if the local row persistence throws (append already stored it)', async () => {
+  it('keeps a provider-applied draft recoverable when local row persistence throws', async () => {
     imapManager.upsertDraftMessageRecord.mockRejectedValueOnce(new Error('db down'));
     const res = await fetch(`${base}/api/mail/draft`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ accountId: ACCOUNT_ID, to: ['a@b.com'], subject: 'x', body: 'y' }),
+      headers: DRAFT_HEADERS,
+      body: JSON.stringify({ accountId: ACCOUNT_ID, to: ['a@example.com'], subject: 'x', body: 'y' }),
     });
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ uid: 5, folder: 'Drafts' });
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/db down/i);
+    expect(imapManager.permanentDeleteMessage).not.toHaveBeenCalled();
   });
 
-  it('does not persist a row when the append returns no uid (no reliable key)', async () => {
-    imapManager.appendToFolder.mockResolvedValueOnce({ uid: null, folder: 'Drafts' });
+  it('does not persist a row when APPEND remains causally uncertain', async () => {
+    imapManager.appendToFolder.mockRejectedValueOnce(
+      Object.assign(new Error('marker absent'), { code: 'PROVIDER_MARKER_ABSENT' }),
+    );
     const res = await fetch(`${base}/api/mail/draft`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ accountId: ACCOUNT_ID, to: ['a@b.com'], subject: 'x', body: 'y' }),
+      headers: DRAFT_HEADERS,
+      body: JSON.stringify({ accountId: ACCOUNT_ID, to: ['a@example.com'], subject: 'x', body: 'y' }),
     });
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(500);
     expect(imapManager.upsertDraftMessageRecord).not.toHaveBeenCalled();
+  });
+
+  it('materializes the new draft inside durable APPEND completion before deleting the old draft', async () => {
+    const events = [];
+    imapManager.appendToFolder.mockImplementationOnce(async (_account, folder, _raw, _flags, options) => {
+      expect(options.operationKey).toMatch(/^draft:user-1:draft-save-1:[a-f0-9]{64}$/);
+      expect(options.operationKey).not.toContain('@');
+      events.push('append-receipt');
+      await options.materialize({ uid: 9, uidValidity: '202', folder });
+      events.push('append-completed');
+      return { uid: 9, uidValidity: '202', folder };
+    });
+    imapManager.upsertDraftMessageRecord.mockImplementationOnce(async () => { events.push('row'); });
+    imapManager.removeMessageCopy.mockImplementationOnce(async () => { events.push('delete-old'); });
+    query.mockResolvedValueOnce({ rows: [{
+      id: 'old-row', account_id: ACCOUNT_ID, uid: 4, folder: 'Drafts',
+      folder_uid_validity: '101', folder_observation_generation: '3',
+    }] });
+
+    const res = await fetch(`${base}/api/mail/draft`, {
+      method: 'POST',
+      headers: DRAFT_HEADERS,
+      body: JSON.stringify({
+        accountId: ACCOUNT_ID, to: ['a@example.com'], subject: 'x', body: 'y',
+        existingUid: 4, existingFolder: 'Drafts',
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(events).toEqual(['append-receipt', 'row', 'append-completed', 'delete-old']);
+  });
+
+  it('accepts legacy headerless saves with unique compatibility identities while preserving client keys', async () => {
+    const body = JSON.stringify({ accountId: ACCOUNT_ID, subject: 'same', body: 'same' });
+    const keys = [];
+    imapManager.appendToFolder.mockImplementation(async (_account, folder, _raw, _flags, options) => {
+      keys.push(options.operationKey);
+      return { uid: keys.length, uidValidity: '202', folder };
+    });
+    const missing = await fetch(`${base}/api/mail/draft`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body,
+    });
+    expect(missing.status).toBe(200);
+
+    for (const key of ['new-draft-1', 'new-draft-2']) {
+      query.mockResolvedValueOnce({ rows: [{ id: ACCOUNT_ID }] });
+      query.mockResolvedValueOnce({ rows: [ACCOUNT_ROW] });
+      query.mockResolvedValueOnce({ rows: [{ path: 'Drafts' }] });
+      const response = await fetch(`${base}/api/mail/draft`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-idempotency-key': key },
+        body,
+      });
+      expect(response.status).toBe(200);
+    }
+    expect(keys[0]).toMatch(/^draft:user-1:compat-[0-9a-f-]{36}:[a-f0-9]{64}$/);
+    expect(keys[1]).toMatch(/^draft:user-1:new-draft-1:[a-f0-9]{64}$/);
+    expect(keys[2]).toMatch(/^draft:user-1:new-draft-2:[a-f0-9]{64}$/);
+    expect(keys[0]).not.toBe(keys[1]);
+    expect(keys[0].split(':').at(-1)).toBe(keys[1].split(':').at(-1));
+    expect(keys[1].split(':').at(-1)).toBe(keys[2].split(':').at(-1));
+  });
+
+  it('binds a reused client key to payload content so edit-after-failure is a new APPEND', async () => {
+    query.mockReset().mockImplementation(async sql => {
+      if (sql.includes('SELECT id FROM email_accounts')) return { rows: [{ id: ACCOUNT_ID }] };
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [ACCOUNT_ROW] };
+      if (sql.includes('SELECT path FROM folders')) return { rows: [{ path: 'Drafts' }] };
+      return { rows: [] };
+    });
+    const operationKeys = [];
+    imapManager.appendToFolder.mockImplementation(async (_account, folder, _raw, _flags, options) => {
+      operationKeys.push(options.operationKey);
+      await options.materialize({ uid: operationKeys.length, uidValidity: '202', folder });
+      return { uid: operationKeys.length, uidValidity: '202', folder };
+    });
+    const save = body => fetch(`${base}/api/mail/draft`, {
+      method: 'POST', headers: DRAFT_HEADERS,
+      body: JSON.stringify({ accountId: ACCOUNT_ID, subject: 'draft', body }),
+    });
+
+    expect((await save('first')).status).toBe(200);
+    expect((await save('first')).status).toBe(200);
+    expect((await save('edited')).status).toBe(200);
+
+    expect(operationKeys[1]).toBe(operationKeys[0]);
+    expect(operationKeys[2]).not.toBe(operationKeys[1]);
+    const messageIds = imapManager.upsertDraftMessageRecord.mock.calls.map(([, , , meta]) => (
+      meta.messageId
+    ));
+    expect(messageIds[1]).toBe(messageIds[0]);
+    expect(messageIds[2]).not.toBe(messageIds[1]);
   });
 });

--- a/backend/src/routes/mail.actions.test.js
+++ b/backend/src/routes/mail.actions.test.js
@@ -1,0 +1,400 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const imapManager = vi.hoisted(() => ({
+  setFlag: vi.fn(),
+  setDesiredFlag: vi.fn(),
+  bulkMoveMessages: vi.fn(),
+  moveMessage: vi.fn(),
+  permanentDeleteMessage: vi.fn(),
+  removeMessageCopy: vi.fn(),
+  ensureFolder: vi.fn(),
+  _guardMoveUid: vi.fn(),
+  _unguardMoveUid: vi.fn(),
+  _enqueueFlagPush: vi.fn(),
+  _resolveFlagPush: vi.fn(),
+  broadcast: vi.fn(),
+}));
+
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => {
+    req.session = { userId: 'user-1' };
+    next();
+  },
+}));
+vi.mock('../index.js', () => ({ imapManager }));
+
+import express from 'express';
+import mailRoutes from './mail.js';
+import { query } from '../services/db.js';
+import { pluginRegistry } from '../plugins/registry.js';
+
+const MESSAGE_ID = '11111111-1111-4111-8111-111111111111';
+const MESSAGE_ID_2 = '22222222-2222-4222-8222-222222222222';
+const UPPER_MESSAGE_ID = 'AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA';
+const LOWER_MESSAGE_ID = UPPER_MESSAGE_ID.toLowerCase();
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/mail', mailRoutes);
+  return app;
+}
+
+async function request(base, method, path, body) {
+  const requestBody = path.includes('/bulk-') && Array.isArray(body?.ids)
+    ? {
+        ...body,
+        operationKeys: Object.fromEntries(body.ids.map(id => [id, `row-key:${id}`])),
+      }
+    : body;
+  return fetch(`${base}${path}`, {
+    method,
+    headers: body ? {
+      'Content-Type': 'application/json',
+      ...(path.includes('/bulk-') ? { 'X-Idempotency-Key': 'test-action-1' } : {}),
+    } : undefined,
+    body: requestBody ? JSON.stringify(requestBody) : undefined,
+  });
+}
+
+describe('message action ownership boundaries', () => {
+  let server;
+  let base;
+
+  beforeAll(async () => {
+    await new Promise(resolve => {
+      server = buildApp().listen(0, resolve);
+    });
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise(resolve => server.close(resolve));
+  });
+
+  beforeEach(() => {
+    query.mockReset();
+    query.mockResolvedValue({ rows: [] });
+    for (const method of Object.values(imapManager)) method.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('creates an independent desired Seen record for every exact live sibling row', async () => {
+    const acted = {
+      id: MESSAGE_ID, account_id: 'acct-1', uid: 7, folder: 'INBOX', message_id: '<m>',
+      is_read: false, sibling_count: 2,
+      folder_uid_validity: '101', folder_observation_generation: '9',
+      read_revision: '3', star_revision: '5',
+    };
+    const sibling = {
+      ...acted, id: MESSAGE_ID_2, uid: 70, folder: 'Todo',
+      folder_uid_validity: '102', folder_observation_generation: '10', read_revision: '8',
+    };
+    vi.spyOn(pluginRegistry, 'hasActiveAsync').mockResolvedValue(true);
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM messages m') && sql.includes('sibling_count')) return { rows: [acted] };
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [{ id: 'acct-1' }] };
+      if (sql.includes('m.message_id = $2') && sql.includes('m.id <> $3')) return { rows: [sibling] };
+      return { rows: [] };
+    });
+    imapManager.setDesiredFlag.mockResolvedValue({ changed: true });
+
+    const response = await request(
+      base, 'PATCH', `/api/mail/messages/${MESSAGE_ID}/read`, { read: true },
+    );
+
+    expect(response.status).toBe(200);
+    expect(imapManager.setDesiredFlag).toHaveBeenCalledTimes(2);
+    expect(imapManager.setDesiredFlag).toHaveBeenNthCalledWith(
+      2, { id: 'acct-1' }, MESSAGE_ID_2, '\\Seen', true,
+      { snapshot: expect.objectContaining({
+        id: MESSAGE_ID_2, uid: 70, folder: 'Todo', uidValidity: '102', folderGeneration: '10',
+      }) },
+    );
+  });
+
+  it.each([
+    ['mark read', 'PATCH', `/api/mail/messages/${MESSAGE_ID}/read`, { read: true }, 404],
+    ['star', 'PATCH', `/api/mail/messages/${MESSAGE_ID}/star`, { starred: true }, 404],
+    ['bulk read', 'POST', '/api/mail/messages/bulk-read', { ids: [MESSAGE_ID], read: true }, 200],
+    ['bulk delete', 'POST', '/api/mail/messages/bulk-delete', { ids: [MESSAGE_ID] }, 200],
+    ['bulk move', 'POST', '/api/mail/messages/bulk-move', { ids: [MESSAGE_ID], folder: 'Archive' }, 200],
+    ['bulk archive', 'POST', '/api/mail/messages/bulk-archive', { ids: [MESSAGE_ID] }, 200],
+    ['snooze', 'POST', `/api/mail/messages/${MESSAGE_ID}/snooze`, { until: new Date(Date.now() + 86_400_000).toISOString() }, 404],
+    ['delete', 'DELETE', `/api/mail/messages/${MESSAGE_ID}`, undefined, 404],
+    ['mark spam', 'POST', `/api/mail/messages/${MESSAGE_ID}/spam`, {}, 404],
+    ['mark ham', 'POST', `/api/mail/messages/${MESSAGE_ID}/ham`, {}, 404],
+    ['set category', 'PATCH', `/api/mail/messages/${MESSAGE_ID}/category`, { category: 'primary' }, 404],
+    ['unsubscribe', 'POST', `/api/mail/messages/${MESSAGE_ID}/unsubscribe`, {}, 404],
+  ])('rejects an incomplete or deleted row before %s', async (_name, method, path, body, status) => {
+    const response = await request(base, method, path, body);
+
+    expect(response.status).toBe(status);
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = query.mock.calls[0][0];
+    expect(sql).toMatch(/(?:m|messages)\.is_deleted\s*=\s*false/);
+    expect(sql).toMatch(/(?:m|messages)\.metadata_complete\s*=\s*true/);
+    expect(sql).toMatch(/JOIN folders live_folder/);
+    expect(sql).toMatch(/live_folder\.is_present\s*=\s*true/);
+    expect(sql).toMatch(/live_folder\.uid_validity IS NOT NULL/);
+    for (const imapMethod of Object.values(imapManager)) {
+      expect(imapMethod).not.toHaveBeenCalled();
+    }
+  });
+
+  it('creates an independent exact-row desired Seen delivery for every bulk-read row', async () => {
+    const rows = [
+      {
+        id: MESSAGE_ID, account_id: 'acct-1', uid: 7, folder: 'INBOX', is_read: false,
+        folder_uid_validity: '101', folder_observation_generation: '9',
+        read_revision: '3', star_revision: '5',
+      },
+      {
+        id: MESSAGE_ID_2, account_id: 'acct-1', uid: 8, folder: 'INBOX', is_read: false,
+        folder_uid_validity: '101', folder_observation_generation: '9',
+        read_revision: '4', star_revision: '6',
+      },
+    ];
+    query.mockImplementation(async sql => {
+      if (sql.includes('m.id = ANY($2::uuid[])') && sql.includes('m.is_read')) return { rows };
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [{ id: 'acct-1' }] };
+      return { rows: [], rowCount: 1 };
+    });
+    imapManager.setDesiredFlag.mockResolvedValue({ changed: true, delivery: { state: 'confirmed' } });
+
+    const response = await request(
+      base, 'POST', '/api/mail/messages/bulk-read', { ids: [MESSAGE_ID, MESSAGE_ID_2], read: true },
+    );
+
+    expect(response.status).toBe(200);
+    expect(imapManager.setDesiredFlag).toHaveBeenCalledTimes(2);
+    expect(imapManager.setDesiredFlag).toHaveBeenNthCalledWith(
+      1, { id: 'acct-1' }, MESSAGE_ID, '\\Seen', true,
+      { snapshot: expect.objectContaining({ id: MESSAGE_ID, uid: 7, readRevision: 3 }) },
+    );
+    expect(imapManager.setDesiredFlag).toHaveBeenNthCalledWith(
+      2, { id: 'acct-1' }, MESSAGE_ID_2, '\\Seen', true,
+      { snapshot: expect.objectContaining({ id: MESSAGE_ID_2, uid: 8, readRevision: 4 }) },
+    );
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE messages SET is_read'))).toBe(false);
+  });
+
+  it.each([
+    ['read', 'read', true, '\\Seen'],
+    ['star', 'starred', true, '\\Flagged'],
+  ])('records %s as one exact revisioned desired delivery before provider work', async (route, field, value, flag) => {
+    const message = {
+      id: MESSAGE_ID, account_id: 'acct-1', uid: 7, folder: 'INBOX',
+      is_read: false, is_starred: false, sibling_count: 1,
+      folder_uid_validity: '101', folder_observation_generation: '9',
+      read_revision: '3', star_revision: '5',
+    };
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM messages m') && sql.includes('sibling_count')) return { rows: [message] };
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [{ id: 'acct-1' }] };
+      return { rows: [], rowCount: 1 };
+    });
+    imapManager.setDesiredFlag.mockResolvedValue({
+      changed: true, delivery: { state: 'confirmed' },
+    });
+
+    const response = await request(
+      base, 'PATCH', `/api/mail/messages/${MESSAGE_ID}/${route}`, { [field]: value },
+    );
+
+    expect(response.status).toBe(200);
+    expect(imapManager.setDesiredFlag).toHaveBeenCalledWith(
+      { id: 'acct-1' }, MESSAGE_ID, flag, true,
+      { snapshot: {
+        id: MESSAGE_ID, accountId: 'acct-1', uid: 7, folder: 'INBOX',
+        uidValidity: '101', folderGeneration: '9', readRevision: 3, starRevision: 5,
+      } },
+    );
+    expect(imapManager.setFlag).not.toHaveBeenCalled();
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE messages SET is_'))).toBe(false);
+  });
+
+  it('gives legacy bulk requests stable server compatibility identities', async () => {
+    const rows = [{
+      id: MESSAGE_ID, account_id: 'acct-1', folder: 'INBOX', uid: 7, is_read: false,
+      folder_uid_validity: '101', folder_observation_generation: '4',
+    }];
+    query.mockImplementation(async sql => {
+      if (/SELECT m\.\*, a\.user_id[\s\S]*FROM messages/.test(sql)) return { rows };
+      if (/SELECT 1 FROM folders/.test(sql)) return { rows: [{ '?column?': 1 }] };
+      if (/SELECT \* FROM email_accounts/.test(sql)) return { rows: [{ id: 'acct-1' }] };
+      return { rows: [], rowCount: 1 };
+    });
+    imapManager.bulkMoveMessages.mockResolvedValue({
+      succeeded: [7], failed: [], uidMap: new Map([[7, 70]]),
+    });
+    const response = await fetch(`${base}/api/mail/messages/bulk-move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Idempotency-Key': 'legacy-batch-key' },
+      body: JSON.stringify({ ids: [MESSAGE_ID], folder: 'Archive' }),
+    });
+
+    expect(response.status).toBe(200);
+    const options = imapManager.bulkMoveMessages.mock.calls[0][4];
+    expect(options.operationKeys.get(7)).toMatch(/^compat:[a-f0-9]{64}$/);
+  });
+
+  it('uses the client exact row-key map across a mixed bulk-move subset', async () => {
+    const rows = [
+      { id: MESSAGE_ID, account_id: 'acct-1', folder: 'INBOX', uid: 7, is_read: false,
+        folder_uid_validity: '101', folder_observation_generation: '4' },
+      { id: MESSAGE_ID_2, account_id: 'acct-1', folder: 'INBOX', uid: 8, is_read: true,
+        folder_uid_validity: '101', folder_observation_generation: '4' },
+    ];
+    query.mockImplementation(async sql => {
+      if (/SELECT m\.\*, a\.user_id[\s\S]*FROM messages/.test(sql)) return { rows };
+      if (/SELECT 1 FROM folders/.test(sql)) return { rows: [{ '?column?': 1 }] };
+      if (/SELECT \* FROM email_accounts/.test(sql)) return { rows: [{ id: 'acct-1' }] };
+      return { rows: [], rowCount: 1 };
+    });
+    imapManager.bulkMoveMessages.mockResolvedValue({
+      succeeded: [7, 8], failed: [], uidMap: new Map([[7, 70], [8, 80]]),
+    });
+    const operationKeys = {
+      [MESSAGE_ID]: 'persisted-row-key-1',
+      [MESSAGE_ID_2]: 'new-row-key-2',
+    };
+
+    const response = await fetch(`${base}/api/mail/messages/bulk-move`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [MESSAGE_ID, MESSAGE_ID_2], folder: 'Archive', operationKeys }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(imapManager.bulkMoveMessages).toHaveBeenCalledWith(
+      { id: 'acct-1' }, [7, 8], 'INBOX', 'Archive', expect.objectContaining({
+        operationKeys: new Map([[7, 'persisted-row-key-1'], [8, 'new-row-key-2']]),
+        sourceSnapshots: expect.any(Map),
+      }),
+    );
+    const options = imapManager.bulkMoveMessages.mock.calls[0][4];
+    expect(options.sourceSnapshots.get(7)).toMatchObject({
+      id: MESSAGE_ID, uid: 7, uidValidity: '101', folderGeneration: '4',
+    });
+  });
+
+  it.each([
+    ['retained row key', { operationKeys: { [MESSAGE_ID]: 'retained-delete-key' } }],
+    ['legacy request shape', {}],
+  ])('replays a completed Trash MOVE for %s without expunging the relocated row', async (
+    _shape, requestShape,
+  ) => {
+    const row = {
+      id: MESSAGE_ID, account_id: 'acct-1', folder: 'Trash', uid: 70,
+      folder_mappings: { trash: 'Trash', drafts: 'Drafts' },
+      folder_uid_validity: '202', folder_observation_generation: '8',
+      is_read: false, is_deleted: false, metadata_complete: true,
+    };
+    query.mockImplementation(async (sql, params) => {
+      if (/SELECT m\.\*, a\.user_id[\s\S]*FROM messages/.test(sql)) return { rows: [row] };
+      if (/FROM provider_operations/.test(sql)) {
+        const requestKey = requestShape.operationKeys?.[MESSAGE_ID] || params.at(-1)?.[0];
+        return { rows: [{
+          operation_key: 'completed-move', account_id: 'acct-1', kind: 'move',
+          request_key: requestKey, source_message_id: MESSAGE_ID,
+          destination_folder: 'Trash', state: 'completed',
+          receipt: { folder: 'Trash', uid: 70, uidValidity: '202' },
+        }] };
+      }
+      if (/SELECT \* FROM email_accounts/.test(sql)) return { rows: [{ id: 'acct-1' }] };
+      if (/FROM folders/.test(sql)) {
+        return { rows: [{ path: 'Trash', name: 'Trash', special_use: '\\Trash' }] };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    const response = await fetch(`${base}/api/mail/messages/bulk-delete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [MESSAGE_ID], ...requestShape }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true, deleted: [MESSAGE_ID] });
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(imapManager.bulkMoveMessages).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['bulk-delete', {}, 'deleted'],
+    ['bulk-move', { folder: 'Archive' }, 'moved'],
+    ['bulk-archive', {}, 'archived'],
+  ])('rejects case-variant duplicate row ids for %s', async (route, extra, resultField) => {
+    const response = await fetch(`${base}/api/mail/messages/${route}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ids: [UPPER_MESSAGE_ID, LOWER_MESSAGE_ID],
+        ...extra,
+        operationKeys: {
+          [UPPER_MESSAGE_ID]: 'upper-row-key',
+          [LOWER_MESSAGE_ID]: 'lower-row-key',
+        },
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).not.toHaveProperty(resultField);
+    expect(query).not.toHaveBeenCalled();
+    expect(imapManager.bulkMoveMessages).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['bulk-delete', {}, 'deleted', 'Trash'],
+    ['bulk-move', { folder: 'Archive' }, 'moved', 'Archive'],
+    ['bulk-archive', {}, 'archived', 'Archive'],
+  ])('preserves an uppercase row id exact key through lowercase DB results for %s', async (
+    route, extra, resultField, destination,
+  ) => {
+    const row = {
+      id: LOWER_MESSAGE_ID,
+      account_id: 'acct-1',
+      folder: 'INBOX',
+      folder_mappings: route === 'bulk-delete'
+        ? { trash: 'Trash', drafts: 'Drafts' }
+        : { archive: 'Archive' },
+      uid: 7,
+      is_read: false,
+    };
+    query.mockImplementation(async (sql, params) => {
+      if (/SELECT m\.\*, a\.user_id/.test(sql)) {
+        expect(params[1]).toEqual([LOWER_MESSAGE_ID]);
+        return { rows: [row] };
+      }
+      if (/SELECT 1 FROM folders/.test(sql) && /special_use = '\\All'/.test(sql)) {
+        return { rows: [] };
+      }
+      if (/SELECT 1 FROM folders/.test(sql)) return { rows: [{ '?column?': 1 }] };
+      if (/SELECT \* FROM email_accounts/.test(sql)) return { rows: [{ id: 'acct-1' }] };
+      return { rows: [], rowCount: 1 };
+    });
+    imapManager.bulkMoveMessages.mockResolvedValue({
+      succeeded: [7], failed: [], uidMap: new Map([[7, 70]]),
+    });
+
+    const response = await fetch(`${base}/api/mail/messages/${route}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ids: [UPPER_MESSAGE_ID],
+        ...extra,
+        operationKeys: { [UPPER_MESSAGE_ID]: `exact-key:${route}` },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect((await response.json())[resultField]).toEqual([LOWER_MESSAGE_ID]);
+    expect(imapManager.bulkMoveMessages).toHaveBeenCalledWith(
+      { id: 'acct-1' }, [7], 'INBOX', destination, expect.objectContaining({
+        operationKeys: new Map([[7, `exact-key:${route}`]]),
+      }),
+    );
+  });
+});

--- a/backend/src/routes/mail.emptyFolder.test.js
+++ b/backend/src/routes/mail.emptyFolder.test.js
@@ -4,7 +4,7 @@ vi.mock('../services/db.js', () => ({ query: vi.fn() }));
 vi.mock('../middleware/auth.js', () => ({
   requireAuth: (req, _res, next) => { req.session = { userId: 'user-1' }; next(); },
 }));
-vi.mock('../index.js', () => ({ imapManager: { emptyFolder: vi.fn(), broadcast: vi.fn() } }));
+vi.mock('../index.js', () => ({ imapManager: { removeMessageCopy: vi.fn(), broadcast: vi.fn() } }));
 
 import express from 'express';
 import mailRoutes from './mail.js';
@@ -13,6 +13,11 @@ import { imapManager } from '../index.js';
 
 const ACCOUNT_ID = 'c3c3c3c3-3333-4333-8333-c3c3c3c3c3c3';
 const ACCOUNT = { id: ACCOUNT_ID, user_id: 'user-1' };
+const ROW = {
+  id: 'row-1', account_id: ACCOUNT_ID, uid: 17, folder: 'Trash',
+  folder_uid_validity: '101', folder_observation_generation: '4',
+  read_revision: 0, star_revision: 0,
+};
 
 function buildApp() {
   const app = express();
@@ -29,9 +34,13 @@ describe('POST /api/mail/folders/empty — async background empty', () => {
   beforeAll(async () => { await new Promise(r => { server = buildApp().listen(0, r); }); base = `http://127.0.0.1:${server.address().port}`; });
   afterAll(async () => { await new Promise(r => server.close(r)); });
   beforeEach(() => {
-    query.mockReset(); imapManager.emptyFolder.mockReset(); imapManager.broadcast.mockReset();
-    query.mockImplementation((sql) => {
+    query.mockReset(); imapManager.removeMessageCopy.mockReset(); imapManager.broadcast.mockReset();
+    query.mockImplementation((sql, params) => {
       if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return Promise.resolve({ rows: [ACCOUNT] });
+      if (sql.includes('FROM folders WHERE account_id = $1 AND path = $2')) {
+        return Promise.resolve({ rows: [{ backfill_incomplete: false }] });
+      }
+      if (sql.includes('FROM messages m')) return Promise.resolve({ rows: [{ ...ROW, folder: params[1] }] });
       return Promise.resolve({ rows: [] });
     });
   });
@@ -42,19 +51,23 @@ describe('POST /api/mail/folders/empty — async background empty', () => {
   });
 
   it('returns 202 immediately and finishes the delete in the background', async () => {
-    imapManager.emptyFolder.mockResolvedValue(undefined);
+    imapManager.removeMessageCopy.mockResolvedValue(1);
     const res = await empty('Trash');
     expect(res.status).toBe(202);
     expect((await res.json()).started).toBe(true);
     await tick();
-    expect(imapManager.emptyFolder).toHaveBeenCalledWith(ACCOUNT, 'Trash');
-    expect(clearedDb()).toBe(true);
+    expect(imapManager.removeMessageCopy).toHaveBeenCalledWith(
+      ACCOUNT_ID, 17, 'Trash', expect.objectContaining({
+        expectedId: 'row-1', expectedUidValidity: '101', snapshot: expect.objectContaining({ id: 'row-1' }),
+      }),
+    );
+    expect(clearedDb()).toBe(false);
     expect(emittedType('folder_emptied')?.ok).toBe(true);
     expect(emittedType('sync_complete')).toBeTruthy();
   });
 
   it('leaves the DB rows intact and reports failure when the IMAP empty throws', async () => {
-    imapManager.emptyFolder.mockRejectedValue(new Error('throttled'));
+    imapManager.removeMessageCopy.mockRejectedValue(new Error('throttled'));
     const res = await empty('Archive');
     expect(res.status).toBe(202);
     await tick();
@@ -65,12 +78,31 @@ describe('POST /api/mail/folders/empty — async background empty', () => {
 
   it('rejects a concurrent empty of the same folder with 409', async () => {
     let release;
-    imapManager.emptyFolder.mockImplementation(() => new Promise(r => { release = r; }));
+    imapManager.removeMessageCopy.mockImplementation(() => new Promise(r => { release = r; }));
     const first = await empty('Junk');
     expect(first.status).toBe(202);
     const second = await empty('Junk');   // same folder still in flight
     expect(second.status).toBe(409);
     release();                            // let the first complete so the guard clears
     await tick();
+  });
+
+  it('refuses to empty a folder until its exact backfill is complete', async () => {
+    query.mockImplementation((sql) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) {
+        return Promise.resolve({ rows: [ACCOUNT] });
+      }
+      if (sql.includes('FROM folders WHERE account_id = $1 AND path = $2')) {
+        return Promise.resolve({ rows: [{ backfill_incomplete: true }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await empty('Trash');
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/sync is incomplete/i);
+    expect(imapManager.removeMessageCopy).not.toHaveBeenCalled();
+    expect(imapManager.broadcast).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { createHash } from 'node:crypto';
 import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const archiver = require('archiver');
@@ -7,13 +8,31 @@ import { requireAuth } from '../middleware/auth.js';
 import { imapManager } from '../index.js';
 import { sanitizeEmail, stripEmailHead, hasRemoteImages, blockRemoteImages, rewriteEbayImageserUrls, rewriteAnchorHrefs } from '../services/emailSanitizer.js';
 import { snippetFromBody, decodeMimeWords, parseRawHeaders, buildHeadersFromMessage } from '../services/messageParser.js';
-import { resolveTrashFolder, resolveAllTrashPaths, resolveAllDraftsPaths, resolveArchiveFolder, isAllMailFolder, resolveSpamFolder, resolveAllSpamPaths, getDeleteStrategy, adjustFolderCounts, fanOutReadToSiblings, fanOutStarToSiblings, fanOutBulkReadToSiblings } from '../utils/mailUtils.js';
+import { resolveTrashFolder, resolveAllTrashPaths, resolveAllDraftsPaths, resolveArchiveFolder, isAllMailFolder, resolveSpamFolder, resolveAllSpamPaths, getDeleteStrategy } from '../utils/mailUtils.js';
 import { pluginRegistry } from '../plugins/registry.js';
 import { listMessages } from '../services/messageService.js';
 import { resolveAccountScope } from '../services/unifiedInbox.js';
 import { validateHost } from '../services/hostValidation.js';
 import { safeFetch } from '../services/safeFetch.js';
 import { safeFilename, attachmentDisposition } from '../utils/contentDisposition.js';
+import {
+  MessageSnapshotError,
+  revalidateLiveMessageSnapshots,
+  snapshotFromMessageRow,
+} from '../services/messageSnapshots.js';
+import { materializeArchiveReceipt } from '../services/archiveInbox.js';
+
+function materializeOrdinaryMove(destinationFolder, allMail = false) {
+  return (row, receipt, operation, tx, providerResource) => materializeArchiveReceipt(tx, {
+    accountId: row.account_id,
+    sourceSnapshot: row,
+    destinationFolder,
+    receipt,
+    operation,
+    allMail,
+    providerResource,
+  });
+}
 
 const router = Router();
 router.use(requireAuth);
@@ -27,6 +46,33 @@ router.use(requireAuth);
 const accountMaintainsLabelSiblings = (accountId) =>
   pluginRegistry.hasActiveAsync('inboxIngest', { account: { id: accountId } });
 
+async function deliverDesiredFlagToLiveSiblings(account, message, flag, value) {
+  if (!message.message_id) return;
+  const siblings = await query(
+    `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                     AND f.is_present = true AND f.uid_validity IS NOT NULL
+      WHERE m.account_id = $1 AND m.message_id = $2 AND m.id <> $3
+        AND m.is_deleted = false AND m.metadata_complete = true
+      ORDER BY m.id`,
+    [message.account_id, message.message_id, message.id],
+  );
+  let firstError;
+  for (const sibling of siblings.rows) {
+    try {
+      await imapManager.setDesiredFlag(
+        account, sibling.id, flag, value, { snapshot: snapshotFromMessageRow(sibling) },
+      );
+    } catch (err) {
+      if (!err?.uncertain) firstError ||= err;
+    }
+  }
+  if (firstError) throw firstError;
+}
+
 // Validate a folder name / path component: no control chars, max 255 chars.
 function isValidFolderName(name) {
   // eslint-disable-next-line no-control-regex -- intentionally rejecting control characters
@@ -36,6 +82,42 @@ function isValidFolderName(name) {
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 function areValidUUIDs(ids) {
   return ids.every(id => typeof id === 'string' && UUID_RE.test(id));
+}
+
+function validatedRowOperationKeys(ids, value, compatibility) {
+  const canonicalIds = ids.map(id => id.toLowerCase());
+  if (new Set(canonicalIds).size !== ids.length) return null;
+  if (value == null) {
+    return new Map(canonicalIds.map(id => {
+      const digest = createHash('sha256')
+        .update(`${compatibility.userId}\0${compatibility.kind}\0${id}\0${compatibility.destination || ''}`)
+        .digest('hex');
+      return [id, `compat:${digest}`];
+    }));
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) return null;
+  const valueEntries = Object.entries(value);
+  if (valueEntries.length !== ids.length) return null;
+  const valuesByCanonicalId = new Map();
+  for (const [id, key] of valueEntries) {
+    if (!UUID_RE.test(id)) return null;
+    const canonicalId = id.toLowerCase();
+    if (valuesByCanonicalId.has(canonicalId)) return null;
+    valuesByCanonicalId.set(canonicalId, key);
+  }
+  const keys = new Map();
+  const seen = new Set();
+  for (const id of canonicalIds) {
+    if (!valuesByCanonicalId.has(id)) return null;
+    const key = valuesByCanonicalId.get(id);
+    if (typeof key !== 'string' || key.length < 1 || key.length > 128 ||
+        key !== key.trim() ||
+        // eslint-disable-next-line no-control-regex -- operation keys must be safe text
+        /[\x00-\x1f\x7f]/.test(key) || seen.has(key)) return null;
+    keys.set(id, key);
+    seen.add(key);
+  }
+  return keys;
 }
 
 // Strip NUL bytes from strings before DB writes. PostgreSQL UTF-8 text columns
@@ -81,7 +163,8 @@ const RELOCATE_COPY_COLS = [
   'read_changed_at', 'star_changed_at', 'spam_score_sa', 'spam_score_ml', 'spam_verdict',
   'spam_analyzed_at', 'spam_details', 'spam_user_override', 'category', 'list_unsubscribe',
   'list_unsubscribe_post', 'unsubscribed_at', 'delivery_addresses', 'plugin_annotations',
-  'sender_name', 'sender_email',
+  'sender_name', 'sender_email', 'metadata_complete',
+  'read_revision', 'star_revision', 'provider_modseq',
 ];
 // INSERT target list and the matching SELECT projection. account_id + the carried columns come
 // from the deleted row; uid is the UIDPLUS-mapped new uid; folder is the destination ($4).
@@ -176,9 +259,13 @@ router.get('/messages/:id', async (req, res) => {
              a.color AS account_color
       FROM messages m
       JOIN email_accounts a ON m.account_id = a.id
+      JOIN folders live_folder ON live_folder.account_id = m.account_id
+        AND live_folder.path = m.folder AND live_folder.is_present = true
+        AND live_folder.uid_validity IS NOT NULL
       WHERE m.id = $1
         AND a.user_id = $2
         AND m.is_deleted = false
+        AND m.metadata_complete = true
     `, [id, req.session.userId]);
     if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
     res.json(result.rows[0]);
@@ -218,9 +305,13 @@ router.get('/resolve-message', async (req, res) => {
       SELECT ${COLS}
       FROM messages m
       JOIN email_accounts a ON m.account_id = a.id
+      JOIN folders live_folder ON live_folder.account_id = m.account_id
+        AND live_folder.path = m.folder AND live_folder.is_present = true
+        AND live_folder.uid_validity IS NOT NULL
       WHERE m.message_id = $1
         AND a.user_id = $2
         AND m.is_deleted = false
+        AND m.metadata_complete = true
         AND ($3::uuid IS NULL OR m.account_id = $3)
       ORDER BY (m.folder = 'INBOX') DESC, m.date DESC NULLS LAST
       LIMIT 1
@@ -231,9 +322,13 @@ router.get('/resolve-message', async (req, res) => {
         SELECT ${COLS}
         FROM messages m
         JOIN email_accounts a ON m.account_id = a.id
+        JOIN folders live_folder ON live_folder.account_id = m.account_id
+          AND live_folder.path = m.folder AND live_folder.is_present = true
+          AND live_folder.uid_validity IS NOT NULL
         WHERE m.id = $1
           AND a.user_id = $2
           AND m.is_deleted = false
+          AND m.metadata_complete = true
           AND ($3::uuid IS NULL OR m.account_id = $3)
       `, [ref, req.session.userId, accountId]);
     }
@@ -291,7 +386,11 @@ router.get('/thread/:threadId', async (req, res) => {
                a.name AS account_name, a.email_address AS account_email, a.color AS account_color
         FROM messages m
         JOIN email_accounts a ON m.account_id = a.id
+        JOIN folders live_folder ON live_folder.account_id = m.account_id
+          AND live_folder.path = m.folder AND live_folder.is_present = true
+          AND live_folder.uid_validity IS NOT NULL
         WHERE m.is_deleted = false
+          AND m.metadata_complete = true
           AND m.account_id = ANY($1)
           AND m.thread_key = $2
         ORDER BY m.message_id,
@@ -319,8 +418,12 @@ router.get('/unread-counts', async (req, res) => {
     SELECT m.account_id, a.include_in_unified_inbox, COUNT(*) AS count
     FROM messages m
     JOIN email_accounts a ON a.id = m.account_id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE a.user_id = $1 AND a.enabled = true
       AND m.folder = 'INBOX' AND m.is_read = false AND m.is_deleted = false
+      AND m.metadata_complete = true
     GROUP BY m.account_id, a.include_in_unified_inbox
   `, [req.session.userId]);
 
@@ -359,14 +462,22 @@ router.get('/messages/:id/body', async (req, res) => {
   if (!UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid message id' });
 
   const result = await query(`
-    SELECT m.*, a.user_id, u.preferences FROM messages m
+    SELECT m.*, a.user_id, u.preferences,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation
+    FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     JOIN users u ON u.id = a.user_id
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
   const message = result.rows[0];
+  const messageSnapshot = snapshotFromMessageRow(message);
 
   // Return cached body if available — but re-fetch when the cached HTML still
   // contains unresolved cid: references, or http:// image URLs that were cached
@@ -440,7 +551,7 @@ router.get('/messages/:id/body', async (req, res) => {
     imapManager.noteUserActivity(account.id);
 
     const { html, text, attachments } = await fetchWithTimeout(
-      imapManager.fetchMessageBody(account, message.uid, message.folder),
+      imapManager.fetchMessageBody(account, message.uid, message.folder, { snapshot: messageSnapshot }),
       BODY_FETCH_TIMEOUT_MS
     );
 
@@ -451,14 +562,31 @@ router.get('/messages/:id/body', async (req, res) => {
     // Only cache when we actually got body content — don't overwrite a prior
     // successful cache with null if a transient IMAP fetch returns nothing.
     if (safeHtml || text || (attachments && attachments.length > 0)) {
-      await query(
+      const cached = await query(
         `UPDATE messages
          SET body_html = $1, body_text = $2, attachments = $3,
              snippet = CASE WHEN $5 != '' THEN $5 ELSE snippet END
-         WHERE id = $4`,
-        [safeHtml, safeText, JSON.stringify(attachments || []), id, snip]
+         WHERE id = $4 AND account_id = $6 AND uid = $7 AND folder = $8
+           AND is_deleted = false AND metadata_complete = true
+           AND EXISTS (
+             SELECT 1 FROM folders f
+              WHERE f.account_id = messages.account_id AND f.path = messages.folder
+                AND f.is_present = true AND f.uid_validity = $9
+                AND f.observation_generation = $10
+           )
+         RETURNING id`,
+        [
+          safeHtml, safeText, JSON.stringify(attachments || []), id, snip,
+          messageSnapshot.accountId, messageSnapshot.uid, messageSnapshot.folder,
+          messageSnapshot.uidValidity, messageSnapshot.folderGeneration,
+        ]
       );
+      if (cached.rowCount === 0) {
+        throw new MessageSnapshotError('Message relocated before body publication');
+      }
     }
+
+    await revalidateLiveMessageSnapshots(message.account_id, [messageSnapshot]);
 
     // Apply remote-image blocking at response time — safeHtml (unblocked) is what
     // was written to the DB cache above, preserving the canonical body.
@@ -487,6 +615,9 @@ router.get('/messages/:id/body', async (req, res) => {
         timeout: true,
       });
     }
+    if (err?.code === 'MESSAGE_SNAPSHOT_SUPERSEDED') {
+      return res.status(409).json({ error: msg, code: err.code, retryable: true });
+    }
     res.status(500).json({ error: msg });
   }
 });
@@ -497,13 +628,21 @@ router.get('/messages/:id/headers', async (req, res) => {
   if (!UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid message id' });
 
   const result = await query(`
-    SELECT m.*, a.user_id FROM messages m
+    SELECT m.*, a.user_id,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation
+    FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
   const message = result.rows[0];
+  const messageSnapshot = snapshotFromMessageRow(message);
 
   try {
     const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]);
@@ -511,14 +650,19 @@ router.get('/messages/:id/headers', async (req, res) => {
 
     let headers = '';
     try {
-      headers = await imapManager.fetchHeaders(account, message.uid, message.folder);
+      headers = await imapManager.fetchHeaders(
+        account, message.uid, message.folder, { snapshot: messageSnapshot },
+      );
     } catch (fetchErr) {
+      if (fetchErr?.code === 'MESSAGE_SNAPSHOT_SUPERSEDED') throw fetchErr;
       console.warn('Headers IMAP fetch failed:', fetchErr.message);
     }
 
     if (!headers?.trim()) {
       headers = buildHeadersFromMessage(message);
     }
+
+    await revalidateLiveMessageSnapshots(message.account_id, [messageSnapshot]);
 
     let resolvedSubject = message.subject;
     if (headers?.trim()) {
@@ -535,6 +679,9 @@ router.get('/messages/:id/headers', async (req, res) => {
     res.json({ headers, subject: resolvedSubject });
   } catch (err) {
     console.error('Headers fetch error:', err);
+    if (err?.code === 'MESSAGE_SNAPSHOT_SUPERSEDED') {
+      return res.status(409).json({ error: err.message, code: err.code, retryable: true });
+    }
     res.status(500).json({ error: 'Failed to fetch message headers' });
   }
 });
@@ -549,13 +696,21 @@ router.get('/messages/:id/attachments.zip', async (req, res) => {
   if (!UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid message id' });
 
   const result = await query(`
-    SELECT m.*, a.user_id FROM messages m
+    SELECT m.*, a.user_id,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation
+    FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
   const message = result.rows[0];
+  const messageSnapshot = snapshotFromMessageRow(message);
 
   const attachments = typeof message.attachments === 'string'
     ? JSON.parse(message.attachments || '[]')
@@ -578,7 +733,9 @@ router.get('/messages/:id/attachments.zip', async (req, res) => {
     if (!accountResult.rows.length) return res.status(404).json({ error: 'Account not found' });
     const account = accountResult.rows[0];
 
-    const bufferMap = await imapManager.fetchMultipleAttachments(account, message.uid, message.folder, eligible);
+    const bufferMap = await imapManager.fetchMultipleAttachments(
+      account, message.uid, message.folder, eligible, { snapshot: messageSnapshot },
+    );
     if (bufferMap.size === 0) return res.status(404).json({ error: 'Could not fetch attachments' });
 
     // Deduplicate filenames: invoice.pdf → invoice (2).pdf
@@ -601,6 +758,8 @@ router.get('/messages/:id/attachments.zip', async (req, res) => {
 
     if (entries.length === 0) return res.status(404).json({ error: 'Could not fetch attachments' });
 
+    await revalidateLiveMessageSnapshots(message.account_id, [messageSnapshot]);
+
     const zipName = (message.subject || 'attachments').substring(0, 100) + '-attachments.zip';
     res.setHeader('Content-Type', 'application/zip');
     res.setHeader('Content-Disposition', attachmentDisposition(zipName));
@@ -617,6 +776,9 @@ router.get('/messages/:id/attachments.zip', async (req, res) => {
     archive.finalize();
   } catch (err) {
     console.error('ZIP fetch error:', err);
+    if (!res.headersSent && err?.code === 'MESSAGE_SNAPSHOT_SUPERSEDED') {
+      return res.status(409).json({ error: err.message, code: err.code, retryable: true });
+    }
     if (!res.headersSent) res.status(500).json({ error: 'Failed to create ZIP' });
   }
 });
@@ -633,13 +795,21 @@ router.get('/messages/:id/attachments/:part', async (req, res) => {
   }
 
   const result = await query(`
-    SELECT m.*, a.user_id FROM messages m
+    SELECT m.*, a.user_id,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation
+    FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
   const message = result.rows[0];
+  const messageSnapshot = snapshotFromMessageRow(message);
 
   // Find attachment metadata
   const attachments = typeof message.attachments === 'string'
@@ -659,9 +829,14 @@ router.get('/messages/:id/attachments/:part', async (req, res) => {
   try {
     const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]);
     if (!accountResult.rows.length) return res.status(404).json({ error: 'Account not found' });
-    const buffer = await imapManager.fetchAttachment(accountResult.rows[0], message.uid, message.folder, partNum);
+    const buffer = await imapManager.fetchAttachment(
+      accountResult.rows[0], message.uid, message.folder, partNum,
+      { snapshot: messageSnapshot },
+    );
 
     if (!buffer) return res.status(404).json({ error: 'Could not fetch attachment' });
+
+    await revalidateLiveMessageSnapshots(message.account_id, [messageSnapshot]);
 
     res.setHeader('Content-Type', att.type || 'application/octet-stream');
     res.setHeader('Content-Disposition', attachmentDisposition(att.filename));
@@ -669,6 +844,9 @@ router.get('/messages/:id/attachments/:part', async (req, res) => {
     res.send(buffer);
   } catch (err) {
     console.error('Attachment fetch error:', err);
+    if (err?.code === 'MESSAGE_SNAPSHOT_SUPERSEDED') {
+      return res.status(409).json({ error: err.message, code: err.code, retryable: true });
+    }
     res.status(500).json({ error: 'Failed to fetch attachment' });
   }
 });
@@ -681,53 +859,47 @@ router.patch('/messages/:id/read', async (req, res) => {
 
   const result = await query(`
     SELECT m.*, a.user_id,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation,
            CASE WHEN m.message_id IS NULL THEN 1
                 ELSE (SELECT COUNT(*) FROM messages s
                        WHERE s.account_id = m.account_id AND s.message_id = m.message_id)
            END AS sibling_count
     FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
   const message = result.rows[0];
+  const messageSnapshot = snapshotFromMessageRow(message);
 
-  // Run DB update and account fetch concurrently — no dependency between them.
-  // read_changed_at tells the IMAP sync not to overwrite this change for 30 s,
-  // preventing a race where a concurrent sync fetch sees the old IMAP flag.
-  const [, accountResult] = await Promise.all([
-    query('UPDATE messages SET is_read = $1, read_changed_at = NOW() WHERE id = $2', [read, id]),
-    query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]),
-  ]);
+  const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]);
+  const account = accountResult.rows[0];
+  try {
+    await imapManager.setDesiredFlag(
+      account, id, '\\Seen', read, { snapshot: messageSnapshot },
+    );
+  } catch (err) {
+    if (!err?.uncertain) throw err;
+    console.error('IMAP desired read delivery remains uncertain:', err.message);
+  }
 
-  // Keep the cached folder unread_count in sync so pagination totals stay accurate.
   if (!!message.is_read !== !!read) {
-    adjustFolderCounts(message.account_id, message.folder, 0, read ? -1 : 1);
     // Notify the user's OTHER sessions so a read/unread on one device reflects on the rest
     // in place, without a full folder refetch (the originating device already applied it).
     imapManager.broadcast({ type: 'message_flags', accountId: message.account_id, changes: [{ id, is_read: read }] }, req.session.userId);
   }
 
-  // GTD: a labeled message owns a sibling row per folder. Fan the read change out to
-  // those rows (and their folder unread counts) so label views don't go stale. Gated on
-  // gtd_enabled (so a non-GTD account is byte-identical to pre-GTD behaviour) AND on the
-  // message actually having siblings — a plain single-folder message keeps the PK-only
-  // fast path. The IMAP \Seen flag is written to the acted folder only (below): Gmail
-  // propagates \Seen message-wide server-side, and per-copy writes to N folders would
-  // multiply round-trips — an asymmetry accepted in the GTD design.
+  // A label-aware account owns one provider row per folder. Resolve every live sibling,
+  // then accept an independent exact-row desired delivery so counts, revisions, and retries
+  // remain ordered even on providers that do not propagate Seen between copies.
   if (Number(message.sibling_count) > 1 && await accountMaintainsLabelSiblings(message.account_id)) {
-    await fanOutReadToSiblings(message.account_id, message.message_id, read);
-  }
-
-  try {
-    await imapManager.setFlag(accountResult.rows[0], message.uid, message.folder, '\\Seen', read);
-    imapManager._resolveFlagPush(message.account_id, id, '\\Seen'); // confirmed — drop any stale queued op
-  } catch (err) {
-    console.error('IMAP flag update failed:', err.message);
-    // Push failed — queue a durable retry so a later flag-sync pull can't silently revert
-    // the user's change once the 30s local-wins window lapses.
-    imapManager._enqueueFlagPush(message.account_id, id, '\\Seen', read);
+    await deliverDesiredFlagToLiveSiblings(account, message, '\\Seen', read);
   }
 
   // Refresh GTD section data if this message's thread carries a GTD label (its head shows read state).
@@ -744,40 +916,40 @@ router.patch('/messages/:id/star', async (req, res) => {
 
   const result = await query(`
     SELECT m.*, a.user_id,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation,
            CASE WHEN m.message_id IS NULL THEN 1
                 ELSE (SELECT COUNT(*) FROM messages s
                        WHERE s.account_id = m.account_id AND s.message_id = m.message_id)
            END AS sibling_count
     FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
   const message = result.rows[0];
+  const messageSnapshot = snapshotFromMessageRow(message);
 
-  // Run DB update and account fetch concurrently — no dependency between them.
-  // star_changed_at tells the IMAP sync not to overwrite this change for 30 s.
-  const [, accountResult] = await Promise.all([
-    query('UPDATE messages SET is_starred = $1, star_changed_at = NOW() WHERE id = $2', [starred, id]),
-    query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]),
-  ]);
-
-  // GTD: fan the star change out to the message's sibling label rows (see the read
-  // handler). Gated on gtd_enabled to keep a non-GTD account byte-identical to pre-GTD.
-  // Stars don't affect folder unread counts, so no count adjustment. The IMAP \Flagged
-  // write below stays on the acted folder only.
-  if (Number(message.sibling_count) > 1 && await accountMaintainsLabelSiblings(message.account_id)) {
-    await fanOutStarToSiblings(message.account_id, message.message_id, starred);
+  const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]);
+  const account = accountResult.rows[0];
+  try {
+    await imapManager.setDesiredFlag(
+      account, id, '\\Flagged', starred, { snapshot: messageSnapshot },
+    );
+  } catch (err) {
+    if (!err?.uncertain) throw err;
+    console.error('IMAP desired star delivery remains uncertain:', err.message);
   }
 
-  try {
-    await imapManager.setFlag(accountResult.rows[0], message.uid, message.folder, '\\Flagged', starred);
-    imapManager._resolveFlagPush(message.account_id, id, '\\Flagged'); // confirmed — drop any stale queued op
-  } catch (err) {
-    console.error('IMAP star update failed:', err.message);
-    // Push failed — queue a durable retry so a later flag-sync pull can't silently revert it.
-    imapManager._enqueueFlagPush(message.account_id, id, '\\Flagged', starred);
+  // Stars use the same independent exact-row sibling delivery as reads; the desired-flag
+  // repository intentionally performs no folder-count adjustment for Flagged changes.
+  if (Number(message.sibling_count) > 1 && await accountMaintainsLabelSiblings(message.account_id)) {
+    await deliverDesiredFlagToLiveSiblings(account, message, '\\Flagged', starred);
   }
 
   // Refresh GTD section data if this message's thread carries a GTD label (its head shows star state).
@@ -857,13 +1029,31 @@ router.post('/mark-all-read', async (req, res) => {
     [accountId, req.session.userId]
   );
   if (!check.rows.length) return res.status(404).json({ error: 'Account not found' });
-  await query('UPDATE messages SET is_read = true, read_changed_at = NOW() WHERE account_id = $1 AND folder = $2', [accountId, folder]);
-  await query('UPDATE folders SET unread_count = 0 WHERE account_id = $1 AND path = $2', [accountId, folder])
-    .catch(err => console.error('Folder count update failed:', err.message));
-  // Also update IMAP so the change survives the next sync (non-fatal if it fails)
-  imapManager.markAllReadImap(check.rows[0], folder).catch(err =>
-    console.warn('markAllReadImap failed:', err.message)
+  const unread = await query(
+    `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+         AND f.is_present = true AND f.uid_validity IS NOT NULL
+      WHERE m.account_id = $1 AND m.folder = $2 AND m.is_read = false
+        AND m.is_deleted = false AND m.metadata_complete = true
+      ORDER BY m.id`,
+    [accountId, folder],
   );
+  try {
+    for (const row of unread.rows) {
+      const outcome = await imapManager.setDesiredFlag(
+        check.rows[0], row.id, 'read', true, { snapshot: snapshotFromMessageRow(row) },
+      );
+      if (outcome?.delivery?.state !== 'confirmed') {
+        throw new Error(`Read delivery for ${row.id} was not confirmed`);
+      }
+    }
+  } catch (err) {
+    console.error('mark-all-read exact delivery failed:', err.message);
+    return res.status(503).json({ error: 'Failed to mark all messages read' });
+  }
   imapManager.broadcast({ type: 'sync_complete', accountId }, check.rows[0].user_id);
   res.json({ ok: true });
 });
@@ -886,13 +1076,8 @@ router.post('/folders', async (req, res) => {
   }
 
   try {
-    await imapManager.createFolder(check.rows[0], path);
-    await query(
-      `INSERT INTO folders (account_id, path, name) VALUES ($1, $2, $3)
-       ON CONFLICT (account_id, path) DO NOTHING`,
-      [accountId, path, name.trim()]
-    );
-    res.json({ ok: true, path });
+    const created = await imapManager.createFolder(check.rows[0], path);
+    res.json({ ok: true, path: created?.path || path });
   } catch (err) {
     console.error('Create folder error:', err);
     res.status(500).json({ error: 'Failed to create folder' });
@@ -913,8 +1098,6 @@ router.post('/folders/delete', async (req, res) => {
     console.error(`IMAP deleteFolder failed for ${path}:`, err.message);
     return res.status(500).json({ error: 'Failed to delete folder on server' });
   }
-  await query('DELETE FROM folders WHERE account_id = $1 AND path = $2', [accountId, path]);
-  await query('DELETE FROM messages WHERE account_id = $1 AND folder = $2', [accountId, path]);
   res.json({ ok: true });
 });
 
@@ -936,48 +1119,6 @@ router.post('/folders/rename', async (req, res) => {
 
   try {
     await imapManager.renameFolder(check.rows[0], oldPath, newPath);
-    // IMAP RENAME moves the entire subtree server-side — mirror that in the DB.
-    // Updating only the exact path left every child folder (and its messages)
-    // under the old path: the next folder sync then upserted the renamed tree
-    // from LIST (a visible duplicate), while the per-folder message sync kept
-    // trying to open the stale old child paths forever.
-    const childPrefix = oldPath + delim;
-    // If a sync raced us and already inserted rows at the new paths, drop the
-    // stale old rows instead of colliding with the unique (account_id, path) /
-    // (account_id, uid, folder) constraints.
-    await query(`
-      DELETE FROM folders old
-      WHERE old.account_id = $1
-        AND (old.path = $2 OR substr(old.path, 1, length($3)) = $3)
-        AND EXISTS (
-          SELECT 1 FROM folders n
-          WHERE n.account_id = $1
-            AND n.path = $4 || substr(old.path, length($2) + 1)
-        )`, [accountId, oldPath, childPrefix, newPath]);
-    await query(`
-      UPDATE folders SET path = $4 || substr(path, length($2) + 1), updated_at = NOW()
-      WHERE account_id = $1
-        AND (path = $2 OR substr(path, 1, length($3)) = $3)`,
-      [accountId, oldPath, childPrefix, newPath]);
-    await query(
-      'UPDATE folders SET name = $1, updated_at = NOW() WHERE account_id = $2 AND path = $3',
-      [newName.trim(), accountId, newPath]
-    );
-    await query(`
-      DELETE FROM messages old
-      WHERE old.account_id = $1
-        AND (old.folder = $2 OR substr(old.folder, 1, length($3)) = $3)
-        AND EXISTS (
-          SELECT 1 FROM messages n
-          WHERE n.account_id = $1
-            AND n.folder = $4 || substr(old.folder, length($2) + 1)
-            AND n.uid = old.uid
-        )`, [accountId, oldPath, childPrefix, newPath]);
-    await query(`
-      UPDATE messages SET folder = $4 || substr(folder, length($2) + 1)
-      WHERE account_id = $1
-        AND (folder = $2 OR substr(folder, 1, length($3)) = $3)`,
-      [accountId, oldPath, childPrefix, newPath]);
     res.json({ ok: true, newPath });
   } catch (err) {
     console.error('Rename folder error:', err);
@@ -1000,6 +1141,27 @@ router.post('/folders/empty', async (req, res) => {
   const check = await query('SELECT * FROM email_accounts WHERE id = $1 AND user_id = $2', [accountId, req.session.userId]);
   if (!check.rows.length) return res.status(404).json({ error: 'Account not found' });
   const account = check.rows[0];
+  const folderState = await query(
+    `SELECT backfill_incomplete
+       FROM folders WHERE account_id = $1 AND path = $2
+        AND is_present = true AND uid_validity IS NOT NULL`,
+    [accountId, path],
+  );
+  if (!folderState.rows.length || folderState.rows[0].backfill_incomplete) {
+    return res.status(409).json({ error: 'Folder sync is incomplete — try again after sync finishes' });
+  }
+  const candidates = await query(
+    `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+         AND f.is_present = true AND f.uid_validity IS NOT NULL
+      WHERE m.account_id = $1 AND m.folder = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+      ORDER BY m.id`,
+    [accountId, path],
+  );
 
   const inflightKey = `${accountId}:${path}`;
   if (emptyInFlight.has(inflightKey)) return res.status(409).json({ error: 'This folder is already being emptied' });
@@ -1009,12 +1171,14 @@ router.post('/folders/empty', async (req, res) => {
 
   (async () => {
     try {
-      await imapManager.emptyFolder(account, path);
-      await query('DELETE FROM messages WHERE account_id = $1 AND folder = $2', [accountId, path]);
-      await query(
-        'UPDATE folders SET total_count = 0, unread_count = 0 WHERE account_id = $1 AND path = $2',
-        [accountId, path]
-      );
+      for (const row of candidates.rows) {
+        await imapManager.removeMessageCopy(accountId, row.uid, path, {
+          expectedId: row.id,
+          expectedUidValidity: row.folder_uid_validity,
+          snapshot: snapshotFromMessageRow(row),
+          notify: false,
+        });
+      }
       imapManager.broadcast({ type: 'folder_emptied', accountId, folder: path, ok: true }, account.user_id);
       imapManager.broadcast({ type: 'sync_complete', accountId }, account.user_id);
     } catch (err) {
@@ -1044,9 +1208,17 @@ router.post('/messages/bulk-read', async (req, res) => {
 
   try {
     const result = await query(
-      `SELECT m.id, m.uid, m.folder, m.is_read, m.account_id, m.message_id FROM messages m
+      `SELECT m.id, m.uid, m.folder, m.is_read, m.account_id, m.message_id,
+              m.read_revision, m.star_revision,
+              live_folder.uid_validity AS folder_uid_validity,
+              live_folder.observation_generation AS folder_observation_generation
+       FROM messages m
        JOIN email_accounts a ON m.account_id = a.id
-       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1`,
+       JOIN folders live_folder ON live_folder.account_id = m.account_id
+         AND live_folder.path = m.folder AND live_folder.is_present = true
+         AND live_folder.uid_validity IS NOT NULL
+       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1
+         AND m.is_deleted = false AND m.metadata_complete = true`,
       [req.session.userId, ids]
     );
 
@@ -1057,45 +1229,11 @@ router.post('/messages/bulk-read', async (req, res) => {
     const toUpdate = owned.filter(m => !!m.is_read !== !!read);
     if (!toUpdate.length) return res.json({ ok: true, updated: [] });
 
-    await query(
-      'UPDATE messages SET is_read = $1, read_changed_at = NOW() WHERE id = ANY($2::uuid[])',
-      [read, toUpdate.map(m => m.id)]
-    );
-
-    // Adjust cached unread counts per account+folder.
-    const folderDeltas = {};
-    for (const msg of toUpdate) {
-      const key = `${msg.account_id}:${msg.folder}`;
-      if (!folderDeltas[key]) folderDeltas[key] = { accountId: msg.account_id, folder: msg.folder, delta: 0 };
-      folderDeltas[key].delta += read ? -1 : 1;
-    }
-    for (const { accountId, folder, delta } of Object.values(folderDeltas)) {
-      adjustFolderCounts(accountId, folder, 0, delta);
-    }
-
-    // GTD: fan the read change out to sibling label rows of every updated message that
-    // belongs to a gtd_enabled account, adjusting each sibling folder's unread count.
-    // Gating on gtd_enabled keeps a non-GTD account byte-identical to pre-GTD (no extra
-    // fan-out query); the fan-out itself is also self-limiting for messages without
-    // siblings. IMAP \Seen is still written per acted row only (below); Gmail propagates
-    // it message-wide server-side.
-    // gtdUpdatedIds is scoped to toUpdate (rows whose read-state actually changed), so a
-    // message already at the target state never triggers sibling fan-out here — unlike the
-    // single-message handler above, which fans out unconditionally regardless of whether the
-    // acted message's own state changed. That asymmetry is acceptable: nothing else in this
-    // path can push a sibling out of sync with its head, and the label-folder tick already
-    // self-heals any divergence on the next read.
     const acctIds = [...new Set(toUpdate.map(m => m.account_id))];
     const gtdAccts = new Set();
     await Promise.all(acctIds.map(async (aid) => {
       if (await accountMaintainsLabelSiblings(aid)) gtdAccts.add(aid);
     }));
-    const gtdUpdatedIds = toUpdate.filter(m => gtdAccts.has(m.account_id)).map(m => m.id);
-    if (gtdUpdatedIds.length) await fanOutBulkReadToSiblings(gtdUpdatedIds, read);
-    // Reflect the bulk read/unread change on the user's other sessions in place (no full refetch).
-    imapManager.broadcast({ type: 'message_flags', changes: toUpdate.map(m => ({ id: m.id, is_read: read })) }, req.session.userId);
-
-    // IMAP flag updates — group by account to fetch each account row once.
     const byAccount = {};
     for (const msg of toUpdate) {
       (byAccount[msg.account_id] = byAccount[msg.account_id] || []).push(msg);
@@ -1105,18 +1243,58 @@ router.post('/messages/bulk-read', async (req, res) => {
       const account = accountResult.rows[0];
       const results = await runInBatches(
         msgs, 3,
-        msg => imapManager.setFlag(account, msg.uid, msg.folder, '\\Seen', read)
+        msg => imapManager.setDesiredFlag(
+          account, msg.id, '\\Seen', read,
+          { snapshot: snapshotFromMessageRow(msg) },
+        )
       );
       results.forEach((r, i) => {
         if (r.status === 'rejected') {
-          console.error(`bulk-read IMAP ${msgs[i].id}:`, r.reason.message);
-          // Durable retry so a later flag-sync pull can't revert this message to unread.
-          imapManager._enqueueFlagPush(accountId, msgs[i].id, '\\Seen', read);
-        } else {
-          imapManager._resolveFlagPush(accountId, msgs[i].id, '\\Seen'); // confirmed
+          if (!r.reason?.uncertain) throw r.reason;
+          console.error(`bulk-read desired delivery ${msgs[i].id}:`, r.reason.message);
         }
       });
     }
+
+    // Label siblings are independent provider rows. Resolve them descriptively by Message-ID,
+    // then immediately convert each match into an exact row/UID/epoch desired delivery.
+    const gtdRows = toUpdate.filter(m => gtdAccts.has(m.account_id) && m.message_id);
+    if (gtdRows.length > 0) {
+      const siblings = await query(
+        `WITH acted AS (
+           SELECT DISTINCT account_id, message_id
+             FROM messages
+            WHERE id = ANY($1::uuid[]) AND message_id IS NOT NULL
+         )
+         SELECT m.id, m.account_id, m.uid, m.folder, m.is_read,
+                m.read_revision, m.star_revision,
+                f.uid_validity AS folder_uid_validity,
+                f.observation_generation AS folder_observation_generation
+           FROM messages m
+           JOIN acted ON acted.account_id = m.account_id AND acted.message_id = m.message_id
+           JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                         AND f.is_present = true AND f.uid_validity IS NOT NULL
+          WHERE m.id <> ALL($1::uuid[])
+            AND m.is_deleted = false AND m.metadata_complete = true`,
+        [gtdRows.map(row => row.id)],
+      );
+      for (const sibling of siblings.rows) {
+        const account = (await query(
+          'SELECT * FROM email_accounts WHERE id = $1', [sibling.account_id],
+        )).rows[0];
+        try {
+          await imapManager.setDesiredFlag(
+            account, sibling.id, '\\Seen', read,
+            { snapshot: snapshotFromMessageRow(sibling) },
+          );
+        } catch (err) {
+          if (!err?.uncertain) throw err;
+        }
+      }
+    }
+
+    // Reflect the bulk read/unread change on the user's other sessions in place (no full refetch).
+    imapManager.broadcast({ type: 'message_flags', changes: toUpdate.map(m => ({ id: m.id, is_read: read })) }, req.session.userId);
 
     // Refresh GTD section data for any updated thread that carries a GTD label.
     notifyMailMutation(toUpdate, req.session.userId);
@@ -1130,7 +1308,7 @@ router.post('/messages/bulk-read', async (req, res) => {
 
 // Bulk delete (move to trash)
 router.post('/messages/bulk-delete', async (req, res) => {
-  const { ids } = req.body;
+  const { ids, operationKeys } = req.body;
   if (!Array.isArray(ids) || ids.length === 0) {
     return res.status(400).json({ error: 'ids array required' });
   }
@@ -1140,18 +1318,48 @@ router.post('/messages/bulk-delete', async (req, res) => {
   if (!areValidUUIDs(ids)) {
     return res.status(400).json({ error: 'Invalid message id format' });
   }
+  const rowOperationKeys = validatedRowOperationKeys(ids, operationKeys, {
+    userId: req.session.userId, kind: 'bulk-delete',
+  });
+  if (!rowOperationKeys) return res.status(400).json({ error: 'One valid operation key per id is required' });
+  const canonicalIds = ids.map(id => id.toLowerCase());
 
   const moveGuards = [];
   try {
     const result = await query(
-      `SELECT m.*, a.user_id, a.folder_mappings FROM messages m
+      `SELECT m.*, a.user_id, a.folder_mappings,
+              live_folder.uid_validity AS folder_uid_validity,
+              live_folder.observation_generation AS folder_observation_generation
+       FROM messages m
        JOIN email_accounts a ON m.account_id = a.id
-       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1`,
-      [req.session.userId, ids]
+       JOIN folders live_folder ON live_folder.account_id = m.account_id
+         AND live_folder.path = m.folder AND live_folder.is_present = true
+         AND live_folder.uid_validity IS NOT NULL
+       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1
+         AND m.is_deleted = false AND m.metadata_complete = true`,
+      [req.session.userId, canonicalIds]
     );
 
     const owned = result.rows;
     if (!owned.length) return res.json({ ok: true, deleted: [] });
+
+    const completedMoveResult = await query(
+      `WITH requested(source_message_id, request_key) AS (
+         SELECT * FROM unnest($1::uuid[], $2::text[])
+       )
+       SELECT po.account_id, po.source_message_id, po.request_key,
+              po.destination_folder, po.receipt
+         FROM provider_operations po
+         JOIN requested r
+           ON r.source_message_id = po.source_message_id
+          AND r.request_key = po.request_key
+        WHERE po.kind = 'move' AND po.state = 'completed'`,
+      [owned.map(msg => msg.id), owned.map(msg => rowOperationKeys.get(msg.id))],
+    );
+    const completedMoves = new Map((completedMoveResult.rows || []).map(operation => [
+      `${operation.account_id}:${operation.source_message_id}:${operation.request_key}`,
+      operation,
+    ]));
 
     // Guard source UIDs for the whole operation so reconcileDeletes can't delete a
     // trash-move source row between the IMAP move and the re-INSERT CTE (message vanishing
@@ -1171,6 +1379,7 @@ router.post('/messages/bulk-delete', async (req, res) => {
     // trashMoveSucceeded: moved from a non-Trash folder into Trash.
     const expungeSucceeded = [];
     const trashMoveSucceeded = []; // { msg, trashPath, newUid }
+    const replaySucceeded = [];
     const accountsById = {};
 
     for (const [accountId, msgs] of Object.entries(byAccount)) {
@@ -1186,9 +1395,28 @@ router.post('/messages/bulk-delete', async (req, res) => {
         continue;
       }
 
+      // A retry can load the row after its first attempt already moved it into Trash. A completed
+      // durable MOVE is terminal for this exact logical row/request key: replay success only when
+      // the current row is the receipt destination, and otherwise fail closed instead of treating
+      // the relocated row as a fresh expunge request.
+      const actionable = msgs.filter(msg => {
+        const requestKey = rowOperationKeys.get(msg.id);
+        const completed = completedMoves.get(`${accountId}:${msg.id}:${requestKey}`);
+        if (!completed) return true;
+        const receipt = completed.receipt || {};
+        const exactDestination = completed.destination_folder === trashPath &&
+          receipt.folder === trashPath && msg.folder === receipt.folder &&
+          Number(msg.uid) === Number(receipt.uid) &&
+          receipt.uidValidity != null &&
+          String(msg.folder_uid_validity) === String(receipt.uidValidity);
+        if (exactDestination) replaySucceeded.push(msg);
+        else console.error(`bulk-delete: completed MOVE identity no longer matches row ${msg.id}`);
+        return false;
+      });
+
       // Drafts and messages already in Trash are permanently deleted; others move to Trash.
-      const toExpunge = msgs.filter(m => allTrashPaths.has(m.folder) || allDraftsPaths.has(m.folder));
-      const toMove    = msgs.filter(m => !allTrashPaths.has(m.folder) && !allDraftsPaths.has(m.folder));
+      const toExpunge = actionable.filter(m => allTrashPaths.has(m.folder) || allDraftsPaths.has(m.folder));
+      const toMove    = actionable.filter(m => !allTrashPaths.has(m.folder) && !allDraftsPaths.has(m.folder));
 
       // Permanently delete messages already in a trash-like folder (grouped by actual folder).
       if (toExpunge.length) {
@@ -1197,10 +1425,18 @@ router.post('/messages/bulk-delete', async (req, res) => {
           (byExpungeFolder[msg.folder] = byExpungeFolder[msg.folder] || []).push(msg);
         }
         for (const [expungeFolder, folderMsgs] of Object.entries(byExpungeFolder)) {
-          const uidToMsg = new Map(folderMsgs.map(m => [String(m.uid), m]));
-          const { succeeded, failed } = await imapManager.bulkPermanentDelete(account, folderMsgs.map(m => m.uid), expungeFolder);
-          for (const uid of succeeded) expungeSucceeded.push(uidToMsg.get(String(uid)));
-          for (const uid of failed) console.error(`bulk-delete IMAP expunge uid ${uid} from ${expungeFolder}: IMAP delete failed`);
+          for (const msg of folderMsgs) {
+            try {
+              await imapManager.removeMessageCopy(accountId, msg.uid, expungeFolder, {
+                expectedId: msg.id,
+                expectedUidValidity: msg.folder_uid_validity,
+                snapshot: snapshotFromMessageRow(msg),
+              });
+              expungeSucceeded.push(msg);
+            } catch (err) {
+              console.error(`bulk-delete IMAP expunge uid ${msg.uid} from ${expungeFolder}: ${err.message}`);
+            }
+          }
         }
       }
 
@@ -1212,7 +1448,20 @@ router.post('/messages/bulk-delete', async (req, res) => {
         }
         for (const [srcFolder, folderMsgs] of Object.entries(byFolder)) {
           const uidToMsg = new Map(folderMsgs.map(m => [String(m.uid), m]));
-          const { uidMap, succeeded, failed } = await imapManager.bulkMoveMessages(account, folderMsgs.map(m => m.uid), srcFolder, trashPath);
+          const { uidMap, succeeded, failed } = await imapManager.bulkMoveMessages(
+            account, folderMsgs.map(m => m.uid), srcFolder, trashPath,
+            {
+              operationKey: 'bulk-delete',
+              operationKeys: new Map(folderMsgs.map(m => [
+                Number(m.uid), rowOperationKeys.get(m.id),
+              ])),
+              sourceSnapshots: new Map(folderMsgs.map(m => [
+                Number(m.uid), snapshotFromMessageRow(m),
+              ])),
+              sourceRows: new Map(folderMsgs.map(m => [Number(m.uid), m])),
+              materialize: materializeOrdinaryMove(trashPath),
+            },
+          );
           for (const uid of succeeded) {
             trashMoveSucceeded.push({ msg: uidToMsg.get(String(uid)), trashPath, newUid: uidMap.get(Number(uid)) || null });
           }
@@ -1221,86 +1470,18 @@ router.post('/messages/bulk-delete', async (req, res) => {
       }
     }
 
-    // Permanently deleted: remove DB rows immediately.
-    if (expungeSucceeded.length) {
-      await query('DELETE FROM messages WHERE id = ANY($1::uuid[])', [expungeSucceeded.map(m => m.id)]);
-    }
-
-    // Trash moves: same CTE approach as bulk-move — DELETE source rows and
-    // immediately re-INSERT at the destination when new UIDs are known.
-    // Group by trashPath since different accounts may have different Trash folders.
-    if (trashMoveSucceeded.length) {
-      const byTrashPath = {};
-      for (const u of trashMoveSucceeded) {
-        (byTrashPath[u.trashPath] = byTrashPath[u.trashPath] || []).push(u);
-      }
-      for (const [trashPath, entries] of Object.entries(byTrashPath)) {
-        const allIds    = entries.map(u => u.msg.id);
-        const withUid   = entries.filter(u => u.newUid);
-        await query(`
-          WITH deleted AS (
-            DELETE FROM messages WHERE id = ANY($1::uuid[]) RETURNING *
-          ),
-          uid_map(src_id, new_uid) AS (
-            SELECT * FROM unnest($2::uuid[], $3::bigint[])
-          )
-          INSERT INTO messages (${RELOCATE_INSERT_COLS})
-          SELECT ${RELOCATE_SELECT_COLS}
-          FROM deleted d
-          JOIN uid_map u ON d.id = u.src_id
-          ON CONFLICT (account_id, uid, folder) DO NOTHING
-        `, [allIds, withUid.map(u => u.msg.id), withUid.map(u => u.newUid), trashPath]);
-      }
-      // Non-UIDPLUS trash moves were deleted with no reinsert; pull each affected
-      // (account, trash folder) now so they reappear promptly instead of via IDLE.
-      const needResync = new Map(); // accountId -> Set<trashPath>
-      for (const u of trashMoveSucceeded) {
-        if (u.newUid) continue;
-        if (!needResync.has(u.msg.account_id)) needResync.set(u.msg.account_id, new Set());
-        needResync.get(u.msg.account_id).add(u.trashPath);
-      }
-      for (const [acctId, paths] of needResync) {
-        const acct = accountsById[acctId];
-        if (!acct) continue;
-        for (const tp of paths) {
-          imapManager.syncFolderOnDemand(acct, tp)
-            .catch(err => console.warn('post-trash destination sync failed:', err.message));
-        }
-      }
-    }
-
-    // Adjust cached folder counts.
-    // Source folders always lose the message; Trash gains only for non-Trash moves.
+    // Exact deletion/relocation and count changes commit inside their provider fence.
     const allSucceeded = [
       ...expungeSucceeded.map(m => m.id),
       ...trashMoveSucceeded.map(u => u.msg.id),
+      ...replaySucceeded.map(m => m.id),
     ];
     if (allSucceeded.length) {
-      const srcDeltas = {};
-      for (const msg of expungeSucceeded) {
-        const key = `${msg.account_id}:${msg.folder}`;
-        if (!srcDeltas[key]) srcDeltas[key] = { accountId: msg.account_id, path: msg.folder, total: 0, unread: 0 };
-        srcDeltas[key].total++;
-        if (!msg.is_read) srcDeltas[key].unread++;
-      }
-      for (const { msg } of trashMoveSucceeded) {
-        const key = `${msg.account_id}:${msg.folder}`;
-        if (!srcDeltas[key]) srcDeltas[key] = { accountId: msg.account_id, path: msg.folder, total: 0, unread: 0 };
-        srcDeltas[key].total++;
-        if (!msg.is_read) srcDeltas[key].unread++;
-      }
-      for (const { accountId, path, total, unread } of Object.values(srcDeltas)) {
-        adjustFolderCounts(accountId, path, -total, -unread);
-      }
       const dstDeltas = {};
       for (const { msg, trashPath } of trashMoveSucceeded) {
         const key = `${msg.account_id}:${trashPath}`;
         if (!dstDeltas[key]) dstDeltas[key] = { accountId: msg.account_id, path: trashPath, total: 0, unread: 0 };
         dstDeltas[key].total++;
-        if (!msg.is_read) dstDeltas[key].unread++;
-      }
-      for (const { accountId, path, total, unread } of Object.values(dstDeltas)) {
-        adjustFolderCounts(accountId, path, total, unread);
       }
       // Notify clients viewing each Trash folder to refresh silently.
       for (const { accountId, path } of Object.values(dstDeltas)) {
@@ -1338,7 +1519,8 @@ router.get('/mailbox-usage', async (req, res) => {
 
   const summary = await query(
     `SELECT count(*)::int AS inbox_total, count(*) FILTER (WHERE is_bulk)::int AS bulk_total
-     FROM messages WHERE account_id = $1 AND folder = 'INBOX'`,
+     FROM messages WHERE account_id = $1 AND folder = 'INBOX'
+       AND is_deleted = false AND metadata_complete = true`,
     [accountId]
   );
   // Group senders case-insensitively so a sender that uses mixed-case addresses
@@ -1350,6 +1532,7 @@ router.get('/mailbox-usage', async (req, res) => {
     `SELECT min(from_email) AS from_email, max(from_name) AS from_name, count(*)::int AS count
      FROM messages
      WHERE account_id = $1 AND folder = 'INBOX' AND is_bulk
+       AND is_deleted = false AND metadata_complete = true
        AND from_email IS NOT NULL AND from_email <> ''
      GROUP BY lower(from_email) ORDER BY count DESC, lower(min(from_email)) LIMIT 25`,
     [accountId]
@@ -1361,7 +1544,8 @@ router.get('/mailbox-usage', async (req, res) => {
     .map((_, i) => `count(*) FILTER (WHERE subject ILIKE $${i + 2} OR coalesce(snippet,'') ILIKE $${i + 2})::int AS k${i}`)
     .join(', ');
   const kw = await query(
-    `SELECT ${filters} FROM messages WHERE account_id = $1 AND folder = 'INBOX'`,
+    `SELECT ${filters} FROM messages WHERE account_id = $1 AND folder = 'INBOX'
+       AND is_deleted = false AND metadata_complete = true`,
     [accountId, ...KEYWORDS.map(k => `%${k}%`)]
   );
 
@@ -1390,7 +1574,8 @@ router.get('/cleanup-preview', async (req, res) => {
 
   const rows = await query(
     `SELECT id FROM messages
-     WHERE account_id = $1 AND folder = 'INBOX' AND is_bulk AND lower(from_email) = lower($2)`,
+     WHERE account_id = $1 AND folder = 'INBOX' AND is_bulk
+       AND is_deleted = false AND metadata_complete = true AND lower(from_email) = lower($2)`,
     [accountId, fromEmail.trim()]
   );
   res.json({ accountId, fromEmail: fromEmail.trim(), count: rows.rows.length, ids: rows.rows.map(r => r.id) });
@@ -1398,7 +1583,7 @@ router.get('/cleanup-preview', async (req, res) => {
 
 // Bulk move to folder
 router.post('/messages/bulk-move', async (req, res) => {
-  const { ids, folder } = req.body;
+  const { ids, folder, operationKeys } = req.body;
   if (!Array.isArray(ids) || ids.length === 0 || !folder) {
     return res.status(400).json({ error: 'ids array and folder required' });
   }
@@ -1411,14 +1596,26 @@ router.post('/messages/bulk-move', async (req, res) => {
   if (!areValidUUIDs(ids)) {
     return res.status(400).json({ error: 'Invalid message id format' });
   }
+  const rowOperationKeys = validatedRowOperationKeys(ids, operationKeys, {
+    userId: req.session.userId, kind: 'bulk-move', destination: folder,
+  });
+  if (!rowOperationKeys) return res.status(400).json({ error: 'One valid operation key per id is required' });
+  const canonicalIds = ids.map(id => id.toLowerCase());
 
   const moveGuards = [];
   try {
     const result = await query(
-      `SELECT m.*, a.user_id FROM messages m
+      `SELECT m.*, a.user_id,
+              live_folder.uid_validity AS folder_uid_validity,
+              live_folder.observation_generation AS folder_observation_generation
+       FROM messages m
        JOIN email_accounts a ON m.account_id = a.id
-       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1`,
-      [req.session.userId, ids]
+       JOIN folders live_folder ON live_folder.account_id = m.account_id
+         AND live_folder.path = m.folder AND live_folder.is_present = true
+         AND live_folder.uid_validity IS NOT NULL
+       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1
+         AND m.is_deleted = false AND m.metadata_complete = true`,
+      [req.session.userId, canonicalIds]
     );
 
     const owned = result.rows;
@@ -1441,8 +1638,6 @@ router.post('/messages/bulk-move', async (req, res) => {
     }
 
     const movedIds = [];
-    const uidUpdates = [];
-    const resyncAccounts = []; // accounts whose moved msgs lacked new UIDs (non-UIDPLUS)
     for (const [accountId, msgs] of Object.entries(byAccount)) {
       // Verify the destination folder exists for this account
       const folderCheck = await query(
@@ -1459,52 +1654,33 @@ router.post('/messages/bulk-move', async (req, res) => {
       for (const msg of msgs) {
         (byFolder[msg.folder] = byFolder[msg.folder] || []).push(msg);
       }
-      let accountMissingUid = false;
       for (const [srcFolder, folderMsgs] of Object.entries(byFolder)) {
         const uidToMsg = new Map(folderMsgs.map(m => [String(m.uid), m]));
-        const { uidMap, succeeded, failed } = await imapManager.bulkMoveMessages(account, folderMsgs.map(m => m.uid), srcFolder, folder);
+        const { succeeded, failed } = await imapManager.bulkMoveMessages(
+          account, folderMsgs.map(m => m.uid), srcFolder, folder,
+          {
+            operationKey: 'bulk-move',
+            operationKeys: new Map(folderMsgs.map(m => [
+              Number(m.uid), rowOperationKeys.get(m.id),
+            ])),
+            sourceSnapshots: new Map(folderMsgs.map(m => [
+              Number(m.uid), snapshotFromMessageRow(m),
+            ])),
+            sourceRows: new Map(folderMsgs.map(m => [Number(m.uid), m])),
+            materialize: materializeOrdinaryMove(folder),
+          },
+        );
         for (const uid of succeeded) {
           const msg = uidToMsg.get(String(uid));
           movedIds.push(msg.id);
-          const newUid = uidMap.get(Number(uid)) || null;
-          if (newUid) uidUpdates.push({ id: msg.id, newUid });
-          else accountMissingUid = true;
         }
         for (const uid of failed) console.error(`bulk-move IMAP uid ${uid}: IMAP move failed`);
       }
-      if (accountMissingUid) resyncAccounts.push(account);
     }
 
     if (movedIds.length > 0) {
-      // DELETE source rows and, when we have UIDPLUS-provided new UIDs, immediately
-      // re-INSERT at the destination in one atomic CTE statement. This avoids any
-      // transient folder/uid state that could collide with existing rows (UIDs are
-      // per-folder, so the same UID number is valid in two different folders).
-      // If IMAP IDLE already inserted the destination row, ON CONFLICT DO NOTHING
-      // keeps it intact. For messages without new UIDs the DELETE-only path relies
-      // on IMAP IDLE + the message_id pre-check in processMsg to re-insert them.
-      const uidUpdateMap = new Map(uidUpdates.map(u => [u.id, u.newUid]));
-      const withNewUid   = movedIds.filter(id =>  uidUpdateMap.has(id));
-      await query(`
-        WITH deleted AS (
-          DELETE FROM messages WHERE id = ANY($1::uuid[]) RETURNING *
-        ),
-        uid_map(src_id, new_uid) AS (
-          SELECT * FROM unnest($2::uuid[], $3::bigint[])
-        )
-        INSERT INTO messages (${RELOCATE_INSERT_COLS})
-        SELECT ${RELOCATE_SELECT_COLS}
-        FROM deleted d
-        JOIN uid_map u ON d.id = u.src_id
-        ON CONFLICT (account_id, uid, folder) DO NOTHING
-      `, [movedIds, withNewUid, withNewUid.map(id => uidUpdateMap.get(id)), folder]);
-      // Messages moved on a non-UIDPLUS server were deleted with no reinsert; pull the
-      // destination folder now so they reappear promptly instead of waiting for IDLE.
-      for (const acct of resyncAccounts) {
-        imapManager.syncFolderOnDemand(acct, folder)
-          .catch(err => console.warn('post-move destination sync failed:', err.message));
-      }
-      // Adjust cached counts: decrement source folders, increment the destination.
+      // Each exact relocation and its count changes committed inside the durable
+      // provider-operation completion transaction. The route only broadcasts the receipt.
       const movedSet = new Set(movedIds);
       const srcTotals = {};
       for (const msg of owned) {
@@ -1514,11 +1690,6 @@ router.post('/messages/bulk-move', async (req, res) => {
         srcTotals[key].total++;
         if (!msg.is_read) srcTotals[key].unread++;
       }
-      for (const { accountId, path, total, unread } of Object.values(srcTotals)) {
-        adjustFolderCounts(accountId, path, -total, -unread);
-        adjustFolderCounts(accountId, folder, total, unread);
-      }
-
       // Notify clients that the destination folder has new content so they
       // refresh without sounds or alerts (unlike new_messages).
       for (const accountId of Object.keys(srcTotals).map(k => k.split(':')[0])) {
@@ -1540,7 +1711,7 @@ router.post('/messages/bulk-move', async (req, res) => {
 
 // Bulk archive — moves messages to the archive folder for each account
 router.post('/messages/bulk-archive', async (req, res) => {
-  const { ids } = req.body;
+  const { ids, operationKeys } = req.body;
   if (!Array.isArray(ids) || ids.length === 0) {
     return res.status(400).json({ error: 'ids array required' });
   }
@@ -1550,14 +1721,26 @@ router.post('/messages/bulk-archive', async (req, res) => {
   if (!areValidUUIDs(ids)) {
     return res.status(400).json({ error: 'Invalid message IDs' });
   }
+  const rowOperationKeys = validatedRowOperationKeys(ids, operationKeys, {
+    userId: req.session.userId, kind: 'bulk-archive',
+  });
+  if (!rowOperationKeys) return res.status(400).json({ error: 'One valid operation key per id is required' });
+  const canonicalIds = ids.map(id => id.toLowerCase());
 
   const moveGuards = [];
   try {
     const result = await query(
-      `SELECT m.*, a.user_id, a.folder_mappings FROM messages m
+      `SELECT m.*, a.user_id, a.folder_mappings,
+              live_folder.uid_validity AS folder_uid_validity,
+              live_folder.observation_generation AS folder_observation_generation
+       FROM messages m
        JOIN email_accounts a ON m.account_id = a.id
-       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1`,
-      [req.session.userId, ids]
+       JOIN folders live_folder ON live_folder.account_id = m.account_id
+         AND live_folder.path = m.folder AND live_folder.is_present = true
+         AND live_folder.uid_validity IS NOT NULL
+       WHERE m.id = ANY($2::uuid[]) AND a.user_id = $1
+         AND m.is_deleted = false AND m.metadata_complete = true`,
+      [req.session.userId, canonicalIds]
     );
 
     const owned = result.rows;
@@ -1603,7 +1786,22 @@ router.post('/messages/bulk-archive', async (req, res) => {
       }
       for (const [srcFolder, folderMsgs] of Object.entries(byFolder)) {
         const uidToMsg = new Map(folderMsgs.map(m => [String(m.uid), m]));
-        const { uidMap, succeeded, failed } = await imapManager.bulkMoveMessages(account, folderMsgs.map(m => m.uid), srcFolder, archiveFolder);
+        const { uidMap, succeeded, failed } = await imapManager.bulkMoveMessages(
+          account, folderMsgs.map(m => m.uid), srcFolder, archiveFolder,
+          {
+            operationKey: 'bulk-archive',
+            operationKeys: new Map(folderMsgs.map(m => [
+              Number(m.uid), rowOperationKeys.get(m.id),
+            ])),
+            sourceSnapshots: new Map(folderMsgs.map(m => [
+              Number(m.uid), snapshotFromMessageRow(m),
+            ])),
+            sourceRows: new Map(folderMsgs.map(m => [Number(m.uid), m])),
+            materialize: materializeOrdinaryMove(
+              archiveFolder, allMailDestFolders.has(archiveFolder),
+            ),
+          },
+        );
         for (const uid of succeeded) {
           const msg = uidToMsg.get(String(uid));
           archivedIds.push({ id: msg.id, accountId, folder: archiveFolder, newUid: uidMap.get(Number(uid)) || null });
@@ -1612,74 +1810,8 @@ router.post('/messages/bulk-archive', async (req, res) => {
       }
     }
 
-    // Update DB: same CTE DELETE+INSERT pattern as bulk-move — except when the
-    // destination is Gmail's All Mail, where the message just vanishes from our view
-    // (see allMailDestFolders above), so a plain DELETE with no reinsert is correct.
-    const byFolder = {};
-    for (const { id, folder, newUid } of archivedIds) {
-      (byFolder[folder] = byFolder[folder] || []).push({ id, newUid });
-    }
-    for (const [archiveFolder, entries] of Object.entries(byFolder)) {
-      const allIds  = entries.map(e => e.id);
-      if (allMailDestFolders.has(archiveFolder)) {
-        await query('DELETE FROM messages WHERE id = ANY($1::uuid[])', [allIds]);
-        continue;
-      }
-      const withUid = entries.filter(e => e.newUid != null);
-      await query(`
-        WITH deleted AS (
-          DELETE FROM messages WHERE id = ANY($1::uuid[]) RETURNING *
-        ),
-        uid_map(src_id, new_uid) AS (
-          SELECT * FROM unnest($2::uuid[], $3::bigint[])
-        )
-        INSERT INTO messages (${RELOCATE_INSERT_COLS})
-        SELECT ${RELOCATE_SELECT_COLS}
-        FROM deleted d
-        JOIN uid_map u ON d.id = u.src_id
-        ON CONFLICT (account_id, uid, folder) DO NOTHING
-      `, [allIds, withUid.map(e => e.id), withUid.map(e => e.newUid), archiveFolder]);
-    }
-
-    // Non-UIDPLUS archive moves were deleted with no reinsert; pull each affected
-    // (account, archive folder) now so they reappear promptly instead of via IDLE.
-    const needResync = new Map(); // accountId -> Set<archiveFolder>
-    for (const e of archivedIds) {
-      if (e.newUid) continue;
-      if (allMailDestFolders.has(e.folder)) continue; // no DB row there to keep fresh
-      if (!needResync.has(e.accountId)) needResync.set(e.accountId, new Set());
-      needResync.get(e.accountId).add(e.folder);
-    }
-    for (const [acctId, paths] of needResync) {
-      const acct = accountsById[acctId];
-      if (!acct) continue;
-      for (const fp of paths) {
-        imapManager.syncFolderOnDemand(acct, fp)
-          .catch(err => console.warn('post-archive destination sync failed:', err.message));
-      }
-    }
-
-    // Adjust cached folder counts: use signed deltas so source and dest share one pass.
+    // Exact row relocation and count changes are part of durable completion. Only notify.
     if (archivedIds.length > 0) {
-      const idToArchiveDest = new Map(archivedIds.map(({ id, folder: dest }) => [id, dest]));
-      const folderDeltas = {}; // key: `${accountId}:${path}` -> { accountId, path, totalDelta, unreadDelta }
-      for (const msg of owned) {
-        const dest = idToArchiveDest.get(msg.id);
-        if (!dest) continue;
-        const wasUnread = !msg.is_read ? 1 : 0;
-        const srcKey = `${msg.account_id}:${msg.folder}`;
-        if (!folderDeltas[srcKey]) folderDeltas[srcKey] = { accountId: msg.account_id, path: msg.folder, totalDelta: 0, unreadDelta: 0 };
-        folderDeltas[srcKey].totalDelta--;
-        folderDeltas[srcKey].unreadDelta -= wasUnread;
-        if (allMailDestFolders.has(dest)) continue; // All Mail counts aren't tracked
-        const dstKey = `${msg.account_id}:${dest}`;
-        if (!folderDeltas[dstKey]) folderDeltas[dstKey] = { accountId: msg.account_id, path: dest, totalDelta: 0, unreadDelta: 0 };
-        folderDeltas[dstKey].totalDelta++;
-        folderDeltas[dstKey].unreadDelta += wasUnread;
-      }
-      for (const { accountId, path, totalDelta, unreadDelta } of Object.values(folderDeltas)) {
-        adjustFolderCounts(accountId, path, totalDelta, unreadDelta);
-      }
       // Notify clients viewing each destination folder to refresh silently.
       const destFolders = [...new Set(archivedIds.map(a => a.folder))].filter(f => !allMailDestFolders.has(f));
       for (const dest of destFolders) {
@@ -1729,9 +1861,15 @@ export async function gatherSnoozeConversation(msg) {
   // reply-chain walk below filters out the subject-only collisions that thread_id
   // also collects (e.g. identical automated-notification emails).
   const pool = (await query(
-    `SELECT id, uid, account_id, folder, message_id, in_reply_to, thread_references, is_read
-     FROM messages
-     WHERE account_id = $1 AND thread_id = $2 AND message_id IS NOT NULL`,
+    `SELECT m.id, m.uid, m.account_id, m.folder, m.message_id, m.in_reply_to,
+            m.thread_references, m.is_read, m.is_deleted, m.metadata_complete,
+            m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+     FROM messages m
+     LEFT JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                        AND f.is_present = true AND f.uid_validity IS NOT NULL
+     WHERE m.account_id = $1 AND m.thread_id = $2 AND m.message_id IS NOT NULL`,
     [msg.account_id, msg.thread_id]
   )).rows;
 
@@ -1776,7 +1914,9 @@ export async function gatherSnoozeConversation(msg) {
   // folder isn't moved (and recorded) twice.
   const picked = new Map();
   for (const r of pool) {
-    if (seen.has(r.message_id) && r.folder === msg.folder && !already.has(r.message_id) && !picked.has(r.message_id)) {
+    if (seen.has(r.message_id) && r.folder === msg.folder
+        && r.is_deleted === false && r.metadata_complete === true
+        && !already.has(r.message_id) && !picked.has(r.message_id)) {
       picked.set(r.message_id, r);
     }
   }
@@ -1806,9 +1946,16 @@ router.post('/messages/:id/snooze', async (req, res) => {
 
   // Ownership check
   const msgResult = await query(
-    `SELECT m.*, a.user_id FROM messages m
+    `SELECT m.*, a.user_id,
+            live_folder.uid_validity AS folder_uid_validity,
+            live_folder.observation_generation AS folder_observation_generation
+     FROM messages m
      JOIN email_accounts a ON a.id = m.account_id
-     WHERE m.id = $1 AND a.user_id = $2`,
+     JOIN folders live_folder ON live_folder.account_id = m.account_id
+       AND live_folder.path = m.folder AND live_folder.is_present = true
+       AND live_folder.uid_validity IS NOT NULL
+     WHERE m.id = $1 AND a.user_id = $2
+       AND m.is_deleted = false AND m.metadata_complete = true`,
     [id, req.session.userId]
   );
   if (!msgResult.rows.length) return res.status(404).json({ error: 'Message not found' });
@@ -1845,11 +1992,51 @@ router.post('/messages/:id/snooze', async (req, res) => {
   }
 
   for (const tm of convo) {
+    if (tm.folder_uid_validity == null || tm.folder_observation_generation == null) {
+      if (tm.id === msg.id) return res.status(409).json({ error: 'Message snapshot is no longer actionable' });
+      continue;
+    }
     imapManager._guardMoveUid(tm.account_id, tm.folder, tm.uid);
     try {
-      let snoozedUid;
       try {
-        snoozedUid = await imapManager.moveMessage(account, tm.uid, tm.folder, snoozedFolder);
+        await imapManager.moveMessage(account, tm.uid, tm.folder, snoozedFolder, {
+          operationKey: `snooze:${tm.id}:${untilDate.toISOString()}`,
+          expectedUidValidity: tm.folder_uid_validity,
+          snapshot: snapshotFromMessageRow(tm),
+          materialize: async (receipt, operation, tx) => {
+            await materializeArchiveReceipt(tx, {
+              accountId: tm.account_id,
+              sourceSnapshot: tm,
+              destinationFolder: snoozedFolder,
+              receipt,
+              operation,
+            });
+            const snoozeInsert = await tx.query(
+              `INSERT INTO snoozed_messages (
+                 user_id, account_id, message_row_id, message_id_header,
+                 original_folder, snooze_until, snoozed_folder
+               ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+               ON CONFLICT (account_id, message_id_header) DO NOTHING
+               RETURNING id`,
+              [req.session.userId, tm.account_id, tm.id, tm.message_id,
+                tm.folder, untilDate.toISOString(), snoozedFolder],
+            );
+            if (snoozeInsert.rowCount !== 1) {
+              const exact = await tx.query(
+                `SELECT 1 FROM snoozed_messages
+                  WHERE account_id = $1 AND message_id_header = $2
+                    AND message_row_id = $3 AND original_folder = $4
+                    AND snooze_until = $5::timestamptz AND snoozed_folder = $6
+                    AND resolution_state = 'active'`,
+                [tm.account_id, tm.message_id, tm.id, tm.folder,
+                  untilDate.toISOString(), snoozedFolder],
+              );
+              if (exact.rows.length !== 1) {
+                throw new Error('Conflicting snooze record prevented exact receipt materialization');
+              }
+            }
+          },
+        });
       } catch (err) {
         console.error(`Snooze IMAP move failed for message ${tm.id}:`, err.message);
         // The message the user acted on must succeed; a failed sibling is logged
@@ -1857,22 +2044,6 @@ router.post('/messages/:id/snooze', async (req, res) => {
         if (tm.id === msg.id) return res.status(500).json({ error: 'Failed to move message to Snoozed folder' });
         continue;
       }
-      if (snoozedUid != null) {
-        await query('UPDATE messages SET folder = $1, uid = $2 WHERE id = $3', [snoozedFolder, snoozedUid, tm.id]);
-      } else {
-        imapManager._guardMoveUid(tm.account_id, snoozedFolder, tm.uid);
-        await query('UPDATE messages SET folder = $1 WHERE id = $2', [snoozedFolder, tm.id]);
-        setTimeout(() => imapManager._unguardMoveUid(tm.account_id, snoozedFolder, tm.uid), 10_000);
-      }
-
-      await query(
-        `INSERT INTO snoozed_messages (user_id, account_id, message_id_header, original_folder, snooze_until, snoozed_folder)
-         VALUES ($1, $2, $3, $4, $5, $6)`,
-        [req.session.userId, tm.account_id, tm.message_id, tm.folder, untilDate.toISOString(), snoozedFolder]
-      );
-
-      adjustFolderCounts(tm.account_id, tm.folder, -1, tm.is_read ? 0 : -1);
-      adjustFolderCounts(tm.account_id, snoozedFolder, 1, tm.is_read ? 0 : 1);
     } finally {
       imapManager._unguardMoveUid(tm.account_id, tm.folder, tm.uid);
     }
@@ -1890,9 +2061,16 @@ router.delete('/messages/:id', async (req, res) => {
   if (!UUID_RE.test(id)) return res.status(400).json({ error: 'Invalid message id' });
 
   const result = await query(`
-    SELECT m.*, a.user_id FROM messages m
+    SELECT m.*, a.user_id,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation
+    FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
@@ -1900,19 +2078,20 @@ router.delete('/messages/:id', async (req, res) => {
 
   const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [message.account_id]);
   const account = accountResult.rows[0];
-  const wasUnread = !message.is_read ? 1 : 0;
 
   // Drafts bypass Trash and are permanently deleted (consistent with all major email clients).
   const allDraftsPaths = await resolveAllDraftsPaths(message.account_id, account.folder_mappings);
   if (allDraftsPaths.has(message.folder)) {
     try {
-      await imapManager.permanentDeleteMessage(account, message.uid, message.folder);
+      await imapManager.removeMessageCopy(message.account_id, message.uid, message.folder, {
+        expectedId: message.id,
+        expectedUidValidity: message.folder_uid_validity,
+        snapshot: snapshotFromMessageRow(message),
+      });
     } catch (err) {
       console.error('IMAP permanent delete (draft) failed:', err.message);
       return res.status(500).json({ error: 'Failed to delete draft' });
     }
-    await query('DELETE FROM messages WHERE id = $1', [id]);
-    adjustFolderCounts(message.account_id, message.folder, -1, -wasUnread);
     imapManager.broadcast({ type: 'folder_updated', folder: message.folder, accountId: message.account_id }, req.session.userId);
     return res.json({ ok: true });
   }
@@ -1929,42 +2108,39 @@ router.delete('/messages/:id', async (req, res) => {
     // Guard the source UID before the IMAP move so reconcileDeletes cannot delete
     // the DB row if an EXPUNGE arrives while the move is in flight.
     imapManager._guardMoveUid(message.account_id, message.folder, message.uid);
-    let newUid;
     try {
       try {
-        newUid = await imapManager.moveMessage(account, message.uid, message.folder, trashPath);
+        await imapManager.moveMessage(account, message.uid, message.folder, trashPath, {
+          operationKey: `delete:${id}:${message.folder}:${trashPath}`,
+          expectedUidValidity: message.folder_uid_validity,
+          snapshot: snapshotFromMessageRow(message),
+          materialize: (receipt, operation, tx) => materializeArchiveReceipt(tx, {
+            accountId: message.account_id,
+            sourceSnapshot: message,
+            destinationFolder: trashPath,
+            receipt,
+            operation,
+          }),
+        });
       } catch (err) {
         console.error('IMAP move to trash failed:', err.message);
         return res.status(500).json({ error: 'Failed to delete message' });
       }
-      if (newUid != null) {
-        // Delete any stale row the sync may have already inserted at the destination,
-        // then update the source row in place to avoid a unique-constraint violation.
-        await query('DELETE FROM messages WHERE account_id = $1 AND uid = $2 AND folder = $3 AND id != $4',
-          [message.account_id, newUid, trashPath, id]);
-        await query('UPDATE messages SET folder = $1, uid = $2 WHERE id = $3', [trashPath, newUid, id]);
-      } else {
-        // Non-UIDPLUS: DB holds the stale source UID at the destination. Guard it so
-        // reconcileDeletes does not treat it as an orphan before the next sync corrects it.
-        imapManager._guardMoveUid(message.account_id, trashPath, message.uid);
-        await query('UPDATE messages SET folder = $1 WHERE id = $2', [trashPath, id]);
-        setTimeout(() => imapManager._unguardMoveUid(message.account_id, trashPath, message.uid), 10_000);
-      }
     } finally {
       imapManager._unguardMoveUid(message.account_id, message.folder, message.uid);
     }
-    adjustFolderCounts(message.account_id, message.folder, -1, -wasUnread);
-    adjustFolderCounts(message.account_id, trashPath, 1, wasUnread);
   } else {
     // strategy.action === 'expunge': message is already in Trash — permanently delete.
     try {
-      await imapManager.permanentDeleteMessage(account, message.uid, message.folder);
+      await imapManager.removeMessageCopy(message.account_id, message.uid, message.folder, {
+        expectedId: message.id,
+        expectedUidValidity: message.folder_uid_validity,
+        snapshot: snapshotFromMessageRow(message),
+      });
     } catch (err) {
       console.error('IMAP permanent delete failed:', err.message);
       return res.status(500).json({ error: 'Failed to delete message' });
     }
-    await query('DELETE FROM messages WHERE id = $1', [id]);
-    adjustFolderCounts(message.account_id, message.folder, -1, -wasUnread);
   }
   imapManager.broadcast({ type: 'folder_updated', folder: message.folder, accountId: message.account_id }, req.session.userId);
   // Refresh GTD section data if this thread still carries a GTD label sibling (same staleness the
@@ -1986,9 +2162,16 @@ router.delete('/messages/:id', async (req, res) => {
 // training_log, and broadcast folder_updated. Shared between /spam and /ham.
 async function moveForSpamLabel(messageId, userId, destinationFolder, label) {
   const result = await query(`
-    SELECT m.*, a.user_id, a.folder_mappings FROM messages m
+    SELECT m.*, a.user_id, a.folder_mappings,
+           live_folder.uid_validity AS folder_uid_validity,
+           live_folder.observation_generation AS folder_observation_generation
+    FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [messageId, userId]);
 
   if (!result.rows.length) return { ok: false, status: 404, error: 'Message not found' };
@@ -2020,50 +2203,39 @@ async function moveForSpamLabel(messageId, userId, destinationFolder, label) {
   let newUid;
   try {
     try {
-      newUid = await imapManager.moveMessage(account, message.uid, message.folder, destinationFolder);
+      newUid = await imapManager.moveMessage(account, message.uid, message.folder, destinationFolder, {
+        operationKey: `spam:${messageId}:${message.folder}:${destinationFolder}:${label}`,
+        expectedUidValidity: message.folder_uid_validity,
+        snapshot: snapshotFromMessageRow(message),
+        materialize: async (receipt, operation, tx) => {
+          await materializeArchiveReceipt(tx, {
+            accountId: account.id,
+            sourceSnapshot: message,
+            destinationFolder,
+            receipt,
+            operation,
+          });
+          await tx.query(
+            `UPDATE messages SET spam_user_override = $1, spam_verdict = $1,
+                    spam_analyzed_at = NOW()
+              WHERE id = $2 AND account_id = $3 AND folder = $4 AND uid = $5`,
+            [label, messageId, account.id, destinationFolder, receipt.uid],
+          );
+          await tx.query(
+            `INSERT INTO spam_training_log
+               (user_id, account_id, message_id_header, message_uid, folder, label, source)
+             VALUES ($1, $2, $3, $4, $5, $6, 'manual')`,
+            [userId, account.id, message.message_id, receipt.uid, destinationFolder, label],
+          );
+        },
+      });
     } catch (err) {
       console.error(`IMAP move for /${label} failed:`, err.message);
       return { ok: false, status: 502, error: `IMAP move failed: ${err.message}` };
     }
-    if (newUid != null) {
-      await query('DELETE FROM messages WHERE account_id = $1 AND uid = $2 AND folder = $3 AND id != $4',
-        [account.id, newUid, destinationFolder, messageId]);
-      await query(
-        `UPDATE messages SET folder = $1, uid = $2,
-            spam_user_override = $3, spam_verdict = $3, spam_analyzed_at = NOW()
-         WHERE id = $4`,
-        [destinationFolder, newUid, label, messageId]
-      );
-    } else {
-      // Non-UIDPLUS server: DB holds the stale source UID at the destination.
-      imapManager._guardMoveUid(account.id, destinationFolder, message.uid);
-      await query(
-        `UPDATE messages SET folder = $1,
-            spam_user_override = $2, spam_verdict = $2, spam_analyzed_at = NOW()
-         WHERE id = $3`,
-        [destinationFolder, label, messageId]
-      );
-      setTimeout(() => imapManager._unguardMoveUid(account.id, destinationFolder, message.uid), 10_000);
-    }
   } finally {
     imapManager._unguardMoveUid(account.id, message.folder, message.uid);
   }
-
-  // Adjust cached folder counts.
-  const wasUnread = !message.is_read ? 1 : 0;
-  adjustFolderCounts(account.id, message.folder, -1, -wasUnread);
-  adjustFolderCounts(account.id, destinationFolder, 1, wasUnread);
-
-  // Training log: capture the decision for future model training. Record the UID that now
-  // lives in the destination folder: on a UIDPLUS move the row was re-keyed to newUid above,
-  // so message.uid (the pre-move source UID) would no longer match the messages row. Non-UIDPLUS
-  // servers keep the source UID at the destination, so newUid is null there and we fall back to it.
-  await query(
-    `INSERT INTO spam_training_log
-       (user_id, account_id, message_id_header, message_uid, folder, label, source)
-     VALUES ($1, $2, $3, $4, $5, $6, 'manual')`,
-    [userId, account.id, message.message_id, newUid ?? message.uid, destinationFolder, label]
-  );
 
   // If folder_mappings.spam is not yet configured, learn from the discovered folder.
   if (label === 'spam' && !account.folder_mappings?.spam) {
@@ -2098,7 +2270,11 @@ router.post('/messages/:id/spam', async (req, res) => {
   const lookup = await query(`
     SELECT m.account_id, a.folder_mappings FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!lookup.rows.length) return res.status(404).json({ error: 'Message not found' });
@@ -2134,6 +2310,7 @@ router.get('/category-counts', async (req, res) => {
     WHERE m.account_id = ANY($1)
       AND m.folder = 'INBOX'
       AND m.is_deleted = false
+      AND m.metadata_complete = true
     GROUP BY COALESCE(m.category, 'primary')
   `, [scopedIds]);
 
@@ -2160,9 +2337,15 @@ router.patch('/messages/:id/category', async (req, res) => {
   const result = await query(
     `UPDATE messages SET category = $1
      FROM email_accounts a
+     JOIN folders live_folder ON live_folder.account_id = a.id
      WHERE messages.id = $2
        AND messages.account_id = a.id
+       AND live_folder.path = messages.folder
+       AND live_folder.is_present = true
+       AND live_folder.uid_validity IS NOT NULL
        AND a.user_id = $3
+       AND messages.is_deleted = false
+       AND messages.metadata_complete = true
      RETURNING messages.id`,
     [category === 'primary' ? null : category, id, req.session.userId]
   );
@@ -2181,7 +2364,11 @@ router.post('/messages/:id/unsubscribe', async (req, res) => {
     SELECT m.list_unsubscribe, m.list_unsubscribe_post
     FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
-    WHERE m.id = $1 AND a.user_id = $2 AND m.is_deleted = false
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
+    WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!result.rows.length) return res.status(404).json({ error: 'Message not found' });
@@ -2252,7 +2439,11 @@ router.post('/messages/:id/ham', async (req, res) => {
   const lookup = await query(`
     SELECT m.account_id, m.folder, a.folder_mappings FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.id = $1 AND a.user_id = $2
+      AND m.is_deleted = false AND m.metadata_complete = true
   `, [id, req.session.userId]);
 
   if (!lookup.rows.length) return res.status(404).json({ error: 'Message not found' });

--- a/backend/src/routes/mail.relocate.test.js
+++ b/backend/src/routes/mail.relocate.test.js
@@ -19,8 +19,11 @@ describe('relocate reinsert column lists', () => {
     expect(insertCols.length).toBe(selectCols.length);
   });
 
-  it('carries the columns that previously went stale (migrations 0037/0044/0050)', () => {
-    for (const col of ['delivery_addresses', 'plugin_annotations', 'sender_name', 'sender_email']) {
+  it('carries data columns added by migrations, including envelope verification', () => {
+    for (const col of [
+      'delivery_addresses', 'plugin_annotations', 'sender_name', 'sender_email',
+      'metadata_complete', 'read_revision', 'star_revision', 'provider_modseq',
+    ]) {
       expect(insertCols).toContain(col);
       expect(selectCols).toContain(`d.${col}`);
     }

--- a/backend/src/routes/mail.safeReads.test.js
+++ b/backend/src/routes/mail.safeReads.test.js
@@ -1,0 +1,132 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const imapManager = vi.hoisted(() => ({
+  fetchMessageBody: vi.fn(),
+  fetchHeaders: vi.fn(),
+  fetchAttachment: vi.fn(),
+  fetchMultipleAttachments: vi.fn(),
+  noteUserActivity: vi.fn(),
+  prefetchFolderBodies: vi.fn(),
+  broadcast: vi.fn(),
+}));
+
+vi.mock('../services/db.js', () => ({
+  query: vi.fn(),
+  withTransaction: vi.fn(callback => callback({ query })),
+}));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => { req.session = { userId: 'user-1' }; next(); },
+}));
+vi.mock('../index.js', () => ({ imapManager }));
+
+import express from 'express';
+import mailRoutes from './mail.js';
+import { query } from '../services/db.js';
+
+const ID = '11111111-1111-4111-8111-111111111111';
+const account = { id: 'acct-1', user_id: 'user-1' };
+const row = {
+  id: ID, account_id: account.id, uid: 7, folder: 'INBOX',
+  folder_uid_validity: '101', folder_observation_generation: '9',
+  read_revision: '3', star_revision: '5',
+  subject: 'Subject', body_html: null, body_text: null, snippet: '',
+  attachments: [{ part: '2', filename: 'a.txt', type: 'text/plain', size: 1 }],
+  preferences: {},
+};
+const snapshot = {
+  id: ID, accountId: account.id, uid: 7, folder: 'INBOX', uidValidity: '101',
+  folderGeneration: '9', readRevision: 3, starRevision: 5,
+};
+
+describe('mail derived reads use exact non-advancing snapshots', () => {
+  let server;
+  let base;
+  beforeAll(async () => {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/mail', mailRoutes);
+    await new Promise(resolve => { server = app.listen(0, resolve); });
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+  afterAll(async () => { await new Promise(resolve => server.close(resolve)); });
+  beforeEach(() => {
+    query.mockReset();
+    for (const fn of Object.values(imapManager)) fn.mockReset();
+  });
+
+  it('binds raw header fetches to the authorized row/folder/UID epoch', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [row] })
+      .mockResolvedValueOnce({ rows: [account] })
+      .mockResolvedValueOnce({ rows: [row] });
+    imapManager.fetchHeaders.mockResolvedValue('Subject: Provider subject\r\n');
+
+    const response = await fetch(`${base}/api/mail/messages/${ID}/headers`);
+
+    expect(response.status).toBe(200);
+    expect(imapManager.fetchHeaders).toHaveBeenCalledWith(account, 7, 'INBOX', { snapshot });
+    const ownershipSql = query.mock.calls[0][0];
+    expect(ownershipSql).toMatch(/folder_uid_validity/);
+    expect(ownershipSql).toMatch(/folder_observation_generation/);
+  });
+
+  it('binds an attachment fetch to the exact authorized row snapshot', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [row] })
+      .mockResolvedValueOnce({ rows: [account] })
+      .mockResolvedValueOnce({ rows: [row] });
+    imapManager.fetchAttachment.mockResolvedValue(Buffer.from('x'));
+
+    const response = await fetch(`${base}/api/mail/messages/${ID}/attachments/2`);
+
+    expect(response.status).toBe(200);
+    expect(imapManager.fetchAttachment).toHaveBeenCalledWith(account, 7, 'INBOX', '2', { snapshot });
+  });
+
+  it('does not cache or publish a fetched body after the exact snapshot CAS loses ownership', async () => {
+    query.mockImplementation(async sql => {
+      if (sql.includes('SELECT m.*, a.user_id, u.preferences')) return { rows: [row] };
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [account] };
+      if (sql.includes('UPDATE messages') && sql.includes('body_html')) return { rowCount: 0, rows: [] };
+      return { rows: [] };
+    });
+    imapManager.fetchMessageBody.mockResolvedValue({ html: null, text: 'stale body', attachments: [] });
+
+    const response = await fetch(`${base}/api/mail/messages/${ID}/body`);
+
+    expect(response.status).toBe(409);
+    expect(imapManager.fetchMessageBody).toHaveBeenCalledWith(account, 7, 'INBOX', { snapshot });
+    expect(await response.json()).toMatchObject({ code: 'MESSAGE_SNAPSHOT_SUPERSEDED' });
+  });
+
+  it.each([
+    ['headers', async () => {
+      imapManager.fetchHeaders.mockResolvedValue('Subject: stale\r\n');
+      return fetch(`${base}/api/mail/messages/${ID}/headers`);
+    }],
+    ['empty body', async () => {
+      imapManager.fetchMessageBody.mockResolvedValue({ html: null, text: null, attachments: [] });
+      return fetch(`${base}/api/mail/messages/${ID}/body`);
+    }],
+    ['attachment', async () => {
+      imapManager.fetchAttachment.mockResolvedValue(Buffer.from('stale'));
+      return fetch(`${base}/api/mail/messages/${ID}/attachments/2`);
+    }],
+    ['ZIP attachments', async () => {
+      imapManager.fetchMultipleAttachments.mockResolvedValue(new Map([['2', Buffer.from('stale')]]));
+      return fetch(`${base}/api/mail/messages/${ID}/attachments.zip`);
+    }],
+  ])('does not publish %s fetched before the source row relocates', async (_label, request) => {
+    query.mockImplementation(async sql => {
+      if (sql.includes('SELECT m.*, a.user_id')) return { rows: [row] };
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [account] };
+      if (sql.includes('WITH expected AS')) return { rows: [] };
+      return { rows: [] };
+    });
+
+    const response = await request();
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ code: 'MESSAGE_SNAPSHOT_SUPERSEDED' });
+  });
+});

--- a/backend/src/routes/mail.snooze.test.js
+++ b/backend/src/routes/mail.snooze.test.js
@@ -8,8 +8,14 @@ import { gatherSnoozeConversation } from './mail.js';
 import { query } from '../services/db.js';
 
 // Column subset that the pool query selects.
-function row(id, message_id, { in_reply_to = null, thread_references = null, folder = 'INBOX', is_read = true } = {}) {
-  return { id, uid: id.charCodeAt(0), account_id: 'acct', folder, message_id, in_reply_to, thread_references, is_read };
+function row(id, message_id, {
+  in_reply_to = null, thread_references = null, folder = 'INBOX', is_read = true,
+  is_deleted = false, metadata_complete = true,
+} = {}) {
+  return {
+    id, uid: id.charCodeAt(0), account_id: 'acct', folder, message_id,
+    in_reply_to, thread_references, is_read, is_deleted, metadata_complete,
+  };
 }
 const ids = (rows) => rows.map(r => r.message_id).sort();
 

--- a/backend/src/routes/mail.unifiedInbox.test.js
+++ b/backend/src/routes/mail.unifiedInbox.test.js
@@ -53,6 +53,7 @@ describe('GET /api/mail/unread-counts unified total', () => {
       total: 2,
       byAccount: { included: 2, excluded: 5 },
     });
+    expect(query.mock.calls[0][0]).toContain('m.metadata_complete = true');
   });
 
   it('uses only opted-in accounts for unified category counts', async () => {
@@ -71,6 +72,7 @@ describe('GET /api/mail/unread-counts unified total', () => {
 
     expect(response.status).toBe(200);
     expect(query.mock.calls[1][1]).toEqual([['included']]);
+    expect(query.mock.calls[1][0]).toContain('m.metadata_complete = true');
   });
 
   it('uses only opted-in accounts when expanding a unified thread', async () => {
@@ -87,5 +89,28 @@ describe('GET /api/mail/unread-counts unified total', () => {
 
     expect(response.status).toBe(200);
     expect(query.mock.calls[1][1][0]).toEqual(['included']);
+    expect(query.mock.calls[1][0]).toContain('m.metadata_complete = true');
+  });
+
+  it('hides an unverified row from the direct message endpoint', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    const response = await fetch(`${base}/api/mail/messages/11111111-1111-4111-8111-111111111111`);
+    expect(response.status).toBe(404);
+    expect(query.mock.calls[0][0]).toContain('m.metadata_complete = true');
+  });
+
+  it.each([
+    ['single attachment', '/attachments/2'],
+    ['attachment ZIP', '/attachments.zip'],
+  ])('hides an incomplete or deleted row from the %s endpoint', async (_name, suffix) => {
+    query.mockResolvedValueOnce({ rows: [] });
+    const response = await fetch(
+      `${base}/api/mail/messages/11111111-1111-4111-8111-111111111111${suffix}`
+    );
+
+    expect(response.status).toBe(404);
+    const sql = query.mock.calls[0][0];
+    expect(sql).toContain('m.is_deleted = false');
+    expect(sql).toContain('m.metadata_complete = true');
   });
 });

--- a/backend/src/routes/rules.js
+++ b/backend/src/routes/rules.js
@@ -130,14 +130,22 @@ router.post('/run', async (req, res) => {
       if (!account) continue;
 
       const BATCH = 500;
+      const observationContext = { accountId: acctId, tokens: [] };
+      await imapMgr.extendFolderObservationContext(acctId, observationContext, ['INBOX']);
       let lastId = null;
       while (true) {
         const msgResult = await query(
-          `SELECT id, uid, folder, from_email, from_name, to_addresses, subject, has_attachments, is_read
-           FROM messages
-           WHERE account_id = $1 AND lower(folder) = 'inbox'
-             ${lastId ? 'AND id > $3' : ''}
-           ORDER BY id
+          `SELECT m.id, m.uid, m.folder, m.from_email, m.from_name, m.to_addresses,
+                  m.subject, m.has_attachments, m.is_read, m.read_revision, m.star_revision,
+                  f.uid_validity AS folder_uid_validity,
+                  f.observation_generation AS folder_observation_generation
+           FROM messages m
+           JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+             AND f.is_present = true AND f.uid_validity IS NOT NULL
+           WHERE m.account_id = $1 AND lower(m.folder) = 'inbox'
+             AND m.is_deleted = false AND m.metadata_complete = true
+             ${lastId ? 'AND m.id > $3' : ''}
+           ORDER BY m.id
            LIMIT $2`,
           lastId ? [acctId, BATCH, lastId] : [acctId, BATCH]
         );
@@ -166,12 +174,16 @@ router.post('/run', async (req, res) => {
             hasAttachments: !!row.has_attachments,
             isRead: !!row.is_read,
             is_read: !!row.is_read,
+            read_revision: row.read_revision,
+            star_revision: row.star_revision,
             parsedHeaders: {},
           };
         });
 
         const before = messages.length;
-        const { remaining } = await applyInboxRules(messages, account, imapMgr);
+        const { remaining } = await applyInboxRules(
+          messages, account, imapMgr, observationContext,
+        );
         processed += before;
         matched += before - remaining.length;
 

--- a/backend/src/routes/search.js
+++ b/backend/src/routes/search.js
@@ -244,8 +244,13 @@ router.get('/', searchLimiter, async (req, res) => {
         a.name as account_name, a.email_address as account_email, a.color as account_color
       FROM messages m
       JOIN email_accounts a ON m.account_id = a.id
+      JOIN folders live_folder ON live_folder.account_id = m.account_id
+        AND live_folder.path = m.folder
+        AND live_folder.is_present = true
+        AND live_folder.uid_validity IS NOT NULL
       WHERE m.account_id = ANY($1)
         AND m.is_deleted = false
+        AND m.metadata_complete = true
         AND ${conditions.join('\n        AND ')}
       ORDER BY m.date DESC
       LIMIT $${p} OFFSET $${p + 1}

--- a/backend/src/routes/search.unifiedInbox.test.js
+++ b/backend/src/routes/search.unifiedInbox.test.js
@@ -51,6 +51,10 @@ describe('GET /api/search unified account scope', () => {
 
     expect(response.status).toBe(200);
     expect(query.mock.calls[1][1][0]).toEqual(['included']);
+    expect(query.mock.calls[1][0]).toContain('m.metadata_complete = true');
+    expect(query.mock.calls[1][0]).toMatch(/JOIN folders live_folder/);
+    expect(query.mock.calls[1][0]).toContain('live_folder.is_present = true');
+    expect(query.mock.calls[1][0]).toContain('live_folder.uid_validity IS NOT NULL');
   });
 
   it('keeps an opted-out account searchable when explicitly selected', async () => {

--- a/backend/src/routes/send.forwarded.test.js
+++ b/backend/src/routes/send.forwarded.test.js
@@ -1,23 +1,53 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import { createHash } from 'node:crypto';
+
+const revalidateLiveMessageSnapshots = vi.hoisted(() => vi.fn());
+const revalidateLiveMessageSnapshotGroups = vi.hoisted(() => vi.fn());
 
 vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../services/messageSnapshots.js', async importOriginal => ({
+  ...(await importOriginal()),
+  revalidateLiveMessageSnapshotGroups,
+  revalidateLiveMessageSnapshots,
+}));
 vi.mock('../middleware/auth.js', () => ({
   requireAuth: (req, _res, next) => { req.session = { userId: 'user-1' }; next(); },
 }));
 vi.mock('../services/redis.js', () => ({
-  redisClient: { get: vi.fn().mockResolvedValue(null), set: vi.fn().mockResolvedValue('OK'), del: vi.fn() },
+  redisClient: { get: vi.fn().mockResolvedValue(null), set: vi.fn().mockResolvedValue('OK'), del: vi.fn().mockResolvedValue(1) },
 }));
-vi.mock('../index.js', () => ({ imapManager: { fetchAttachment: vi.fn() } }));
+vi.mock('../index.js', () => ({ imapManager: {
+  fetchAttachment: vi.fn(),
+  appendToSent: vi.fn(),
+  upsertSentMessageRecord: vi.fn(),
+  findUidByMessageIdReceipt: vi.fn(),
+  upsertSentMessageRecordFromReceipt: vi.fn(),
+  syncFolderOnDemand: vi.fn().mockResolvedValue(undefined),
+  pluginFacade: {},
+} }));
 vi.mock('../services/smtpTransport.js', () => ({ createAccountSmtpTransport: vi.fn() }));
 
 import express from 'express';
 import sendRoutes from './send.js';
 import { query } from '../services/db.js';
 import { imapManager } from '../index.js';
+import { createAccountSmtpTransport } from '../services/smtpTransport.js';
+import { redisClient } from '../services/redis.js';
 
 const ACCOUNT_ID = 'a1a1a1a1-1111-4111-8111-a1a1a1a1a1a1';
 const MSG_ID = 'b2b2b2b2-2222-4222-8222-b2b2b2b2b2b2';
 const ACCOUNT = { id: ACCOUNT_ID, email_address: 'me@example.com', name: 'Me', sender_name: null, signature: null };
+
+function headersFrom(message) {
+  const headerBlock = Buffer.from(message).toString('utf8').split(/\r?\n\r?\n/, 1)[0];
+  const unfolded = headerBlock.replace(/\r?\n[ \t]+/g, ' ');
+  return new Map(unfolded.split(/\r?\n/).flatMap(line => {
+    const separator = line.indexOf(':');
+    return separator < 1
+      ? []
+      : [[line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim()]];
+  }));
+}
 
 function buildApp() {
   const app = express();
@@ -27,16 +57,82 @@ function buildApp() {
 }
 
 describe('POST /api/mail/send — forwarded attachment guards (#F2)', () => {
-  let server, base;
+let server, base;
+  let ledgerDigest;
   beforeAll(async () => {
     await new Promise(r => { server = buildApp().listen(0, r); });
     base = `http://127.0.0.1:${server.address().port}`;
   });
   afterAll(async () => { await new Promise(r => server.close(r)); });
-  beforeEach(() => { query.mockReset(); imapManager.fetchAttachment.mockReset(); });
+  beforeEach(() => {
+    query.mockReset();
+    imapManager.fetchAttachment.mockReset();
+    imapManager.appendToSent.mockReset();
+    imapManager.upsertSentMessageRecord.mockReset();
+    imapManager.findUidByMessageIdReceipt.mockReset();
+    imapManager.upsertSentMessageRecordFromReceipt.mockReset();
+    revalidateLiveMessageSnapshots.mockReset().mockResolvedValue(undefined);
+    revalidateLiveMessageSnapshotGroups.mockReset().mockResolvedValue(undefined);
+    createAccountSmtpTransport.mockReset();
+    redisClient.get.mockReset().mockResolvedValue(null);
+    redisClient.set.mockReset().mockResolvedValue('OK');
+    redisClient.del.mockReset().mockResolvedValue(1);
+    ledgerDigest = null;
+  });
 
   const post = (body) => fetch(`${base}/api/mail/send`, {
-    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+    method: 'POST', headers: {
+      'Content-Type': 'application/json', 'X-Idempotency-Key': 'test-send-key',
+    }, body: JSON.stringify(body),
+  });
+
+  it('requires a durable operation identity before SMTP or IMAP mutation', async () => {
+    const res = await fetch(`${base}/api/mail/send`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accountId: ACCOUNT_ID, to: ['x@example.com'] }),
+    });
+    expect(res.status).toBe(400);
+    expect(query).not.toHaveBeenCalled();
+    expect(createAccountSmtpTransport).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the durable send reservation store is unavailable', async () => {
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return { rows: [ACCOUNT] };
+      if (sql.includes('SELECT preferences FROM users')) return { rows: [{ preferences: {} }] };
+      if (sql.includes('INSERT INTO send_operations')) throw new Error('database unavailable');
+      return { rows: [] };
+    });
+    const res = await post({ accountId: ACCOUNT_ID, to: ['x@example.com'] });
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({
+      operationKeyDisposition: 'rotate_on_payload_change',
+    });
+    expect(createAccountSmtpTransport).not.toHaveBeenCalled();
+  });
+
+  it('tells clients to retain a key whose provider attempt already started', async () => {
+    let digest;
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return { rows: [ACCOUNT] };
+      if (sql.includes('INSERT INTO send_operations')) {
+        digest = params[2];
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('SELECT state, payload_digest')) {
+        return { rows: [{ state: 'provider_started', payload_digest: digest }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await post({ accountId: ACCOUNT_ID, to: ['x@example.com'] });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      code: 'SEND_OUTCOME_UNCERTAIN',
+      operationKeyDisposition: 'retain',
+    });
+    expect(createAccountSmtpTransport).not.toHaveBeenCalled();
   });
 
   it('rejects more than 100 forwarded attachments before doing any DB work', async () => {
@@ -49,9 +145,11 @@ describe('POST /api/mail/send — forwarded attachment guards (#F2)', () => {
   });
 
   it('rejects an oversized forwarded batch by declared size, before fetching any attachment', async () => {
-    query.mockImplementation((sql) => {
+    query.mockImplementation((sql, params) => {
       if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return Promise.resolve({ rows: [ACCOUNT] });
       if (sql.includes('SELECT preferences FROM users')) return Promise.resolve({ rows: [{ preferences: {} }] });
+      if (sql.includes('INSERT INTO send_operations')) { ledgerDigest = params[2]; return Promise.resolve({ rows: [] }); }
+      if (sql.includes('SELECT state, payload_digest')) return Promise.resolve({ rows: [{ state: 'ready', payload_digest: ledgerDigest }] });
       if (sql.includes('FROM messages m') && sql.includes('m.id = ANY')) {
         return Promise.resolve({ rows: [{
           id: MSG_ID, uid: 5, folder: 'INBOX', account_id: ACCOUNT_ID,
@@ -69,5 +167,393 @@ describe('POST /api/mail/send — forwarded attachment guards (#F2)', () => {
     expect((await res.json()).error).toMatch(/exceeds 25 MB/);
     // The whole point: no IMAP fetch happens when the declared size already blows the limit.
     expect(imapManager.fetchAttachment).not.toHaveBeenCalled();
+  });
+
+  it('rejects a deleted or incomplete forwarded-message source before IMAP fetch', async () => {
+    query.mockImplementation((sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return Promise.resolve({ rows: [ACCOUNT] });
+      if (sql.includes('SELECT preferences FROM users')) return Promise.resolve({ rows: [{ preferences: {} }] });
+      if (sql.includes('INSERT INTO send_operations')) { ledgerDigest = params[2]; return Promise.resolve({ rows: [] }); }
+      if (sql.includes('SELECT state, payload_digest')) return Promise.resolve({ rows: [{ state: 'ready', payload_digest: ledgerDigest }] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await post({
+      accountId: ACCOUNT_ID, to: ['x@example.com'],
+      forwardedAttachments: [{ messageId: MSG_ID, part: '2' }],
+    });
+
+    expect(res.status).toBe(404);
+    const ownershipSql = query.mock.calls.find(([sql]) => sql.includes('FROM messages m'))[0];
+    expect(ownershipSql).toMatch(/m\.is_deleted = false/);
+    expect(ownershipSql).toMatch(/m\.metadata_complete = true/);
+    expect(ownershipSql).toMatch(/JOIN folders live_folder/);
+    expect(ownershipSql).toMatch(/live_folder\.is_present = true/);
+    expect(ownershipSql).toMatch(/live_folder\.uid_validity IS NOT NULL/);
+    expect(ownershipSql).toMatch(/folder_uid_validity/);
+    expect(ownershipSql).toMatch(/folder_observation_generation/);
+    expect(imapManager.fetchAttachment).not.toHaveBeenCalled();
+  });
+
+  it('uses the request idempotency key for durable Sent APPEND and materializes inside completion', async () => {
+    const sendMail = vi.fn().mockResolvedValue({ messageId: '<sent@x>' });
+    const account = { ...ACCOUNT, oauth_provider: null, folder_mappings: { sent: 'Sent' } };
+    createAccountSmtpTransport.mockResolvedValue({ account, transport: { sendMail } });
+    imapManager.appendToSent.mockImplementationOnce(async (_account, folder, _raw, options) => {
+      expect(options.operationKey).toBe('send:user-1:request-123');
+      await options.materialize({ uid: 88, uidValidity: '202', folder });
+      return { uid: 88, uidValidity: '202', folder };
+    });
+    imapManager.upsertSentMessageRecord.mockResolvedValueOnce(undefined);
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) {
+        return { rows: [account] };
+      }
+      if (sql.includes('SELECT preferences FROM users')) return { rows: [{ preferences: {} }] };
+      if (sql.includes('SELECT 1 FROM folders')) return { rows: [{ '?column?': 1 }] };
+      if (sql.includes('INSERT INTO address_books')) return { rows: [{ id: 'book-1' }] };
+      if (sql.includes('INSERT INTO send_operations')) { ledgerDigest = params[2]; return { rows: [], rowCount: 1 }; }
+      if (sql.includes('SELECT state, payload_digest')) return { rows: [{ state: 'ready', payload_digest: ledgerDigest }] };
+      if (sql.includes('UPDATE send_operations')) return { rows: [{ operation_key: 'request-123' }], rowCount: 1 };
+      return { rows: [] };
+    });
+
+    const res = await fetch(`${base}/api/mail/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Idempotency-Key': 'request-123' },
+      body: JSON.stringify({ accountId: ACCOUNT_ID, to: ['x@example.com'], subject: 'hello', body: 'body' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(imapManager.appendToSent).toHaveBeenCalledOnce();
+    expect(imapManager.upsertSentMessageRecord).toHaveBeenCalledWith(
+      expect.objectContaining({ id: ACCOUNT_ID }), 'Sent', 88, expect.objectContaining({ subject: 'hello' }),
+    );
+    const completionSql = query.mock.calls.find(([sql]) => sql.includes("SET state = 'completed'"))?.[0];
+    expect(completionSql).toMatch(/smtp_message\s*=\s*NULL/i);
+    expect(completionSql).toMatch(/smtp_envelope\s*=\s*NULL/i);
+    expect(completionSql).toMatch(/raw_message\s*=\s*NULL/i);
+    expect(completionSql).toMatch(/source_snapshots\s*=\s*NULL/i);
+  });
+
+  it('durably prepares the stable Message-ID and exact Sent recovery facts before SMTP starts', async () => {
+    const events = [];
+    const sendMail = vi.fn(async mail => {
+      events.push('smtp');
+      expect(Buffer.from(mail.raw).toString()).toContain(`Message-ID: ${operation.message_id}`);
+      return { messageId: operation.message_id };
+    });
+    const account = { ...ACCOUNT, oauth_provider: null, folder_mappings: { sent: 'Sent' } };
+    const operation = { state: 'ready', payload_digest: null };
+    createAccountSmtpTransport.mockResolvedValue({ account, transport: { sendMail } });
+    imapManager.appendToSent.mockResolvedValue({ uid: 88, uidValidity: '202', folder: 'Sent' });
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return { rows: [account] };
+      if (sql.includes('SELECT preferences FROM users')) return { rows: [{ preferences: {} }] };
+      if (sql.includes('INSERT INTO send_operations')) {
+        operation.payload_digest = params[2];
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('SELECT state, payload_digest')) return { rows: [{ ...operation }] };
+      if (sql.includes('SELECT 1 FROM folders')) return { rows: [{ '?column?': 1 }] };
+      if (sql.includes('SET message_id =')) {
+        events.push('prepared');
+        operation.message_id = params[3];
+        operation.sent_folder = params[4];
+        operation.sent_metadata = JSON.parse(params[5]);
+        operation.raw_message = params[6];
+        operation.server_auto_saves = params[7];
+        operation.smtp_message = params[8];
+        operation.smtp_envelope = JSON.parse(params[9]);
+        operation.prepared_payload_digest = params[10];
+        operation.source_snapshots = JSON.parse(params[11]);
+        return { rows: [{ ...operation }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'provider_started'")) {
+        expect(events).toEqual(['prepared']);
+        operation.state = 'provider_started';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'provider_applied'")) {
+        operation.state = 'provider_applied';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'completed'")) {
+        operation.state = 'completed';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO address_books')) return { rows: [{ id: 'book-1' }] };
+      return { rows: [] };
+    });
+
+    const res = await post({
+      accountId: ACCOUNT_ID,
+      to: ['Visible <visible@example.com>'],
+      cc: ['Copy <copy@example.com>'],
+      bcc: ['Hidden <hidden@example.com>'],
+      subject: 'hello',
+      body: 'body',
+    });
+
+    expect(res.status).toBe(200);
+    expect(events).toEqual(['prepared', 'smtp']);
+    expect(operation.sent_folder).toBe('Sent');
+    expect(operation.sent_metadata).toMatchObject({
+      messageId: expect.stringMatching(/^<.+@example\.com>$/),
+      subject: 'hello',
+    });
+    expect(operation.raw_message).toBeInstanceOf(Buffer);
+    expect(operation.server_auto_saves).toBe(false);
+    const deliveryHeaders = headersFrom(operation.smtp_message);
+    expect(deliveryHeaders.get('to')).toContain('visible@example.com');
+    expect(deliveryHeaders.get('cc')).toContain('copy@example.com');
+    expect(deliveryHeaders.has('bcc')).toBe(false);
+    expect(operation.smtp_envelope).toEqual({
+      from: 'me@example.com',
+      to: ['visible@example.com', 'copy@example.com', 'hidden@example.com'],
+    });
+    expect(headersFrom(operation.raw_message).get('bcc')).toContain('hidden@example.com');
+    expect(operation.prepared_payload_digest).toBe(
+      createHash('sha256')
+        .update(operation.smtp_message)
+        .update('\0')
+        .update('{"from":"me@example.com","to":["visible@example.com","copy@example.com","hidden@example.com"]}')
+        .digest('hex'),
+    );
+  });
+
+  it('replays provider-applied Sent materialization without another SMTP delivery', async () => {
+    const sendMail = vi.fn().mockResolvedValue({ messageId: '<stable@example.com>' });
+    const account = { ...ACCOUNT, oauth_provider: null, folder_mappings: { sent: 'Sent' } };
+    const operation = { state: 'ready', payload_digest: null };
+    let appendAttempts = 0;
+    createAccountSmtpTransport.mockResolvedValue({ account, transport: { sendMail } });
+    imapManager.appendToSent.mockImplementation(async () => {
+      appendAttempts++;
+      if (appendAttempts === 1) throw new Error('Sent materialization unavailable');
+      return { uid: 88, uidValidity: '202', folder: 'Sent' };
+    });
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return { rows: [account] };
+      if (sql.includes('SELECT preferences FROM users')) return { rows: [{ preferences: {} }] };
+      if (sql.includes('INSERT INTO send_operations')) {
+        operation.payload_digest ||= params[2];
+        return { rows: [], rowCount: 1 };
+      }
+      if (sql.includes('SELECT state, payload_digest')) return { rows: [{ ...operation }] };
+      if (sql.includes('SELECT 1 FROM folders')) return { rows: [{ '?column?': 1 }] };
+      if (sql.includes('SET message_id =')) {
+        Object.assign(operation, {
+          message_id: params[3], sent_folder: params[4],
+          sent_metadata: JSON.parse(params[5]), raw_message: params[6],
+          server_auto_saves: params[7],
+        });
+        return { rows: [{ ...operation }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'provider_started'")) {
+        operation.state = 'provider_started';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'provider_applied'")) {
+        operation.state = 'provider_applied';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'completed'")) {
+        operation.state = 'completed';
+        operation.response = JSON.parse(params[3]);
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO address_books')) return { rows: [{ id: 'book-1' }] };
+      return { rows: [] };
+    });
+
+    const body = { accountId: ACCOUNT_ID, to: ['x@example.com'], subject: 'hello', body: 'body' };
+    const first = await post(body);
+    expect(first.status).toBe(503);
+    expect(operation.state).toBe('provider_applied');
+    expect(sendMail).toHaveBeenCalledTimes(1);
+
+    const replay = await post(body);
+    expect(replay.status).toBe(200);
+    expect(operation.state).toBe('completed');
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    expect(createAccountSmtpTransport).toHaveBeenCalledTimes(1);
+    expect(imapManager.appendToSent).toHaveBeenCalledTimes(2);
+  });
+
+  it('replays a ready operation from its exact prepared SMTP bytes without current alias or preference drift', async () => {
+    const raw = Buffer.from('From: frozen@example.com\r\nTo: Visible <visible@example.com>\r\nCc: Copy <copy@example.com>\r\nMessage-ID: <frozen@example.com>\r\n\r\nfrozen body');
+    const envelope = {
+      from: 'frozen@example.com',
+      to: ['visible@example.com', 'copy@example.com', 'hidden@example.com'],
+    };
+    const preparedDigest = createHash('sha256')
+      .update(raw)
+      .update('\0')
+      .update('{"from":"frozen@example.com","to":["visible@example.com","copy@example.com","hidden@example.com"]}')
+      .digest('hex');
+    const operation = {
+      state: 'ready', payload_digest: null, message_id: '<frozen@example.com>',
+      sent_folder: null, sent_metadata: null, raw_message: null, server_auto_saves: false,
+      smtp_message: raw, smtp_envelope: envelope,
+      prepared_payload_digest: preparedDigest, source_snapshots: [],
+    };
+    const sendMail = vi.fn().mockResolvedValue({ messageId: '<frozen@example.com>' });
+    createAccountSmtpTransport.mockResolvedValue({
+      account: { ...ACCOUNT, signature: '<p>changed server signature</p>' },
+      transport: { sendMail },
+    });
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) {
+        return { rows: [{ ...ACCOUNT, signature: '<p>changed server signature</p>' }] };
+      }
+      if (sql.includes('SELECT preferences FROM users')) {
+        return { rows: [{ preferences: { plaintextEmail: true } }] };
+      }
+      if (sql.includes('INSERT INTO send_operations')) {
+        operation.payload_digest = params[2];
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes('SELECT state, payload_digest')) return { rows: [{ ...operation }] };
+      if (sql.includes('FROM account_aliases')) return { rows: [{
+        name: 'Changed Alias', email: 'changed@example.com', reply_to: null,
+        signature: '<p>changed alias signature</p>',
+      }] };
+      if (sql.includes('FROM messages m')) return { rows: [] };
+      if (sql.includes("SET state = 'provider_started'")) {
+        operation.state = 'provider_started';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'provider_applied'")) {
+        operation.state = 'provider_applied';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'completed'")) {
+        operation.state = 'completed';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes('INSERT INTO address_books')) return { rows: [{ id: 'book-1' }] };
+      return { rows: [] };
+    });
+
+    const res = await post({
+      accountId: ACCOUNT_ID, aliasId: 'changed-alias',
+      to: ['Visible <visible@example.com>'], cc: ['Copy <copy@example.com>'],
+      bcc: ['Hidden <hidden@example.com>'],
+      subject: 'same request', body: 'same request body',
+    });
+
+    expect(res.status).toBe(200);
+    expect(sendMail).toHaveBeenCalledWith({ raw, envelope });
+    expect(headersFrom(raw).has('bcc')).toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('SELECT preferences FROM users'))).toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('FROM account_aliases'))).toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('FROM messages m'))).toBe(false);
+    expect(imapManager.fetchAttachment).not.toHaveBeenCalled();
+    expect(operation.state).toBe('completed');
+  });
+
+  it('records SMTP acceptance before a post-delivery source supersession', async () => {
+    const events = [];
+    const sendMail = vi.fn(async () => { events.push('smtp'); return { accepted: true }; });
+    const source = {
+      id: MSG_ID, uid: 5, folder: 'INBOX', account_id: ACCOUNT_ID,
+      folder_uid_validity: '101', folder_observation_generation: '9',
+      read_revision: '3', star_revision: '5',
+      attachments: [{ part: '2', size: 5, filename: 'a.txt', type: 'text/plain' }],
+    };
+    const operation = { state: 'ready', payload_digest: null };
+    createAccountSmtpTransport.mockResolvedValue({ account: ACCOUNT, transport: { sendMail } });
+    imapManager.fetchAttachment.mockResolvedValue(Buffer.from('exact'));
+    revalidateLiveMessageSnapshotGroups
+      .mockImplementationOnce(async () => { events.push('validate-pre'); })
+      .mockImplementationOnce(async () => {
+        events.push('validate-post');
+        throw Object.assign(new Error('Message snapshot was relocated or superseded'), {
+          code: 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable: true,
+        });
+      });
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return { rows: [ACCOUNT] };
+      if (sql.includes('SELECT preferences FROM users')) return { rows: [{ preferences: {} }] };
+      if (sql.includes('FROM messages m') && sql.includes('m.id = ANY')) return { rows: [source] };
+      if (sql.includes('FROM email_accounts WHERE id = ANY')) return { rows: [ACCOUNT] };
+      if (sql.includes('INSERT INTO send_operations')) { operation.payload_digest ||= params[2]; return { rows: [] }; }
+      if (sql.includes('SELECT state, payload_digest')) return { rows: [{ ...operation }] };
+      if (sql.includes('SET message_id =')) return { rows: [{ ...operation, message_id: params[3] }], rowCount: 1 };
+      if (sql.includes("SET state = 'provider_started'")) {
+        operation.state = 'provider_started';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'provider_applied'")) {
+        events.push('provider-applied');
+        operation.state = 'provider_applied';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'uncertain'")) {
+        operation.state = 'uncertain';
+        return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      }
+      if (sql.includes("SET state = 'completed'")) throw new Error('source fence failure must defer completion');
+      return { rows: [] };
+    });
+
+    const res = await post({
+      accountId: ACCOUNT_ID, to: ['x@example.com'], subject: 'forward', body: 'body',
+      forwardedAttachments: [{ messageId: MSG_ID, part: '2' }],
+    });
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toMatchObject({
+      code: 'SENT_MATERIALIZATION_PENDING',
+      outcome: 'provider_applied',
+      retryable: true,
+      operationKeyDisposition: 'retain',
+    });
+    expect(events).toEqual(['validate-pre', 'smtp', 'provider-applied', 'validate-post']);
+    expect(operation.state).toBe('provider_applied');
+  });
+
+  it('does not hand fetched forwarded attachments to SMTP after their source relocates', async () => {
+    const sendMail = vi.fn().mockResolvedValue({ messageId: '<sent@x>' });
+    createAccountSmtpTransport.mockResolvedValue({ account: ACCOUNT, transport: { sendMail } });
+    const source = {
+      id: MSG_ID, uid: 5, folder: 'INBOX', account_id: ACCOUNT_ID,
+      folder_uid_validity: '101', folder_observation_generation: '9',
+      read_revision: '3', star_revision: '5',
+      attachments: [{ part: '2', size: 5, filename: 'a.txt', type: 'text/plain' }],
+    };
+    query.mockImplementation(async (sql, params) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return { rows: [ACCOUNT] };
+      if (sql.includes('SELECT preferences FROM users')) return { rows: [{ preferences: {} }] };
+      if (sql.includes('FROM messages m') && sql.includes('m.id = ANY')) return { rows: [source] };
+      if (sql.includes('FROM email_accounts WHERE id = ANY')) return { rows: [ACCOUNT] };
+      if (sql.includes('INSERT INTO send_operations')) { ledgerDigest = params[2]; return { rows: [], rowCount: 1 }; }
+      if (sql.includes('SELECT state, payload_digest')) return { rows: [{ state: 'ready', payload_digest: ledgerDigest }] };
+      if (sql.includes('UPDATE send_operations')) return { rows: [{ operation_key: 'test-send-key' }], rowCount: 1 };
+      return { rows: [] };
+    });
+    imapManager.fetchAttachment.mockResolvedValue(Buffer.from('stale'));
+    revalidateLiveMessageSnapshotGroups.mockRejectedValue(Object.assign(
+      new Error('Message snapshot was relocated or superseded'),
+      { code: 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable: true },
+    ));
+
+    const res = await post({
+      accountId: ACCOUNT_ID, to: ['x@example.com'], subject: 'forward', body: 'body',
+      forwardedAttachments: [{ messageId: MSG_ID, part: '2' }],
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      outcome: 'not_sent',
+      operationKeyDisposition: 'rotate_on_payload_change',
+    });
+    expect(revalidateLiveMessageSnapshotGroups).toHaveBeenCalledWith(expect.any(Map));
+    const groups = revalidateLiveMessageSnapshotGroups.mock.calls[0][0];
+    expect(groups.get(ACCOUNT_ID)).toEqual([expect.objectContaining({
+      id: MSG_ID, uid: 5, folder: 'INBOX', uidValidity: '101', folderGeneration: '9',
+    })]);
+    expect(sendMail).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/routes/send.js
+++ b/backend/src/routes/send.js
@@ -1,4 +1,3 @@
-import nodemailer from 'nodemailer';
 import { randomBytes, createHash, randomUUID } from 'crypto';
 import { Router } from 'express';
 import { query } from '../services/db.js';
@@ -6,11 +5,14 @@ import { requireAuth } from '../middleware/auth.js';
 import sanitizeHtml from 'sanitize-html';
 import { sanitizeSignature, sanitizeComposeBody } from '../services/emailSanitizer.js';
 import { embedInlineDataImages } from '../utils/inlineImages.js';
-import { redisClient } from '../services/redis.js';
-import { redactEmail } from '../utils/redact.js';
+import {
+  revalidateLiveMessageSnapshotGroups,
+  snapshotFromMessageRow,
+} from '../services/messageSnapshots.js';
 import { resolveSentFolder } from '../utils/mailUtils.js';
 import { generateVCard } from '../utils/vcard.js';
 import { createAccountSmtpTransport } from '../services/smtpTransport.js';
+import { loadPreparedSmtp, renderPreparedSmtp } from '../services/preparedSmtp.js';
 import { imapManager } from '../index.js';
 import { pluginRegistry } from '../plugins/registry.js';
 
@@ -59,24 +61,6 @@ function buildSentSnippet(body, bodyIsHtml) {
   return bodyToPlain(body, bodyIsHtml).replace(/\s+/g, ' ').trim().substring(0, 200);
 }
 
-function scheduleSentMetadataUpsert(account, sentFolder, mailOptions, meta) {
-  if (!sentFolder || !mailOptions.messageId) return;
-  setImmediate(async () => {
-    for (const delay of [3000, 10000, 20000]) {
-      await new Promise(r => setTimeout(r, delay));
-      try {
-        const uid = await imapManager.findUidByMessageId(account, sentFolder, mailOptions.messageId);
-        if (uid) {
-          await imapManager.upsertSentMessageRecord(account, sentFolder, uid, meta);
-          return;
-        }
-      } catch (err) {
-        console.warn('Post-send sent metadata upsert failed:', err.message);
-      }
-    }
-  });
-}
-
 // Reject any recipient address that contains newlines, null bytes, or looks
 // malformed — these are the classic email header-injection vectors.
 function normalizeRecipients(list, fieldName) {
@@ -123,6 +107,102 @@ function bodyToHtml(body, isHtml) {
   return sanitizeComposeBody(body);
 }
 
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function parseStoredJson(value) {
+  if (typeof value !== 'string') return value;
+  return JSON.parse(value);
+}
+
+function scheduleSentSync(account, sentFolder, messageId, delay, label) {
+  setTimeout(() => {
+    imapManager.syncFolderOnDemand(account, sentFolder)
+      .then(() => pluginRegistry.runHook('onSentMessage', {
+        imapManager: imapManager.pluginFacade, account, messageId,
+      }))
+      .catch(e => console.error(`Post-send ${label} sync failed: ${e.message}`));
+  }, delay);
+}
+
+async function materializePreparedSent(account, operation, userId, idempotencyKey) {
+  const sentFolder = operation.sent_folder;
+  if (!sentFolder) return null;
+  const sentMeta = parseStoredJson(operation.sent_metadata);
+  if (!operation.message_id || !sentMeta || sentMeta.messageId !== operation.message_id) {
+    throw new Error('Durable Sent recovery facts are incomplete');
+  }
+
+  if (operation.server_auto_saves) {
+    const receipt = await imapManager.findUidByMessageIdReceipt(
+      account, sentFolder, operation.message_id,
+    );
+    await imapManager.upsertSentMessageRecordFromReceipt(account, receipt, sentMeta);
+    scheduleSentSync(account, sentFolder, operation.message_id, 3000, '3s');
+    scheduleSentSync(account, sentFolder, operation.message_id, 15000, '15s');
+    return null;
+  }
+
+  if (!operation.raw_message) throw new Error('Durable Sent MIME is unavailable');
+  await Promise.race([
+    imapManager.appendToSent(account, sentFolder, Buffer.from(operation.raw_message), {
+      operationKey: `send:${userId}:${idempotencyKey}`,
+      materialize: ({ uid: appendedUid }, tx) => (
+        tx
+          ? imapManager.upsertSentMessageRecord(
+              account, sentFolder, appendedUid, sentMeta, { tx },
+            )
+          : imapManager.upsertSentMessageRecord(
+              account, sentFolder, appendedUid, sentMeta,
+            )
+      ),
+    }),
+    new Promise((_, reject) => setTimeout(() => reject(new Error('Sent APPEND timed out')), 20000)),
+  ]);
+  scheduleSentSync(account, sentFolder, operation.message_id, 1000, 'post-append');
+  return true;
+}
+
+async function completeProviderAppliedSend({ account, operation, userId, idempotencyKey, payloadDigest }) {
+  const sentCopySaved = await materializePreparedSent(
+    account, operation, userId, idempotencyKey,
+  );
+  const sendResult = { ok: true };
+  if (sentCopySaved === false) sendResult.sentCopySaved = false;
+  if (operation.sent_folder) sendResult.sentFolder = operation.sent_folder;
+  const completed = await query(
+    `UPDATE send_operations
+        SET state = 'completed', response = $4::jsonb,
+            message_id = NULL, sent_folder = NULL, sent_metadata = NULL,
+            raw_message = NULL, server_auto_saves = NULL,
+            smtp_message = NULL, smtp_envelope = NULL,
+            prepared_payload_digest = NULL, source_snapshots = NULL,
+            completed_at = NOW(), updated_at = NOW()
+      WHERE user_id = $1 AND operation_key = $2 AND payload_digest = $3
+        AND state = 'provider_applied'
+      RETURNING operation_key`,
+    [userId, idempotencyKey, payloadDigest, JSON.stringify(sendResult)],
+  );
+  if (completed.rowCount !== 1) throw new Error('Durable send completion was not persisted');
+  return sendResult;
+}
+
+async function revalidateForwardedSnapshots(forwardedSnapshots) {
+  if (forwardedSnapshots.size === 0) return;
+  const byAccount = new Map();
+  for (const snapshot of forwardedSnapshots.values()) {
+    const snapshots = byAccount.get(snapshot.accountId) || [];
+    snapshots.push(snapshot);
+    byAccount.set(snapshot.accountId, snapshots);
+  }
+  await revalidateLiveMessageSnapshotGroups(byAccount);
+}
+
 const router = Router();
 router.use(requireAuth);
 
@@ -138,14 +218,12 @@ router.post('/send', async (req, res) => {
   // concurrent same-key submit is blocked by the reservation set just before delivery
   // (below). Neither can produce a duplicate email.
   const idempotencyKey = typeof req.headers['x-idempotency-key'] === 'string'
-    ? req.headers['x-idempotency-key'].slice(0, 128)
+    ? req.headers['x-idempotency-key'].trim().slice(0, 128)
     : null;
-  const idemKeyRedis = idempotencyKey ? `send_idem:${req.session.userId}:${idempotencyKey}` : null;
-  if (idemKeyRedis) {
-    const cached = await redisClient.get(idemKeyRedis).catch(() => null);
-    if (cached === '__inflight__') return res.status(409).json({ error: 'This message is already being sent.' });
-    if (cached) return res.json(JSON.parse(cached));
+  if (!idempotencyKey) {
+    return res.status(400).json({ error: 'X-Idempotency-Key required for send' });
   }
+  const sendPayloadDigest = createHash('sha256').update(stableJson(req.body)).digest('hex');
 
   if (attachments !== undefined) {
     if (!Array.isArray(attachments)) return res.status(400).json({ error: 'attachments must be an array' });
@@ -177,19 +255,100 @@ router.post('/send', async (req, res) => {
   }
   const normalizedSubject = sanitizeHeaderValue(subject || '');
 
-  const [result, prefResult] = await Promise.all([
-    query('SELECT * FROM email_accounts WHERE id = $1 AND user_id = $2', [accountId, req.session.userId]),
-    query('SELECT preferences FROM users WHERE id = $1', [req.session.userId]),
-  ]);
+  const result = await query(
+    'SELECT * FROM email_accounts WHERE id = $1 AND user_id = $2',
+    [accountId, req.session.userId],
+  );
   if (!result.rows.length) return res.status(404).json({ error: 'Account not found' });
-  const plaintextEmail = prefResult.rows[0]?.preferences?.plaintextEmail === true;
   let account = result.rows[0];
 
-  // Resolve the From identity — account by default, alias if requested
+  let sendOperation;
+  try {
+    await query(
+      `INSERT INTO send_operations (user_id, operation_key, payload_digest)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (user_id, operation_key) DO NOTHING`,
+      [req.session.userId, idempotencyKey, sendPayloadDigest],
+    );
+    const sendOperationResult = await query(
+      `SELECT state, payload_digest, response, message_id, sent_folder,
+              sent_metadata, raw_message, server_auto_saves, smtp_message,
+              smtp_envelope, prepared_payload_digest, source_snapshots
+         FROM send_operations
+        WHERE user_id = $1 AND operation_key = $2`,
+      [req.session.userId, idempotencyKey],
+    );
+    sendOperation = sendOperationResult.rows[0];
+  } catch (err) {
+    console.error('Send reservation failed:', err.message);
+    return res.status(500).json({
+      error: 'Failed to reserve send operation.',
+      operationKeyDisposition: 'rotate_on_payload_change',
+    });
+  }
+  if (!sendOperation) return res.status(503).json({ error: 'Durable send ledger unavailable' });
+  if (sendOperation.payload_digest !== sendPayloadDigest) {
+    return res.status(409).json({
+      error: 'Idempotency key is already bound to a different message.',
+      operationKeyDisposition: sendOperation.state === 'ready'
+        ? 'rotate_on_payload_change'
+        : 'retain',
+    });
+  }
+  if (sendOperation.state === 'completed') return res.json(sendOperation.response || { ok: true });
+  if (['provider_started', 'uncertain'].includes(sendOperation.state)) {
+    return res.status(409).json({
+      error: 'The prior send outcome is uncertain; another SMTP delivery is blocked.',
+      code: 'SEND_OUTCOME_UNCERTAIN', outcome: sendOperation.state, retryable: false,
+      operationKeyDisposition: 'retain',
+    });
+  }
+  if (!['ready', 'provider_applied'].includes(sendOperation.state)) {
+    return res.status(409).json({ error: 'The prior send outcome cannot be resumed.' });
+  }
+
+  if (sendOperation.state === 'provider_applied') {
+    try {
+      const sendResult = await completeProviderAppliedSend({
+        account, operation: sendOperation, userId: req.session.userId,
+        idempotencyKey, payloadDigest: sendPayloadDigest,
+      });
+      return res.json(sendResult);
+    } catch (err) {
+      console.error('Sent materialization recovery failed:', err.message);
+      return res.status(503).json({
+        error: 'Message was delivered, but its Sent copy is still being recovered.',
+        code: 'SENT_MATERIALIZATION_PENDING', outcome: 'provider_applied', retryable: true,
+        operationKeyDisposition: 'retain',
+      });
+    }
+  }
+
+  const preparedReplay = Boolean(sendOperation.smtp_message);
+  const plaintextEmail = preparedReplay
+    ? false
+    : (await query('SELECT preferences FROM users WHERE id = $1', [req.session.userId]))
+      .rows[0]?.preferences?.plaintextEmail === true;
   let fromName = account.sender_name || account.name;
   let fromEmail = account.email_address;
   let fromSignature = account.signature;
   let fromReplyTo = null;
+  let effectiveSignature = null;
+  let resolvedFwdAttachments = [];
+  const forwardedSnapshots = new Map();
+
+  if (preparedReplay) {
+    for (const snapshot of parseStoredJson(sendOperation.source_snapshots) || []) {
+      if (!snapshot?.id || !snapshot.accountId) {
+        return res.status(409).json({
+          error: 'Durable send source snapshot is unavailable.',
+          operationKeyDisposition: 'rotate_on_payload_change',
+        });
+      }
+      forwardedSnapshots.set(snapshot.id, snapshot);
+    }
+  } else {
+  // Resolve the From identity — account by default, alias if requested
 
   if (aliasId) {
     const aliasResult = await query(
@@ -208,22 +367,29 @@ router.post('/send', async (req, res) => {
 
   // Allow the client to override the signature per-send (editedSignature === undefined means use DB value).
   // Sanitize client-supplied HTML to prevent injecting scripts or tracking pixels into sent mail.
-  const effectiveSignature = editedSignature !== undefined
+  effectiveSignature = editedSignature !== undefined
     ? (editedSignature ? sanitizeSignature(editedSignature) : null)
     : fromSignature;  // fromSignature from DB is already sanitized on write
 
   // Fetch forwarded attachment content from IMAP before entering the SMTP try-block so that
   // attachment errors return descriptive messages rather than being sanitized as SMTP errors.
-  let resolvedFwdAttachments = [];
   if (forwardedAttachments?.length) {
     try {
       // Resolve every referenced message in a SINGLE ownership-scoped query so a large
       // forwardedAttachments array can't fan out into one DB round-trip per entry.
       const distinctMsgIds = [...new Set(forwardedAttachments.map(fa => fa.messageId))];
       const msgRows = await query(
-        `SELECT m.id, m.uid, m.folder, m.attachments, m.account_id FROM messages m
+        `SELECT m.id, m.uid, m.folder, m.attachments, m.account_id,
+                m.read_revision, m.star_revision,
+                live_folder.uid_validity AS folder_uid_validity,
+                live_folder.observation_generation AS folder_observation_generation
+         FROM messages m
          JOIN email_accounts a ON m.account_id = a.id
-         WHERE m.id = ANY($1::uuid[]) AND a.user_id = $2`,
+         JOIN folders live_folder ON live_folder.account_id = m.account_id
+           AND live_folder.path = m.folder AND live_folder.is_present = true
+           AND live_folder.uid_validity IS NOT NULL
+         WHERE m.id = ANY($1::uuid[]) AND a.user_id = $2
+           AND m.is_deleted = false AND m.metadata_complete = true`,
         [distinctMsgIds, req.session.userId]
       );
       const msgById = new Map(msgRows.rows.map(m => [m.id, m]));
@@ -242,6 +408,7 @@ router.post('/send', async (req, res) => {
           : (msg.attachments || []);
         const att = storedAtts.find(a => a.part === fa.part);
         if (!att) throw Object.assign(new Error('Attachment not found in message'), { status: 404 });
+        forwardedSnapshots.set(msg.id, snapshotFromMessageRow(msg));
         declaredFwdBytes += Number(att.size) || 0;
         return { msg, att };
       });
@@ -261,7 +428,10 @@ router.post('/send', async (req, res) => {
         const fetched = await Promise.all(batch.map(async ({ msg, att }) => {
           const acct = acctById.get(msg.account_id);
           if (!acct) throw Object.assign(new Error('Account not found'), { status: 404 });
-          const buffer = await imapManager.fetchAttachment(acct, msg.uid, msg.folder, att.part);
+          const buffer = await imapManager.fetchAttachment(
+            acct, msg.uid, msg.folder, att.part,
+            { snapshot: snapshotFromMessageRow(msg) },
+          );
           if (!buffer) throw Object.assign(new Error(`Could not fetch attachment: ${att.filename}`), { status: 502 });
           return {
             filename: sanitizeHeaderValue(att.filename || 'attachment'),
@@ -278,100 +448,175 @@ router.post('/send', async (req, res) => {
         return res.status(400).json({ error: 'Total attachment size exceeds 25 MB' });
       }
     } catch (err) {
-      return res.status(err.status || 500).json({ error: err.message || 'Failed to fetch forwarded attachments' });
+      return res.status(err.status || 500).json({
+        error: err.message || 'Failed to fetch forwarded attachments',
+        operationKeyDisposition: 'rotate_on_payload_change',
+      });
     }
   }
+  }
 
-  let delivered = false; // true once transport.sendMail has actually handed off the message
+  let operationState = 'ready';
   try {
+    // The Message-ID is prepared durably while the operation is still retryable, then reused
+    // by SMTP and every Sent-materialization recovery attempt. A ready replay never rebuilds
+    // these facts from mutable aliases, preferences, signatures, or attachment sources.
+    const domain = fromEmail.split('@')[1] || 'mailflow.local';
+    const messageId = sendOperation.message_id
+      || `<${randomBytes(16).toString('hex')}@${domain}>`;
+    let serverAutoSaves = sendOperation.server_auto_saves === true;
+    let sentFolder = sendOperation.sent_folder;
+    let sentMeta = parseStoredJson(sendOperation.sent_metadata);
+    let rawMessage = sendOperation.raw_message;
+    let preparedMail;
+
+    if (preparedReplay) {
+      preparedMail = loadPreparedSmtp({
+        message: sendOperation.smtp_message,
+        envelope: sendOperation.smtp_envelope,
+        digest: sendOperation.prepared_payload_digest,
+      });
+    } else {
+      const mailOptions = {
+        messageId,
+        from: `${fromName} <${fromEmail}>`,
+        ...(fromReplyTo ? { replyTo: fromReplyTo } : {}),
+        to: normalizedTo.join(', '),
+        cc: normalizedCc.join(', ') || undefined,
+        bcc: normalizedBcc.join(', ') || undefined,
+        subject: normalizedSubject,
+        ...(emailPriority !== 'normal' ? { priority: emailPriority } : {}),
+        text: effectiveSignature
+          ? bodyToPlain(body, bodyIsHtml) + '\n\n-- \n' + sigToPlainText(effectiveSignature) + (quotedBody || '')
+          : bodyToPlain(body, bodyIsHtml) + (quotedBody || ''),
+      };
+
+      let inlineImageAttachments = [];
+      if (!plaintextEmail) {
+        const rawHtml = bodyToHtml(body, bodyIsHtml) +
+          (effectiveSignature
+            ? '<div style="margin-top:16px;color:#555;font-size:13px">' + effectiveSignature + '</div>'
+            : '') +
+          (quotedBodyHtml || (quotedBody ? textToHtml(quotedBody) : ''));
+        const embedded = embedInlineDataImages(rawHtml);
+        mailOptions.html = embedded.html;
+        inlineImageAttachments = embedded.attachments;
+      }
+
+      if (inReplyTo) {
+        mailOptions.inReplyTo = sanitizeHeaderValue(inReplyTo);
+        mailOptions.references = sanitizeHeaderValue(references || inReplyTo);
+      }
+      const allAttachments = [
+        ...inlineImageAttachments,
+        ...(attachments?.length ? attachments.map(a => ({
+          filename: sanitizeHeaderValue(a.filename),
+          content: Buffer.from(a.content, 'base64'),
+          contentType: typeof a.contentType === 'string' ? a.contentType : 'application/octet-stream',
+        })) : []),
+        ...resolvedFwdAttachments,
+      ];
+      if (allAttachments.length) mailOptions.attachments = allAttachments;
+
+      serverAutoSaves = !!account.oauth_provider;
+      sentFolder = await resolveSentFolder(accountId, account.folder_mappings);
+      sentMeta = sentFolder ? {
+          messageId,
+          subject: normalizedSubject,
+          fromName,
+          fromEmail,
+          to: mapRecipientList(normalizedTo),
+          cc: mapRecipientList(normalizedCc),
+          snippet: buildSentSnippet(body, bodyIsHtml),
+          date: new Date().toISOString(),
+          inReplyTo: mailOptions.inReplyTo || null,
+          references: mailOptions.references || null,
+        } : null;
+      const envelope = {
+        from: fromEmail,
+        to: [...normalizedTo, ...normalizedCc, ...normalizedBcc]
+          .map(address => parseAddress(address).email),
+      };
+      const needsSentCopy = Boolean(sentFolder && !serverAutoSaves);
+      const rendered = await renderPreparedSmtp(
+        mailOptions,
+        envelope,
+        { includeBccInSentCopy: needsSentCopy },
+      );
+      rawMessage = needsSentCopy ? rendered.sentMessage : null;
+      const prepared = await query(
+        `UPDATE send_operations
+            SET message_id = $4, sent_folder = $5, sent_metadata = $6::jsonb,
+                raw_message = $7, server_auto_saves = $8,
+                smtp_message = $9, smtp_envelope = $10::jsonb,
+                prepared_payload_digest = $11, source_snapshots = $12::jsonb,
+                prepared_at = NOW(), updated_at = NOW()
+          WHERE user_id = $1 AND operation_key = $2 AND payload_digest = $3
+            AND state = 'ready' AND smtp_message IS NULL
+          RETURNING state, payload_digest, message_id, sent_folder,
+                    sent_metadata, raw_message, server_auto_saves, smtp_message,
+                    smtp_envelope, prepared_payload_digest, source_snapshots`,
+        [
+          req.session.userId, idempotencyKey, sendPayloadDigest, messageId,
+          sentFolder, sentMeta ? JSON.stringify(sentMeta) : null, rawMessage, serverAutoSaves,
+          rendered.message, JSON.stringify(rendered.envelope), rendered.digest,
+          JSON.stringify([...forwardedSnapshots.values()]),
+        ],
+      );
+      if (prepared.rowCount !== 1) {
+        return res.status(409).json({ error: 'This message is already being prepared or sent.' });
+      }
+      sendOperation = {
+        ...sendOperation, state: 'ready', message_id: messageId, sent_folder: sentFolder,
+        sent_metadata: sentMeta, raw_message: rawMessage, server_auto_saves: serverAutoSaves,
+        smtp_message: rendered.message, smtp_envelope: rendered.envelope,
+        prepared_payload_digest: rendered.digest,
+        source_snapshots: [...forwardedSnapshots.values()],
+      };
+      preparedMail = loadPreparedSmtp({
+        message: sendOperation.smtp_message,
+        envelope: sendOperation.smtp_envelope,
+        digest: sendOperation.prepared_payload_digest,
+      });
+    }
+
+    await revalidateForwardedSnapshots(forwardedSnapshots);
+
     const smtp = await createAccountSmtpTransport(account);
-    if (smtp.error) return res.status(smtp.status).json({ error: smtp.error });
+    if (smtp.error) return res.status(smtp.status).json({
+      error: smtp.error,
+      operationKeyDisposition: 'rotate_on_payload_change',
+    });
     account = smtp.account;
     const transport = smtp.transport;
 
-    // Use a stable Message-ID so the SMTP copy and any IMAP APPEND reference the same message.
-    const domain = fromEmail.split('@')[1] || 'mailflow.local';
-    const mailOptions = {
-      messageId: `<${randomBytes(16).toString('hex')}@${domain}>`,
-      from: `${fromName} <${fromEmail}>`,
-      ...(fromReplyTo ? { replyTo: fromReplyTo } : {}),
-      to: normalizedTo.join(', '),
-      cc: normalizedCc.join(', ') || undefined,
-      bcc: normalizedBcc.join(', ') || undefined,
-      subject: normalizedSubject,
-      ...(emailPriority !== 'normal' ? { priority: emailPriority } : {}),
-      text: effectiveSignature
-        ? bodyToPlain(body, bodyIsHtml) + '\n\n-- \n' + sigToPlainText(effectiveSignature) + (quotedBody || '')
-        : bodyToPlain(body, bodyIsHtml) + (quotedBody || ''),
-    };
-
-    let inlineImageAttachments = [];
-    if (!plaintextEmail) {
-      const rawHtml = bodyToHtml(body, bodyIsHtml) +
-        (effectiveSignature
-          ? '<div style="margin-top:16px;color:#555;font-size:13px">' + effectiveSignature + '</div>'
-          : '') +
-        (quotedBodyHtml || (quotedBody ? textToHtml(quotedBody) : ''));
-      const embedded = embedInlineDataImages(rawHtml);
-      mailOptions.html = embedded.html;
-      inlineImageAttachments = embedded.attachments;
+    const started = await query(
+      `UPDATE send_operations
+          SET state = 'provider_started', provider_started_at = NOW(), updated_at = NOW()
+        WHERE user_id = $1 AND operation_key = $2 AND payload_digest = $3
+          AND state = 'ready' AND message_id = $4 AND prepared_payload_digest = $5
+        RETURNING operation_key`,
+      [
+        req.session.userId, idempotencyKey, sendPayloadDigest, messageId,
+        sendOperation.prepared_payload_digest,
+      ],
+    );
+    if (started.rowCount !== 1) {
+      return res.status(409).json({ error: 'This message is already being sent.' });
     }
-
-    if (inReplyTo) {
-      mailOptions.inReplyTo = sanitizeHeaderValue(inReplyTo);
-      // Use the full prior references chain if available; fall back to just inReplyTo.
-      mailOptions.references = sanitizeHeaderValue(references || inReplyTo);
-    }
-    const allAttachments = [
-      ...inlineImageAttachments,
-      ...(attachments?.length ? attachments.map(a => ({
-        filename: sanitizeHeaderValue(a.filename),
-        content: Buffer.from(a.content, 'base64'),
-        contentType: typeof a.contentType === 'string' ? a.contentType : 'application/octet-stream',
-      })) : []),
-      ...resolvedFwdAttachments,
-    ];
-    if (allAttachments.length) {
-      mailOptions.attachments = allAttachments;
-    }
-
-    // OAuth providers (Gmail, Microsoft) save sent mail to IMAP automatically via their
-    // servers — skip APPEND and sync after a delay.  All other accounts use direct IMAP
-    // APPEND so sent mail reliably appears regardless of what the SMTP server does.
-    const serverAutoSaves = !!account.oauth_provider;
-
-    // For servers that don't auto-save, generate the raw MIME now so we can APPEND it.
-    // Use CRLF newlines ('windows'): RFC 5322 / IMAP APPEND require CRLF. A bare-LF message is
-    // stored verbatim by strict servers (e.g. PurelyMail/Dovecot), and downstream clients then
-    // mis-parse the headers — the reporter saw Subject and the To display-name dropped (#365). This
-    // only affects non-OAuth accounts (OAuth servers auto-save and skip this path); the SMTP-
-    // delivered copy uses a separate transport that is already CRLF, so only the Sent copy was wrong.
-    let rawMessage = null;
-    if (!serverAutoSaves) {
-      const streamTransport = nodemailer.createTransport({ streamTransport: true, newline: 'windows' });
-      const streamInfo = await streamTransport.sendMail(mailOptions);
-      const chunks = [];
-      await new Promise((resolve, reject) => {
-        streamInfo.message.on('data', c => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
-        streamInfo.message.on('end', resolve);
-        streamInfo.message.on('error', reject);
-      });
-      rawMessage = Buffer.concat(chunks);
-    }
-
-    // Reserve the idempotency key atomically right before delivery so a concurrent
-    // same-key submit cannot also send (the post-send cache alone can't stop concurrent
-    // duplicates). Overwritten with the result on success; released in the catch only if
-    // delivery never happened, so a genuine retry after a pre-send failure can proceed.
-    if (idemKeyRedis) {
-      // TTL comfortably above the worst-case send (large attachment over a slow SMTP
-      // server) so the in-flight guard cannot lapse while this request is still running.
-      const reserved = await redisClient.set(idemKeyRedis, '__inflight__', { NX: true, EX: 300 }).catch(() => 'OK');
-      if (reserved === null) return res.status(409).json({ error: 'This message is already being sent.' });
-    }
-
-    await transport.sendMail(mailOptions);
-    delivered = true;
+    operationState = 'provider_started';
+    await transport.sendMail(preparedMail);
+    const applied = await query(
+      `UPDATE send_operations
+          SET state = 'provider_applied', provider_applied_at = NOW(), updated_at = NOW()
+        WHERE user_id = $1 AND operation_key = $2 AND payload_digest = $3
+          AND state = 'provider_started'
+        RETURNING operation_key`,
+      [req.session.userId, idempotencyKey, sendPayloadDigest],
+    );
+    if (applied.rowCount !== 1) throw new Error('Durable send provider receipt was not persisted');
+    operationState = 'provider_applied';
+    await revalidateForwardedSnapshots(forwardedSnapshots);
 
     // Auto-learn sent recipients so they rank above inbound-only senders in autocomplete.
     // Fire-and-forget — a DB error here must never affect the send response.
@@ -440,115 +685,52 @@ router.post('/send', async (req, res) => {
       });
     }
 
-    // Get the Sent folder path (manual mapping takes priority over special_use auto-detect,
-    // but a mapping pointing at a non-selectable folder is ignored in favour of \Sent — #386).
-    const sentFolder = await resolveSentFolder(accountId, account.folder_mappings);
-    console.log(`Post-send: ${redactEmail(account.email_address)} sentFolder=${sentFolder} autoSaves=${serverAutoSaves}`);
-
-    // sentCopySaved: null = not applicable (server auto-saves, or no Sent folder resolved);
-    // true/false = whether OUR IMAP APPEND landed the Sent copy. Surfaced to the client so
-    // it can warn when a delivered message could not be saved to Sent.
-    let sentCopySaved = null;
-    const sentMeta = sentFolder ? {
-      messageId: mailOptions.messageId,
-      subject: normalizedSubject,
-      fromName,
-      fromEmail,
-      to: mapRecipientList(normalizedTo),
-      cc: mapRecipientList(normalizedCc),
-      snippet: buildSentSnippet(body, bodyIsHtml),
-      date: new Date(),
-      // Carried so the Sent row threads into its conversation via the References chain
-      // rather than orphaning at its own Message-ID (#378).
-      inReplyTo: mailOptions.inReplyTo || null,
-      references: mailOptions.references || null,
-    } : null;
-
-    if (sentFolder) {
-      if (rawMessage) {
-        // Non-auto-saving account: APPEND the Sent copy ourselves — exactly ONCE. IMAP
-        // APPEND is NOT idempotent (unlike a \Seen flag), so we must not retry: a retry
-        // whose first attempt merely timed out (but still lands on the server) would store
-        // a SECOND copy. Bound the wait so a stalled connection can't hang the response;
-        // the abandoned append can at worst still save the single copy. On failure, warn
-        // the user and schedule a fallback sync in case the append landed late. Audit [2].
-        sentCopySaved = false;
-        try {
-          const { uid } = await Promise.race([
-            imapManager.appendToSent(account, sentFolder, rawMessage),
-            new Promise((_, rej) => setTimeout(() => rej(new Error('Sent APPEND timed out')), 20000)),
-          ]);
-          sentCopySaved = true;
-          if (uid && sentMeta) {
-            await imapManager.upsertSentMessageRecord(account, sentFolder, uid, sentMeta)
-              .catch(err => console.warn('Sent metadata upsert failed:', err.message));
-          }
-          setTimeout(() => {
-            imapManager.syncFolderOnDemand(account, sentFolder)
-              // Once the Sent copy is in the DB, notify label plugins the message synced: GTD
-              // re-runs transitions for its thread (a reply to a Todo/Someday thread means the
-              // owner acted, so that label should drop). The sent message reaches no other hook
-              // (Sent isn't INBOX, and the tick watches only the state folders), so this is the
-              // only trigger. The hook swallows per-plugin errors — the next inbound sync / tick
-              // self-heals.
-              .then(() => pluginRegistry.runHook('onSentMessage', { imapManager: imapManager.pluginFacade, account, messageId: mailOptions.messageId }))
-              .catch(e => console.error(`Post-append sync failed: ${e.message}`));
-          }, 1000);
-        } catch (appendErr) {
-          console.error(`IMAP append to Sent failed for ${redactEmail(account.email_address)}/${sentFolder}: ${appendErr.message}`);
-          // The append may still have landed (or land shortly) — pull the folder so a
-          // late-completing append self-corrects the DB rather than staying invisible.
-          setTimeout(() => {
-            imapManager.syncFolderOnDemand(account, sentFolder)
-              .catch(e => console.error(`Post-append fallback sync failed: ${e.message}`));
-          }, 8000);
-        }
-      } else {
-        // Server auto-saves via SMTP; seed metadata once the Sent copy is searchable.
-        if (sentMeta) scheduleSentMetadataUpsert(account, sentFolder, mailOptions, sentMeta);
-        // Server auto-saves via SMTP; just sync after a delay. Two attempts because the
-        // provider (e.g. Gmail) can be slow to expose the sent message; the 3s pass usually
-        // catches it, the 15s pass is the safety net. GTD transitions run after each: the 3s
-        // attempt may miss (Sent copy not yet visible → empty thread set → no-op) and the 15s
-        // attempt then catches it; if 3s already stripped, 15s is an idempotent no-op.
-        const syncAttempt = (label) => imapManager.syncFolderOnDemand(account, sentFolder)
-          .then(() => {
-            console.log(`Post-send ${label} sync done: ${redactEmail(account.email_address)}/${sentFolder}`);
-            return pluginRegistry.runHook('onSentMessage', { imapManager: imapManager.pluginFacade, account, messageId: mailOptions.messageId });
-          })
-          .catch(e => console.error(`Post-send ${label} sync failed: ${e.message}`));
-        setTimeout(() => syncAttempt('3s'), 3000);
-        setTimeout(() => syncAttempt('15s'), 15000);
-      }
-    }
-
-    const sendResult = { ok: true };
-    // Surface only the problem case so existing success handling is unchanged; the UI warns
-    // when a delivered message could not be saved to the account's Sent folder.
-    if (sentCopySaved === false) sendResult.sentCopySaved = false;
-    // Tell the client which Sent folder we actually resolved to, so its post-send "View"
-    // navigates to the real folder rather than recomputing from a possibly-stale mapping (#386).
-    if (sentFolder) sendResult.sentFolder = sentFolder;
-    // Overwrite the in-flight reservation with the final result so a retry after a lost
-    // response returns this instead of re-sending.
-    if (idemKeyRedis) redisClient.set(idemKeyRedis, JSON.stringify(sendResult), { EX: 86400 }).catch(() => {});
+    const sendResult = await completeProviderAppliedSend({
+      account, operation: sendOperation, userId: req.session.userId,
+      idempotencyKey, payloadDigest: sendPayloadDigest,
+    });
+    operationState = 'completed';
     res.json(sendResult);
   } catch (err) {
     console.error('Send failed:', err.message);
-    if (idemKeyRedis) {
-      if (delivered) {
-        // The message WAS delivered but a later step threw. Persist a DURABLE success
-        // result (not just the short-lived reservation) so a retry at ANY time returns it
-        // instead of re-running transport.sendMail — otherwise the reservation would lapse
-        // and the same key could deliver a second copy.
-        redisClient.set(idemKeyRedis, JSON.stringify({ ok: true }), { EX: 86400 }).catch(() => {});
-      } else {
-        // Delivery never happened — release so a genuine retry after a pre-send failure
-        // can proceed immediately.
-        redisClient.del(idemKeyRedis).catch(() => {});
-      }
+    if (operationState === 'provider_started') {
+      const uncertain = await query(
+        `UPDATE send_operations
+            SET state = 'uncertain', updated_at = NOW()
+          WHERE user_id = $1 AND operation_key = $2 AND payload_digest = $3
+            AND state = 'provider_started'
+          RETURNING operation_key`,
+        [req.session.userId, idempotencyKey, sendPayloadDigest],
+      ).catch(() => null);
+      if (uncertain?.rowCount === 1) operationState = 'uncertain';
     }
-    res.status(500).json({ error: sanitizeSmtpError(err) });
+    if (operationState === 'provider_applied') {
+      return res.status(503).json({
+        error: 'Message was delivered, but its Sent copy is still being recovered.',
+        code: 'SENT_MATERIALIZATION_PENDING', outcome: 'provider_applied', retryable: true,
+        operationKeyDisposition: 'retain',
+      });
+    }
+    if (err?.code === 'MESSAGE_SNAPSHOT_SUPERSEDED') {
+      const uncertainOutcome = ['provider_started', 'uncertain'].includes(operationState);
+      return res.status(409).json({
+        error: err.message, code: err.code,
+        outcome: uncertainOutcome ? operationState : 'not_sent',
+        retryable: !uncertainOutcome,
+        operationKeyDisposition: uncertainOutcome ? 'retain' : 'rotate_on_payload_change',
+      });
+    }
+    if (operationState === 'provider_started' || operationState === 'uncertain') {
+      return res.status(409).json({
+        error: 'SMTP delivery may have occurred; another delivery is blocked.',
+        code: 'SEND_OUTCOME_UNCERTAIN', outcome: operationState, retryable: false,
+        operationKeyDisposition: 'retain',
+      });
+    }
+    res.status(500).json({
+      error: sanitizeSmtpError(err),
+      operationKeyDisposition: 'rotate_on_payload_change',
+    });
   }
 });
 

--- a/backend/src/services/archiveInbox.js
+++ b/backend/src/services/archiveInbox.js
@@ -1,75 +1,444 @@
-import { query } from './db.js';
-import { resolveArchiveFolder, isAllMailFolder, adjustFolderCounts } from '../utils/mailUtils.js';
+import { resolveArchiveFolder, isAllMailFolder, adjustFolderCounts, folderCountDeltasInLockOrder } from '../utils/mailUtils.js';
+import { snapshotFromMessageRow } from './messageSnapshots.js';
 
-// Archive a single INBOX copy of a message: the one guarded per-copy archive move, shared
-// by any route that needs "move this INBOX row to the account's Archive and repoint the DB".
-// The GTD /done handler owns the surrounding orchestration (mark-read → strip labels →
-// archive, plus the partial-success response contract); this primitive owns ONLY the archive
-// move itself so that archive semantics — the guard protocol, the Gmail All-Mail branch, the
-// race-safe DB repoint, and the count adjustments — live in exactly one place.
-//
-// Contract, mirroring the move paths in mail.js and imapManager.js:
-//   • No Archive folder configured is a SOFT outcome, not a failure: returns
-//     { archived: false, noArchiveFolder: true } so the caller can leave the row alone
-//     without treating it as an error (in /done the labels are already gone, so the thread
-//     has left the rail regardless).
-//   • A concurrent /done can move + repoint this same INBOX row between the caller's load
-//     and our write. moveMessage is then a silent server-side no-op (the uid no longer lives
-//     in INBOX) and returns without throwing. Every DB write is scoped to WHERE folder =
-//     'INBOX' and its rowCount is the authority: the loser of that race applies nothing, so
-//     we skip the count adjustments and return archived:false rather than double-decrementing
-//     INBOX.
-//   • Gmail's All Mail is excluded from sync/backfill and the relocate guard, so archiving
-//     there just strips the INBOX row from our view: DELETE, not move+repoint, and no
-//     destination count (All Mail counts aren't tracked).
-//   • IMAP move / DB write failures THROW. The caller maps that to its own failure contract
-//     (in /done: HTTP 200 { archived:false, archiveFailed:true } so a mostly-successful action
-//     isn't misreported as a 500 and the id stays retryable).
-//
-// Guard protocol (ref-counted _guardMoveUid/_unguardMoveUid, byte-equivalent to the move
-// paths): the source (INBOX, uid) is guarded for the whole move so reconcileDeletes can't
-// treat the row as an orphan mid-flight; released in the finally so it is freed even when the
-// move or write throws. On a non-UIDPLUS server the new destination uid is unknown, so the DB
-// row keeps the stale source uid at the destination — guard (Archive, uid) too, and hold that
-// guard for the sync that learns the real uid only when the row was actually moved; a lost
-// race (rowCount 0) or a throw releases it immediately, since there is nothing to protect.
-export async function archiveInboxCopy(imapManager, account, inboxCopy) {
+function archiveMaterializationError(message, code = 'ARCHIVE_MATERIALIZATION_RETRY') {
+  const error = new Error(message);
+  error.code = code;
+  error.retryable = true;
+  error.uncertain = true;
+  return error;
+}
+
+function sameObservation(left, right, { includeUid = false } = {}) {
+  return Boolean(left && right) &&
+    left.folder === right.folder &&
+    String(left.uidValidity) === String(right.uidValidity) &&
+    String(left.generation) === String(right.generation) &&
+    (!includeUid || Number(left.uid) === Number(right.uid));
+}
+
+function deepMerge(destination, source) {
+  if (!destination || typeof destination !== 'object' || Array.isArray(destination)) {
+    return source;
+  }
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return source;
+  const merged = { ...destination };
+  for (const [key, value] of Object.entries(source)) {
+    merged[key] = key in merged ? deepMerge(merged[key], value) : value;
+  }
+  return merged;
+}
+
+function usefulProviderValue(value) {
+  if (value === undefined || value === null || value === '') return false;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function providerValue(source, destination, key) {
+  return destination && Object.prototype.hasOwnProperty.call(destination, key)
+    ? destination[key]
+    : source[key];
+}
+
+function sourceValue(source, destination, key) {
+  return source[key] === undefined || source[key] === null ? destination?.[key] : source[key];
+}
+
+// Message-row inventory for archive dedupe:
+// - provider/envelope fields refresh from a later live complete destination observation;
+// - body/snippet/thread caches retain source work and accept destination-only enrichment;
+// - user/local classifiers, flag conflict timestamps, unsubscribe state, spam state, and
+//   plugin annotations retain the original source row's decisions.
+// Unknown/future columns are deliberately untouched by the narrow UPDATE below, which also
+// preserves Task 5 desired-flag state when that schema lands.
+export function mergeArchiveRows(source, destination) {
+  if (!destination) return { ...source, is_deleted: false, metadata_complete: true };
+  return {
+    ...source,
+    message_id: providerValue(source, destination, 'message_id'),
+    subject: providerValue(source, destination, 'subject'),
+    from_name: providerValue(source, destination, 'from_name'),
+    from_email: providerValue(source, destination, 'from_email'),
+    to_addresses: providerValue(source, destination, 'to_addresses'),
+    cc_addresses: providerValue(source, destination, 'cc_addresses'),
+    reply_to: providerValue(source, destination, 'reply_to'),
+    in_reply_to: providerValue(source, destination, 'in_reply_to'),
+    date: providerValue(source, destination, 'date'),
+    flags: providerValue(source, destination, 'flags'),
+    has_attachments: providerValue(source, destination, 'has_attachments'),
+    thread_references: providerValue(source, destination, 'thread_references'),
+    list_unsubscribe: providerValue(source, destination, 'list_unsubscribe'),
+    list_unsubscribe_post: providerValue(source, destination, 'list_unsubscribe_post'),
+    delivery_addresses: providerValue(source, destination, 'delivery_addresses'),
+    sender_name: providerValue(source, destination, 'sender_name'),
+    sender_email: providerValue(source, destination, 'sender_email'),
+    snippet: usefulProviderValue(source.snippet) ? source.snippet : destination.snippet,
+    body_text: usefulProviderValue(source.body_text) ? source.body_text : destination.body_text,
+    body_html: usefulProviderValue(source.body_html) ? source.body_html : destination.body_html,
+    attachments: usefulProviderValue(source.attachments) ? source.attachments : destination.attachments,
+    thread_id: sourceValue(source, destination, 'thread_id'),
+    is_bulk: sourceValue(source, destination, 'is_bulk'),
+    category: sourceValue(source, destination, 'category'),
+    spam_score_sa: sourceValue(source, destination, 'spam_score_sa'),
+    spam_score_ml: sourceValue(source, destination, 'spam_score_ml'),
+    spam_verdict: sourceValue(source, destination, 'spam_verdict'),
+    spam_analyzed_at: sourceValue(source, destination, 'spam_analyzed_at'),
+    spam_details: deepMerge(destination.spam_details || {}, source.spam_details || {}),
+    spam_user_override: sourceValue(source, destination, 'spam_user_override'),
+    unsubscribed_at: sourceValue(source, destination, 'unsubscribed_at'),
+    plugin_annotations: deepMerge(
+      destination.plugin_annotations || {}, source.plugin_annotations || {},
+    ),
+    snippet_attempted_at: sourceValue(source, destination, 'snippet_attempted_at'),
+    is_read: source.is_read,
+    is_starred: source.is_starred,
+    read_changed_at: source.read_changed_at,
+    star_changed_at: source.star_changed_at,
+    is_deleted: false,
+    metadata_complete: true,
+  };
+}
+
+const ARCHIVE_UPDATE_COLUMNS = [
+  'message_id', 'subject', 'from_name', 'from_email', 'to_addresses', 'cc_addresses',
+  'reply_to', 'in_reply_to', 'date', 'snippet', 'body_text', 'body_html',
+  'has_attachments', 'attachments', 'flags', 'thread_references', 'thread_id', 'is_bulk',
+  'read_changed_at', 'star_changed_at', 'spam_score_sa', 'spam_score_ml', 'spam_verdict',
+  'spam_analyzed_at', 'spam_details', 'spam_user_override', 'category', 'list_unsubscribe',
+  'list_unsubscribe_post', 'unsubscribed_at', 'delivery_addresses', 'plugin_annotations',
+  'snippet_attempted_at', 'sender_name', 'sender_email', 'is_read', 'is_starred',
+];
+
+function counted(row) {
+  return Boolean(row && row.is_deleted === false && row.metadata_complete === true);
+}
+
+function unread(row) {
+  return counted(row) && row.is_read === false ? 1 : 0;
+}
+
+function assertExactFolderObservations(rows, receipt) {
+  const byPath = new Map(rows.map(row => [row.path, row]));
+  for (const token of [receipt.sourceToken, receipt.destinationToken]) {
+    const row = byPath.get(token.folder);
+    if (!row || row.is_present !== true || row.uid_validity == null ||
+        String(row.uid_validity) !== String(token.uidValidity) ||
+        String(row.observation_generation) !== String(token.generation)) {
+      throw archiveMaterializationError(
+        `Folder observation changed before archive materialization for ${token.folder}`,
+        'FOLDER_OBSERVATION_SUPERSEDED',
+      );
+    }
+  }
+}
+
+function exactLiveWinner(row, { accountId, sourceSnapshot, receipt }) {
+  return Boolean(row && row.id === sourceSnapshot.id && row.account_id === accountId &&
+    row.folder === receipt.folder && Number(row.uid) === Number(receipt.uid) && counted(row));
+}
+
+function assertAllMailProviderReceipt(providerResource, receipt) {
+  const selectedFolder = providerResource?.client?.mailbox?.path || providerResource?.folder;
+  const selectedUidValidity = providerResource?.client?.mailbox?.uidValidity ??
+    providerResource?.uidValidities?.get?.(receipt.folder);
+  if (!providerResource?.client || selectedFolder !== receipt.folder ||
+      selectedUidValidity == null ||
+      String(selectedUidValidity) !== String(receipt.destinationToken.uidValidity)) {
+    throw archiveMaterializationError(
+      'All Mail desired flags require the exact destination provider epoch',
+      'FOLDER_OBSERVATION_SUPERSEDED',
+    );
+  }
+}
+
+async function applyAllMailDesiredFlags(tx, providerResource, source, receipt) {
+  const pending = await tx.query(
+    `SELECT flag, desired_value, revision, folder, uid, uid_validity, folder_generation
+       FROM message_flag_deliveries
+      WHERE message_id = $1 AND account_id = $2
+        AND state IN ('pending', 'delivering', 'uncertain')
+      ORDER BY flag
+      FOR UPDATE`,
+    [source.id, source.account_id],
+  );
+  if (!(pending.rows || []).length) return;
+  assertAllMailProviderReceipt(providerResource, receipt);
+  for (const delivery of pending.rows || []) {
+    const revisionColumn = delivery.flag === 'read' ? 'read_revision' :
+      delivery.flag === 'star' ? 'star_revision' : null;
+    const observation = delivery.folder === receipt.sourceToken.folder
+      ? receipt.sourceToken
+      : delivery.folder === receipt.destinationToken.folder
+        ? { ...receipt.destinationToken, uid: receipt.uid }
+        : null;
+    if (!revisionColumn || Number(source[revisionColumn]) !== Number(delivery.revision) ||
+        !observation || Number(delivery.uid) !== Number(source.uid) ||
+        String(delivery.uid_validity) !== String(observation.uidValidity) ||
+        String(delivery.folder_generation) !== String(observation.generation)) {
+      throw archiveMaterializationError(
+        'An accepted desired flag was superseded before All Mail completion',
+        'DESIRED_FLAG_SUPERSEDED',
+      );
+    }
+    const imapFlag = delivery.flag === 'read' ? '\\Seen' : '\\Flagged';
+    const result = delivery.desired_value
+      ? await providerResource.client.messageFlagsAdd(String(receipt.uid), [imapFlag], { uid: true })
+      : await providerResource.client.messageFlagsRemove(String(receipt.uid), [imapFlag], { uid: true });
+    if (result === false) {
+      throw archiveMaterializationError(
+        `Provider did not confirm ${delivery.flag} on the All Mail receipt`,
+        'DESIRED_FLAG_PROVIDER_UNCONFIRMED',
+      );
+    }
+  }
+}
+
+export async function materializeArchiveReceipt(tx, {
+  accountId, sourceSnapshot, destinationFolder, receipt, operation, allMail = false,
+  providerResource = null,
+}) {
+  const valid = operation?.kind === 'move' && operation.accountId === accountId &&
+    sourceSnapshot?.account_id === accountId &&
+    typeof receipt?.marker === 'string' && receipt.marker.length > 0 &&
+    operation.marker === receipt.marker && receipt.folder === destinationFolder &&
+    Number.isSafeInteger(Number(receipt?.uid)) && Number(receipt.uid) > 0 &&
+    sameObservation(operation.source, receipt?.sourceToken, { includeUid: true }) &&
+    sameObservation(operation.destination, receipt?.destinationToken) &&
+    receipt.sourceToken.folder === sourceSnapshot?.folder &&
+    Number(receipt.sourceToken.uid) === Number(sourceSnapshot?.uid) &&
+    String(receipt.sourceToken.uidValidity) === String(sourceSnapshot?.folder_uid_validity) &&
+    receipt.destinationToken.folder === destinationFolder &&
+    String(receipt.destinationToken.uidValidity) === String(receipt.uidValidity);
+  if (!valid) {
+    throw archiveMaterializationError(
+      'Provider receipt does not identify the exact archive operation',
+      'PROVIDER_RECEIPT_IDENTITY_MISMATCH',
+    );
+  }
+
+  const paths = [...new Set([receipt.sourceToken.folder, destinationFolder])].sort();
+  const folderLock = await tx.query(
+    `SELECT path, uid_validity, observation_generation, is_present
+       FROM folders
+      WHERE account_id = $1 AND path = ANY($2::text[])
+      ORDER BY path
+      FOR UPDATE`,
+    [accountId, paths],
+  );
+  assertExactFolderObservations(folderLock.rows || [], receipt);
+
+  const locked = await tx.query(
+    `SELECT m.*
+       FROM messages m
+      WHERE m.account_id = $1
+        AND (m.id = $2 OR (m.folder = $3 AND m.uid = $4))
+      ORDER BY m.id
+      FOR UPDATE`,
+    [accountId, sourceSnapshot.id, destinationFolder, Number(receipt.uid)],
+  );
+  const source = (locked.rows || []).find(row => row.id === sourceSnapshot.id);
+  const occupant = (locked.rows || []).find(row => (
+    row.id !== sourceSnapshot.id && row.folder === destinationFolder &&
+    Number(row.uid) === Number(receipt.uid)
+  ));
+
+  const sourceAtDestination = exactLiveWinner(source, { accountId, sourceSnapshot, receipt });
+  if (!sourceAtDestination && (
+    !source || source.account_id !== accountId || source.folder !== receipt.sourceToken.folder ||
+      Number(source.uid) !== Number(receipt.sourceToken.uid) || !counted(source)
+  )) {
+    throw archiveMaterializationError(
+      'The exact archive source row was superseded', 'ARCHIVE_SOURCE_SUPERSEDED',
+    );
+  }
+
+  const options = { strict: true, query: tx.query.bind(tx) };
+  if (allMail) {
+    await applyAllMailDesiredFlags(tx, providerResource, source, receipt);
+    const removed = await tx.query(
+      `DELETE FROM messages
+        WHERE id = $1 AND account_id = $2 AND folder = $3 AND uid = $4
+        RETURNING id, account_id, folder, uid, is_read, is_deleted, metadata_complete`,
+      [source.id, accountId, source.folder, source.uid],
+    );
+    if (removed.rowCount !== 1) {
+      throw archiveMaterializationError(
+        'The exact All Mail archive source row was superseded', 'ARCHIVE_SOURCE_SUPERSEDED',
+      );
+    }
+    const deleted = removed.rows[0];
+    if (counted(deleted)) {
+      await adjustFolderCounts(
+        accountId, source.folder, -1, unread(deleted) ? -1 : 0, options,
+      );
+    }
+    return { archived: true, sourceId: source.id, concurrentWinner: false };
+  }
+  if (sourceAtDestination) {
+    return { archived: true, sourceId: sourceSnapshot.id, concurrentWinner: true };
+  }
+
+  const liveOccupant = counted(occupant) ? occupant : null;
+  let removedOccupant = null;
+  if (occupant) {
+    const removed = await tx.query(
+      `DELETE FROM messages
+        WHERE id = $1 AND account_id = $2 AND folder = $3 AND uid = $4
+        RETURNING id, account_id, folder, uid, is_read, is_deleted, metadata_complete`,
+      [occupant.id, accountId, destinationFolder, Number(receipt.uid)],
+    );
+    if (removed.rowCount !== 1) {
+      throw archiveMaterializationError(
+        'The exact archive destination occupant was superseded',
+        'ARCHIVE_DESTINATION_SUPERSEDED',
+      );
+    }
+    removedOccupant = removed.rows[0];
+  }
+
+  const merged = mergeArchiveRows(source, liveOccupant);
+  const values = ARCHIVE_UPDATE_COLUMNS.map(column => merged[column]);
+  const assignments = ARCHIVE_UPDATE_COLUMNS.map((column, index) => `${column} = $${index + 1}`);
+  const identityStart = values.length + 1;
+  const moved = await tx.query(
+    `UPDATE messages
+        SET ${assignments.join(', ')}, folder = $${identityStart}, uid = $${identityStart + 1},
+            is_deleted = false, metadata_complete = true, synced_at = NOW()
+      WHERE id = $${identityStart + 2} AND account_id = $${identityStart + 3}
+        AND folder = $${identityStart + 4} AND uid = $${identityStart + 5}
+      RETURNING id, account_id, folder, uid, is_read, is_deleted, metadata_complete`,
+    [
+      ...values, destinationFolder, Number(receipt.uid), source.id, accountId,
+      receipt.sourceToken.folder, Number(receipt.sourceToken.uid),
+    ],
+  );
+  if (moved.rowCount !== 1) {
+    const winner = await tx.query(
+      `SELECT id, account_id, folder, uid, is_read, is_deleted, metadata_complete
+         FROM messages
+        WHERE id = $1 AND account_id = $2 AND folder = $3 AND uid = $4
+        FOR UPDATE`,
+      [sourceSnapshot.id, accountId, destinationFolder, Number(receipt.uid)],
+    );
+    if (exactLiveWinner(winner.rows?.[0], { accountId, sourceSnapshot, receipt })) {
+      return { archived: true, sourceId: sourceSnapshot.id, concurrentWinner: true };
+    }
+    throw archiveMaterializationError(
+      'The exact archive source row was superseded during materialization',
+      'ARCHIVE_SOURCE_SUPERSEDED',
+    );
+  }
+
+  const post = moved.rows[0];
+  if (!exactLiveWinner(post, { accountId, sourceSnapshot, receipt })) {
+    throw archiveMaterializationError(
+      'Archive materialization did not return the exact live source row',
+      'ARCHIVE_MATERIALIZATION_INVALID',
+    );
+  }
+  // A desired flag accepted after provider MOVE but before local completion still belongs
+  // to this stable row id. Move its durable delivery coordinates atomically with the row so
+  // reconciliation cannot strand it against the now-absent source UID.
+  await tx.query(
+    `UPDATE message_flag_deliveries
+        SET folder = $3, uid = $4, uid_validity = $5, folder_generation = $6,
+            updated_at = NOW()
+      WHERE message_id = $1 AND account_id = $2
+        AND folder = $7 AND uid = $8
+        AND uid_validity = $9 AND folder_generation = $10`,
+    [
+      source.id, accountId, destinationFolder, Number(receipt.uid),
+      String(receipt.destinationToken.uidValidity),
+      String(receipt.destinationToken.generation),
+      receipt.sourceToken.folder, Number(receipt.sourceToken.uid),
+      String(receipt.sourceToken.uidValidity), String(receipt.sourceToken.generation),
+    ],
+  );
+  const deltas = folderCountDeltasInLockOrder([
+    { path: source.folder, totalDelta: counted(source) ? -1 : 0, unreadDelta: -unread(source) },
+    {
+      path: destinationFolder,
+      totalDelta: (counted(post) ? 1 : 0) - (counted(removedOccupant) ? 1 : 0),
+      unreadDelta: unread(post) - unread(removedOccupant),
+    },
+  ]);
+  for (const delta of deltas) {
+    await adjustFolderCounts(
+      accountId, delta.path, delta.totalDelta, delta.unreadDelta, options,
+    );
+  }
+  return { archived: true, sourceId: source.id, concurrentWinner: false };
+}
+
+// Archive one exact INBOX row. The provider executor owns command/recovery serialization and
+// invokes `materialize` inside the same fenced transaction as its checked `completed` update.
+// Missing archive configuration remains a soft outcome. Every provider, receipt, folder,
+// source, destination, dedupe, count, or completion uncertainty throws and stays retryable.
+// Gmail All Mail keeps no local destination row, so its completion deletes only the exact
+// source row. The source guard prevents delete reconciliation from racing the provider phase.
+export async function archiveInboxCopy(imapManager, account, inboxCopy, frozen = null) {
   const accountId = account.id;
-  const archiveFolder = await resolveArchiveFolder(accountId, account.folder_mappings);
-  if (!archiveFolder) return { archived: false, noArchiveFolder: true };
+  const archiveFolder = frozen && Object.prototype.hasOwnProperty.call(frozen, 'archiveFolder')
+    ? frozen.archiveFolder
+    : await resolveArchiveFolder(accountId, account.folder_mappings);
+  if (!archiveFolder) return { archived: false, alreadyGone: false, noArchiveFolder: true };
+  if (!inboxCopy?.id || inboxCopy.account_id !== accountId || inboxCopy.folder !== 'INBOX' ||
+      !Number.isSafeInteger(Number(inboxCopy.uid)) || Number(inboxCopy.uid) <= 0 ||
+      inboxCopy.folder_uid_validity == null || inboxCopy.folder_observation_generation == null ||
+      (frozen?.archiveObservation && inboxCopy.folder_topology_identity == null)) {
+    throw archiveMaterializationError(
+      'Archive requires an exact persisted INBOX source observation',
+      'ARCHIVE_SOURCE_OBSERVATION_REQUIRED',
+    );
+  }
 
-  const allMail = await isAllMailFolder(accountId, archiveFolder);
+  const allMail = frozen && typeof frozen.archiveAllMail === 'boolean'
+    ? frozen.archiveAllMail
+    : await isAllMailFolder(accountId, archiveFolder);
   imapManager._guardMoveUid(accountId, 'INBOX', inboxCopy.uid);
-  let destGuardHeld = false;
   try {
-    const newUid = await imapManager.moveMessage(account, inboxCopy.uid, 'INBOX', archiveFolder);
-    let applied;
+    const materialize = (providerReceipt, operation, tx, providerResource) => materializeArchiveReceipt(tx, {
+      accountId,
+      sourceSnapshot: inboxCopy,
+      destinationFolder: archiveFolder,
+      receipt: providerReceipt,
+      operation,
+      allMail,
+      providerResource,
+    });
+    const moveOptions = {
+      operationKey: `archive:${inboxCopy.id}`,
+      expectedUidValidity: inboxCopy.folder_uid_validity,
+      snapshot: snapshotFromMessageRow(inboxCopy),
+      materialize,
+      ...(frozen?.archiveObservation ? { operationTokens: [{
+        folder: inboxCopy.folder,
+        uidValidity: String(inboxCopy.folder_uid_validity),
+        generation: String(inboxCopy.folder_observation_generation),
+        topologyIdentity: String(inboxCopy.folder_topology_identity),
+        isPresent: true,
+      }, frozen.archiveObservation] } : {}),
+    };
     if (allMail) {
-      const del = await query("DELETE FROM messages WHERE id = $1 AND folder = 'INBOX'", [inboxCopy.id]);
-      applied = del.rowCount > 0;
-    } else if (newUid != null) {
-      const upd = await query("UPDATE messages SET folder = $1, uid = $2 WHERE id = $3 AND folder = 'INBOX'", [archiveFolder, newUid, inboxCopy.id]);
-      applied = upd.rowCount > 0;
+      await imapManager.moveMessage(
+        account,
+        inboxCopy.uid,
+        'INBOX',
+        archiveFolder,
+        { ...moveOptions, returnReceipt: true },
+      );
     } else {
-      imapManager._guardMoveUid(accountId, archiveFolder, inboxCopy.uid);
-      destGuardHeld = true;
-      const upd = await query("UPDATE messages SET folder = $1 WHERE id = $2 AND folder = 'INBOX'", [archiveFolder, inboxCopy.id]);
-      applied = upd.rowCount > 0;
-      // Hold the destination guard for the sync that learns the real uid only when we
-      // actually moved the row; a lost race releases it immediately (nothing to protect).
-      if (applied) setTimeout(() => imapManager._unguardMoveUid(accountId, archiveFolder, inboxCopy.uid), 10_000);
-      else imapManager._unguardMoveUid(accountId, archiveFolder, inboxCopy.uid);
-      destGuardHeld = false;
+      await imapManager.moveMessageWithReceipt(
+        account,
+        inboxCopy.uid,
+        'INBOX',
+        archiveFolder,
+        moveOptions,
+      );
     }
-    if (applied) {
-      // Counts: the caller has already marked the thread read, so both sides move zero unread.
-      adjustFolderCounts(accountId, 'INBOX', -1, 0);
-      if (!allMail) adjustFolderCounts(accountId, archiveFolder, 1, 0);
-    }
-    return { archived: applied, noArchiveFolder: false };
+    return { archived: true, alreadyGone: false, noArchiveFolder: false };
   } finally {
     imapManager._unguardMoveUid(accountId, 'INBOX', inboxCopy.uid);
-    // Release the destination guard when its DB write throws before normal handoff.
-    if (destGuardHeld) imapManager._unguardMoveUid(accountId, archiveFolder, inboxCopy.uid);
   }
 }

--- a/backend/src/services/archiveInbox.test.js
+++ b/backend/src/services/archiveInbox.test.js
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => {
+  const query = vi.fn();
+  const lockQuery = vi.fn();
+  return {
+    query,
+    lockQuery,
+    withTransaction: vi.fn(callback => callback({
+      query: (sql, params) => /SELECT path, uid_validity, observation_generation/.test(sql)
+        ? lockQuery(sql, params)
+        : query(sql, params),
+    })),
+  };
+});
+vi.mock('../utils/mailUtils.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  resolveArchiveFolder: vi.fn(),
+  isAllMailFolder: vi.fn(),
+  adjustFolderCounts: vi.fn(),
+}));
+
+import { query, lockQuery, withTransaction } from './db.js';
+import { resolveArchiveFolder, isAllMailFolder, adjustFolderCounts } from '../utils/mailUtils.js';
+import { archiveInboxCopy } from './archiveInbox.js';
+
+const account = { id: 'acct-1', folder_mappings: {} };
+const row = {
+  id: 'row-1', account_id: 'acct-1', uid: 7, folder: 'INBOX',
+  message_id: '<m@x>', folder_uid_validity: 123,
+  folder_observation_generation: 4, read_revision: 2, star_revision: 3,
+  folder_topology_identity: 'inbox-incarnation',
+};
+
+function manager() {
+  const moveMessage = vi.fn();
+  return {
+    moveMessage,
+    moveMessageWithReceipt: vi.fn(async (...args) => {
+      const moved = await moveMessage(...args);
+      if (moved && typeof moved === 'object') return moved;
+      return {
+        folder: args[3], uid: moved, uidValidity: '456',
+        sourceToken: { folder: 'INBOX', uid: 7, uidValidity: '123', generation: '4' },
+        destinationToken: { folder: args[3], uidValidity: '456', generation: '8' },
+      };
+    }),
+    findUidByRecoveryKeyword: vi.fn(),
+    clearMoveRecoveryKeyword: vi.fn(),
+    _guardMoveUid: vi.fn(),
+    _unguardMoveUid: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  query.mockReset();
+  lockQuery.mockReset().mockResolvedValue({ rows: [
+    { path: 'Archive', uid_validity: 456, observation_generation: 8 },
+    { path: 'INBOX', uid_validity: 123, observation_generation: 4 },
+  ] });
+  withTransaction.mockReset();
+  withTransaction.mockImplementation(callback => callback({
+    query: (sql, params) => /SELECT path, uid_validity, observation_generation/.test(sql)
+      ? lockQuery(sql, params)
+      : query(sql, params),
+  }));
+  resolveArchiveFolder.mockReset().mockResolvedValue('Archive');
+  isAllMailFolder.mockReset().mockResolvedValue(false);
+  adjustFolderCounts.mockReset();
+});
+
+describe('archiveInboxCopy race outcomes', () => {
+  it('reports missing archive configuration as a skipped target', async () => {
+    resolveArchiveFolder.mockResolvedValueOnce(null);
+    await expect(archiveInboxCopy(manager(), account, row)).resolves.toEqual({
+      archived: false,
+      alreadyGone: false,
+      noArchiveFolder: true,
+    });
+  });
+
+  it('fails before provider work when the source snapshot has no exact UIDVALIDITY', async () => {
+    const imap = manager();
+    const epochless = { ...row };
+    delete epochless.folder_uid_validity;
+
+    await expect(archiveInboxCopy(imap, account, epochless)).rejects.toMatchObject({
+      code: 'ARCHIVE_SOURCE_OBSERVATION_REQUIRED', retryable: true, uncertain: true,
+    });
+    expect(imap.moveMessage).not.toHaveBeenCalled();
+    expect(imap.moveMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  it('fails before provider work when the source snapshot has no folder generation', async () => {
+    const imap = manager();
+    const generationless = { ...row };
+    delete generationless.folder_observation_generation;
+
+    await expect(archiveInboxCopy(imap, account, generationless)).rejects.toMatchObject({
+      code: 'ARCHIVE_SOURCE_OBSERVATION_REQUIRED', retryable: true, uncertain: true,
+    });
+    expect(imap.moveMessage).not.toHaveBeenCalled();
+    expect(imap.moveMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  it('never turns provider uncertainty into success from DB source disappearance', async () => {
+    const imap = manager();
+    const providerError = new Error('messageMove returned false');
+    imap.moveMessage.mockRejectedValueOnce(providerError);
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(archiveInboxCopy(imap, account, row)).rejects.toBe(providerError);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('never suppresses a snapshot epoch change as concurrent completion', async () => {
+    const imap = manager();
+    const err = Object.assign(new Error('Snapshot UIDVALIDITY changed'), {
+      code: 'SNAPSHOT_UIDVALIDITY_CHANGED',
+    });
+    imap.moveMessage.mockRejectedValueOnce(err);
+    query.mockResolvedValue({ rows: [] });
+
+    await expect(archiveInboxCopy(imap, account, row)).rejects.toBe(err);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('does not accept an IMAP failure when the same row id remains in INBOX under a healed UID', async () => {
+    const imap = manager();
+    imap.moveMessage.mockRejectedValueOnce(new Error('no matching uid 7'));
+    query.mockImplementation(async (sql) => ({
+      rows: sql.includes('uid = $3') ? [] : [{ id: 'row-1' }],
+    }));
+
+    await expect(archiveInboxCopy(imap, account, row)).rejects.toThrow('no matching uid 7');
+  });
+
+  it('keeps a real IMAP failure visible while the exact snapshot row remains in INBOX', async () => {
+    const imap = manager();
+    imap.moveMessage.mockRejectedValueOnce(new Error('provider down'));
+    query.mockResolvedValue({ rows: [{ id: 'row-1' }] });
+    await expect(archiveInboxCopy(imap, account, row)).rejects.toThrow('provider down');
+  });
+
+  it('does not poll DB disappearance to promote an uncertain provider move', async () => {
+    const imap = manager();
+    const providerError = new Error('messageMove returned false');
+    imap.moveMessage.mockRejectedValueOnce(providerError);
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'row-1' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(archiveInboxCopy(imap, account, row)).rejects.toBe(providerError);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('uses the durable operation receipt when Message-ID is absent', async () => {
+    const imap = manager();
+    const headerless = { ...row, message_id: null };
+    imap.moveMessage.mockResolvedValueOnce(77);
+    query.mockResolvedValueOnce({ rowCount: 1 });
+
+    await expect(archiveInboxCopy(imap, account, headerless)).resolves.toEqual({
+      archived: true,
+      alreadyGone: false,
+      noArchiveFolder: false,
+    });
+
+    expect(imap.moveMessageWithReceipt).toHaveBeenCalledWith(
+      account, 7, 'INBOX', 'Archive', {
+        expectedUidValidity: 123, operationKey: 'archive:row-1',
+        snapshot: {
+          id: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+          uidValidity: '123', folderGeneration: '4', readRevision: 2, starRevision: 3,
+        },
+        materialize: expect.any(Function),
+      },
+    );
+    expect(imap.findUidByRecoveryKeyword).not.toHaveBeenCalled();
+    expect(imap.clearMoveRecoveryKeyword).not.toHaveBeenCalled();
+  });
+
+  it('carries frozen folder incarnation identities into GTD archive recovery tokens', async () => {
+    const imap = manager();
+    imap.moveMessage.mockResolvedValueOnce(77);
+
+    await archiveInboxCopy(imap, account, row, {
+      archiveFolder: 'Archive', archiveAllMail: false,
+      archiveObservation: {
+        folder: 'Archive', uidValidity: '456', generation: '8',
+        topologyIdentity: 'archive-incarnation', isPresent: true,
+      },
+    });
+
+    expect(imap.moveMessageWithReceipt).toHaveBeenCalledWith(
+      account, 7, 'INBOX', 'Archive', expect.objectContaining({
+        operationTokens: [
+          {
+            folder: 'INBOX', uidValidity: '123', generation: '4',
+            topologyIdentity: 'inbox-incarnation', isPresent: true,
+          },
+          {
+            folder: 'Archive', uidValidity: '456', generation: '8',
+            topologyIdentity: 'archive-incarnation', isPresent: true,
+          },
+        ],
+      }),
+    );
+  });
+
+  it('does not require a recovery keyword for a headerless Gmail All Mail archive', async () => {
+    const imap = manager();
+    const headerless = { ...row, message_id: null };
+    isAllMailFolder.mockResolvedValueOnce(true);
+    imap.moveMessage.mockResolvedValueOnce({
+      uid: 91,
+      sourceToken: { folder: 'INBOX', uid: 7, uidValidity: '123', generation: '4' },
+    });
+    query.mockResolvedValueOnce({ rowCount: 1 });
+
+    await expect(archiveInboxCopy(imap, account, headerless)).resolves.toMatchObject({ archived: true });
+
+    expect(imap.moveMessage).toHaveBeenCalledWith(
+      account, 7, 'INBOX', 'Archive', {
+        expectedUidValidity: 123, operationKey: 'archive:row-1', returnReceipt: true,
+        snapshot: {
+          id: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+          uidValidity: '123', folderGeneration: '4', readRevision: 2, starRevision: 3,
+        },
+        materialize: expect.any(Function),
+      }
+    );
+    expect(imap.findUidByRecoveryKeyword).not.toHaveBeenCalled();
+    expect(imap.clearMoveRecoveryKeyword).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/archiveMaterialization.test.js
+++ b/backend/src/services/archiveMaterialization.test.js
@@ -1,0 +1,581 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../utils/mailUtils.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  adjustFolderCounts: vi.fn(),
+}));
+
+import { adjustFolderCounts } from '../utils/mailUtils.js';
+import { materializeArchiveReceipt, mergeArchiveRows } from './archiveInbox.js';
+
+const sourceToken = {
+  folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4',
+};
+const destinationToken = {
+  folder: 'Archive', uidValidity: '202', generation: '8',
+};
+const receipt = {
+  folder: 'Archive', uid: 88, uidValidity: '202', marker: '$MailFlowOp-test',
+  sourceToken, destinationToken,
+};
+const operation = {
+  id: 'operation-1', kind: 'move', accountId: 'acct-1', marker: '$MailFlowOp-test',
+  source: sourceToken, destination: destinationToken,
+};
+const snapshot = {
+  id: '00000000-0000-4000-8000-000000000001', account_id: 'acct-1',
+  folder: 'INBOX', uid: 7, folder_uid_validity: 101,
+};
+
+const sourceRow = {
+  ...snapshot,
+  read_revision: 3,
+  star_revision: 5,
+  is_deleted: false,
+  metadata_complete: true,
+  is_read: false,
+  is_starred: true,
+  read_changed_at: new Date('2026-08-25T00:00:00Z'),
+  star_changed_at: new Date('2026-08-25T00:01:00Z'),
+  category: 'primary',
+  spam_score_sa: 1,
+  spam_score_ml: 2,
+  spam_verdict: 'ham',
+  spam_analyzed_at: new Date('2026-08-25T00:02:00Z'),
+  spam_details: { sourceOnly: true, conflict: 'source' },
+  spam_user_override: 'ham',
+  unsubscribed_at: new Date('2026-08-25T00:03:00Z'),
+  plugin_annotations: {
+    gtd: { gist: 'source gist', sourceOnly: true },
+    sourcePlugin: { kept: true },
+  },
+  snippet: 'source snippet',
+  snippet_attempted_at: new Date('2026-08-25T00:04:00Z'),
+  body_text: 'source body',
+  body_html: null,
+  attachments: [],
+  message_id: '<source@example.test>',
+  subject: 'source subject',
+  from_name: 'Source Name',
+  from_email: 'source@example.test',
+  to_addresses: [],
+  cc_addresses: [],
+  reply_to: [],
+  in_reply_to: null,
+  thread_references: null,
+  thread_id: 'source-thread',
+  date: new Date('2026-08-24T00:00:00Z'),
+  has_attachments: false,
+  flags: ['\\Flagged'],
+  is_bulk: false,
+  list_unsubscribe: null,
+  list_unsubscribe_post: null,
+  delivery_addresses: null,
+  sender_name: null,
+  sender_email: null,
+};
+
+const liveOccupant = {
+  ...sourceRow,
+  id: '00000000-0000-4000-8000-000000000002',
+  folder: 'Archive',
+  uid: 88,
+  is_read: true,
+  is_starred: false,
+  category: 'promotion',
+  spam_score_sa: 9,
+  spam_details: { destinationOnly: true, conflict: 'destination' },
+  spam_user_override: 'spam',
+  unsubscribed_at: new Date('2026-08-26T00:00:00Z'),
+  plugin_annotations: {
+    gtd: { gist: 'destination gist', destinationOnly: true },
+    destinationPlugin: { kept: true },
+  },
+  snippet: 'destination snippet',
+  body_text: null,
+  body_html: '<p>destination body</p>',
+  attachments: [{ filename: 'receipt.pdf' }],
+  message_id: '<destination@example.test>',
+  subject: 'destination subject',
+  from_name: 'Destination Name',
+  from_email: 'destination@example.test',
+  to_addresses: [{ address: 'to@example.test' }],
+  cc_addresses: [{ address: 'cc@example.test' }],
+  reply_to: [{ address: 'reply@example.test' }],
+  in_reply_to: '<parent@example.test>',
+  thread_references: '<root@example.test>',
+  thread_id: 'destination-thread',
+  date: new Date('2026-08-26T00:00:00Z'),
+  has_attachments: true,
+  flags: ['\\Seen', '$MailFlowOp-test'],
+  is_bulk: true,
+  list_unsubscribe: '<https://example.test/unsubscribe>',
+  list_unsubscribe_post: 'List-Unsubscribe=One-Click',
+  delivery_addresses: ['alias@example.test'],
+  sender_name: 'Submitting Service',
+  sender_email: 'submitter@example.test',
+};
+
+const folderRows = [
+  { path: 'Archive', uid_validity: 202, observation_generation: 8, is_present: true },
+  { path: 'INBOX', uid_validity: 101, observation_generation: 4, is_present: true },
+];
+
+function transaction({
+  source = sourceRow,
+  occupant = null,
+  folders = folderRows,
+  updateRow = null,
+  updateRowCount = 1,
+  concurrentWinner = null,
+  deliveries = [],
+  failOn = null,
+} = {}) {
+  const query = vi.fn(async (sql, params) => {
+    if (/SELECT path, uid_validity, observation_generation, is_present/.test(sql)) {
+      if (failOn === 'folders') throw new Error('folder lock failed');
+      return { rows: folders };
+    }
+    if (/SELECT m\.\*/.test(sql)) {
+      return { rows: [source, occupant].filter(Boolean) };
+    }
+    if (/FROM message_flag_deliveries/.test(sql)) return { rows: deliveries };
+    if (/DELETE FROM messages/.test(sql)) {
+      if (failOn === 'delete') throw new Error('duplicate delete failed');
+      const deleted = params?.[0] === source?.id ? source : occupant;
+      return { rowCount: deleted ? 1 : 0, rows: deleted ? [deleted] : [] };
+    }
+    if (/UPDATE messages/.test(sql)) {
+      if (failOn === 'update') throw new Error('source update failed');
+      const row = updateRow || { ...source, folder: 'Archive', uid: 88 };
+      return { rowCount: updateRowCount, rows: updateRowCount ? [row] : [] };
+    }
+    if (/UPDATE message_flag_deliveries/.test(sql)) return { rowCount: 1, rows: [] };
+    if (/SELECT id, account_id, folder, uid/.test(sql)) {
+      return { rows: concurrentWinner ? [concurrentWinner] : [] };
+    }
+    throw new Error(`Unexpected SQL: ${sql}`);
+  });
+  return { query };
+}
+
+function materialize(tx, overrides = {}) {
+  return materializeArchiveReceipt(tx, {
+    accountId: 'acct-1', sourceSnapshot: snapshot, destinationFolder: 'Archive',
+    receipt, operation, allMail: false, ...overrides,
+  });
+}
+
+describe('archive receipt validation', () => {
+  beforeEach(() => adjustFolderCounts.mockReset());
+
+  it('rejects a receipt for a different exact source before querying', async () => {
+    const tx = { query: vi.fn() };
+
+    await expect(materializeArchiveReceipt(tx, {
+      accountId: 'acct-1', sourceSnapshot: snapshot, destinationFolder: 'Archive',
+      receipt: { ...receipt, sourceToken: { ...sourceToken, uid: 8 } }, operation,
+    })).rejects.toMatchObject({
+      code: 'PROVIDER_RECEIPT_IDENTITY_MISMATCH', retryable: true, uncertain: true,
+    });
+
+    expect(tx.query).not.toHaveBeenCalled();
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['operation kind', { operation: { ...operation, kind: 'copy' } }],
+    ['operation account', { operation: { ...operation, accountId: 'acct-2' } }],
+    ['operation marker', { operation: { ...operation, marker: '$other' } }],
+    ['missing persisted marker', {
+      operation: { ...operation, marker: undefined }, receipt: { ...receipt, marker: undefined },
+    }],
+    ['source snapshot account', {
+      sourceSnapshot: { ...snapshot, account_id: 'acct-2' },
+    }],
+    ['destination UIDVALIDITY', { receipt: { ...receipt, uidValidity: '999' } }],
+    ['destination generation', {
+      receipt: { ...receipt, destinationToken: { ...destinationToken, generation: '9' } },
+    }],
+  ])('rejects a mismatched %s before locking rows', async (_label, overrides) => {
+    const tx = transaction();
+    await expect(materialize(tx, overrides)).rejects.toMatchObject({
+      code: 'PROVIDER_RECEIPT_IDENTITY_MISMATCH', retryable: true, uncertain: true,
+    });
+    expect(tx.query).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing source folder', folderRows.filter(row => row.path !== 'INBOX')],
+    ['absent source folder', folderRows.map(row => row.path === 'INBOX' ? { ...row, is_present: false } : row)],
+    ['null destination epoch', folderRows.map(row => row.path === 'Archive' ? { ...row, uid_validity: null } : row)],
+    ['superseded destination generation', folderRows.map(row => row.path === 'Archive' ? { ...row, observation_generation: 9 } : row)],
+  ])('fails closed on %s before locking messages', async (_label, folders) => {
+    const tx = transaction({ folders });
+    await expect(materialize(tx)).rejects.toMatchObject({
+      code: 'FOLDER_OBSERVATION_SUPERSEDED', retryable: true, uncertain: true,
+    });
+    expect(tx.query).toHaveBeenCalledOnce();
+  });
+
+  it('validates both tokens when source and destination use the same folder', async () => {
+    const sameReceipt = {
+      ...receipt,
+      folder: 'INBOX',
+      uidValidity: '101',
+      destinationToken: { folder: 'INBOX', uidValidity: '101', generation: '9' },
+    };
+    const sameOperation = {
+      ...operation,
+      destination: sameReceipt.destinationToken,
+    };
+    const tx = transaction({ folders: [folderRows[1]] });
+
+    await expect(materialize(tx, {
+      destinationFolder: 'INBOX', receipt: sameReceipt, operation: sameOperation,
+    })).rejects.toMatchObject({ code: 'FOLDER_OBSERVATION_SUPERSEDED' });
+    expect(tx.query).toHaveBeenCalledOnce();
+  });
+});
+
+describe('archive identity and annotation merge', () => {
+  it('keeps source-local conflicts, destination-only annotations, and live provider enrichment', () => {
+    expect(mergeArchiveRows(sourceRow, liveOccupant)).toMatchObject({
+      id: sourceRow.id,
+      is_read: false,
+      is_starred: true,
+      read_changed_at: sourceRow.read_changed_at,
+      star_changed_at: sourceRow.star_changed_at,
+      category: 'primary',
+      spam_score_sa: 1,
+      spam_user_override: 'ham',
+      unsubscribed_at: sourceRow.unsubscribed_at,
+      spam_details: {
+        sourceOnly: true, destinationOnly: true, conflict: 'source',
+      },
+      plugin_annotations: {
+        gtd: { gist: 'source gist', sourceOnly: true, destinationOnly: true },
+        sourcePlugin: { kept: true },
+        destinationPlugin: { kept: true },
+      },
+      snippet: 'source snippet',
+      snippet_attempted_at: sourceRow.snippet_attempted_at,
+      body_text: 'source body',
+      body_html: '<p>destination body</p>',
+      attachments: [{ filename: 'receipt.pdf' }],
+      message_id: '<destination@example.test>',
+      subject: 'destination subject',
+      from_email: 'destination@example.test',
+      flags: ['\\Seen', '$MailFlowOp-test'],
+      delivery_addresses: ['alias@example.test'],
+      sender_email: 'submitter@example.test',
+      thread_id: 'source-thread',
+      metadata_complete: true,
+      is_deleted: false,
+    });
+  });
+
+  it.each([
+    ['flags', []],
+    ['to_addresses', []],
+    ['cc_addresses', []],
+    ['reply_to', []],
+    ['in_reply_to', null],
+    ['thread_references', null],
+    ['list_unsubscribe', null],
+    ['list_unsubscribe_post', ''],
+    ['delivery_addresses', []],
+    ['sender_name', null],
+    ['sender_email', null],
+    ['has_attachments', false],
+  ])('uses an authoritative empty destination %s to clear stale source provider data', (
+    field, destinationValue,
+  ) => {
+    const staleSource = {
+      ...sourceRow,
+      [field]: Array.isArray(destinationValue) ? [{ stale: true }] : 'stale provider value',
+    };
+    const freshDestination = { ...liveOccupant, [field]: destinationValue };
+
+    const merged = mergeArchiveRows(staleSource, freshDestination);
+
+    expect(merged[field]).toEqual(destinationValue);
+    expect(merged.category).toBe(staleSource.category);
+    expect(merged.body_text).toBe(staleSource.body_text);
+    expect(merged.plugin_annotations.gtd.gist).toBe('source gist');
+  });
+});
+
+describe('archive occupant materialization', () => {
+  beforeEach(() => adjustFolderCounts.mockReset().mockResolvedValue(undefined));
+
+  it('relocates durable desired-flag delivery coordinates with the exact moved row', async () => {
+    const tx = transaction();
+
+    await materialize(tx);
+
+    const delivery = tx.query.mock.calls.find(([sql]) => /UPDATE message_flag_deliveries/.test(sql));
+    expect(delivery[0]).toMatch(/message_id = \$1/);
+    expect(delivery[0]).toMatch(/folder = \$7 AND uid = \$8/);
+    expect(delivery[1]).toEqual([
+      sourceRow.id, 'acct-1', 'Archive', 88, '202', '8', 'INBOX', 7, '101', '4',
+    ]);
+  });
+
+  it.each([
+    ['no occupant', null, 0],
+    ['live complete occupant', liveOccupant, 1],
+    ['quarantined occupant', { ...liveOccupant, metadata_complete: false }, 1],
+    ['deleted occupant', { ...liveOccupant, is_deleted: true }, 1],
+  ])('preserves the source UUID while replacing %s', async (_label, occupant, deletes) => {
+    const tx = transaction({ occupant });
+
+    await expect(materialize(tx)).resolves.toMatchObject({
+      archived: true, sourceId: sourceRow.id,
+    });
+
+    expect(tx.query.mock.calls.filter(([sql]) => /DELETE FROM messages/.test(sql))).toHaveLength(deletes);
+    const update = tx.query.mock.calls.find(([sql]) => /UPDATE messages/.test(sql));
+    expect(update[0]).toMatch(/WHERE id = \$\d+.*account_id = \$\d+.*folder = \$\d+.*uid = \$\d+/s);
+    expect(update[1]).toContain(sourceRow.id);
+    expect(update[1]).not.toContain(liveOccupant.id);
+  });
+
+  it('treats an exact already-materialized source UUID as an idempotent concurrent winner', async () => {
+    const winner = { ...sourceRow, folder: 'Archive', uid: 88 };
+    const tx = transaction({ source: winner });
+
+    await expect(materialize(tx)).resolves.toMatchObject({
+      archived: true, sourceId: sourceRow.id, concurrentWinner: true,
+    });
+    expect(tx.query.mock.calls.some(([sql]) => /DELETE FROM messages|UPDATE messages/.test(sql))).toBe(false);
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it('does not accept a different UUID at the destination when the source disappeared', async () => {
+    const tx = transaction({ source: null, occupant: liveOccupant });
+    await expect(materialize(tx)).rejects.toMatchObject({ code: 'ARCHIVE_SOURCE_SUPERSEDED' });
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it('accepts zero-row CAS only after confirming the same source UUID at the exact live tuple', async () => {
+    const winner = { ...sourceRow, folder: 'Archive', uid: 88 };
+    const tx = transaction({ updateRowCount: 0, concurrentWinner: winner });
+    await expect(materialize(tx)).resolves.toMatchObject({ concurrentWinner: true });
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it('rejects zero-row CAS with a wrong-UUID destination occupant', async () => {
+    const tx = transaction({ updateRowCount: 0, concurrentWinner: liveOccupant });
+    await expect(materialize(tx)).rejects.toMatchObject({ code: 'ARCHIVE_SOURCE_SUPERSEDED' });
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [true, 0],
+    [false, -1],
+  ])('deletes an exact All Mail winner and debits its actual read=%s row state', async (
+    isRead, unreadDelta,
+  ) => {
+    const allMailSource = { ...sourceRow, folder: 'All Mail', uid: 88, is_read: isRead };
+    const allMailReceipt = {
+      ...receipt,
+      folder: 'All Mail',
+      destinationToken: { folder: 'All Mail', uidValidity: '202', generation: '8' },
+    };
+    const allMailOperation = {
+      ...operation,
+      destination: allMailReceipt.destinationToken,
+    };
+    const tx = transaction({
+      source: allMailSource,
+      folders: [
+        { path: 'All Mail', uid_validity: 202, observation_generation: 8, is_present: true },
+        folderRows[1],
+      ],
+    });
+
+    await expect(materialize(tx, {
+      destinationFolder: 'All Mail', receipt: allMailReceipt,
+      operation: allMailOperation, allMail: true,
+    })).resolves.toMatchObject({
+      archived: true, sourceId: sourceRow.id, concurrentWinner: false,
+    });
+
+    const deleted = tx.query.mock.calls.find(([sql]) => /DELETE FROM messages/.test(sql));
+    expect(deleted[1]).toEqual([sourceRow.id, 'acct-1', 'All Mail', 88]);
+    expect(adjustFolderCounts).toHaveBeenCalledOnce();
+    expect(adjustFolderCounts).toHaveBeenCalledWith(
+      'acct-1', 'All Mail', -1, unreadDelta, expect.objectContaining({ strict: true }),
+    );
+  });
+
+  it('applies accepted desired flags to the exact All Mail destination before deleting the source row', async () => {
+    const allMailSource = { ...sourceRow, folder: 'All Mail', uid: 88 };
+    const allMailReceipt = {
+      ...receipt,
+      folder: 'All Mail',
+      destinationToken: { folder: 'All Mail', uidValidity: '202', generation: '8' },
+    };
+    const allMailOperation = { ...operation, destination: allMailReceipt.destinationToken };
+    const client = {
+      mailbox: { path: 'All Mail', uidValidity: 202 },
+      messageFlagsAdd: vi.fn().mockResolvedValue(true),
+      messageFlagsRemove: vi.fn().mockResolvedValue(true),
+    };
+    const tx = transaction({
+      source: allMailSource,
+      folders: [
+        { path: 'All Mail', uid_validity: 202, observation_generation: 8, is_present: true },
+        folderRows[1],
+      ],
+      deliveries: [
+        {
+          flag: 'read', desired_value: true, revision: 3,
+          folder: 'All Mail', uid: 88, uid_validity: 202, folder_generation: 8,
+        },
+        {
+          flag: 'star', desired_value: false, revision: 5,
+          folder: 'All Mail', uid: 88, uid_validity: 202, folder_generation: 8,
+        },
+      ],
+    });
+
+    await materialize(tx, {
+      destinationFolder: 'All Mail', receipt: allMailReceipt,
+      operation: allMailOperation, allMail: true,
+      providerResource: { client, folder: 'All Mail', uidValidities: new Map([['All Mail', '202']]) },
+    });
+
+    expect(client.messageFlagsAdd).toHaveBeenCalledWith('88', ['\\Seen'], { uid: true });
+    expect(client.messageFlagsRemove).toHaveBeenCalledWith('88', ['\\Flagged'], { uid: true });
+    const deleteCall = tx.query.mock.calls.find(([sql]) => /DELETE FROM messages/.test(sql));
+    expect(client.messageFlagsAdd.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.query.mock.invocationCallOrder[tx.query.mock.calls.indexOf(deleteCall)],
+    );
+    expect(client.messageFlagsRemove.mock.invocationCallOrder[0]).toBeLessThan(
+      tx.query.mock.invocationCallOrder[tx.query.mock.calls.indexOf(deleteCall)],
+    );
+  });
+
+  it('keeps the All Mail source row when an accepted flag revision was superseded', async () => {
+    const allMailSource = { ...sourceRow, folder: 'All Mail', uid: 88 };
+    const allMailReceipt = {
+      ...receipt,
+      folder: 'All Mail',
+      destinationToken: { folder: 'All Mail', uidValidity: '202', generation: '8' },
+    };
+    const tx = transaction({
+      source: allMailSource,
+      folders: [
+        { path: 'All Mail', uid_validity: 202, observation_generation: 8, is_present: true },
+        folderRows[1],
+      ],
+      deliveries: [{
+        flag: 'read', desired_value: true, revision: 4,
+        folder: 'All Mail', uid: 88, uid_validity: 202, folder_generation: 8,
+      }],
+    });
+
+    await expect(materialize(tx, {
+      destinationFolder: 'All Mail', receipt: allMailReceipt,
+      operation: { ...operation, destination: allMailReceipt.destinationToken }, allMail: true,
+      providerResource: {
+        client: { mailbox: { path: 'All Mail', uidValidity: 202 } },
+        folder: 'All Mail', uidValidities: new Map([['All Mail', '202']]),
+      },
+    })).rejects.toMatchObject({ code: 'DESIRED_FLAG_SUPERSEDED' });
+
+    expect(tx.query.mock.calls.some(([sql]) => /DELETE FROM messages/.test(sql))).toBe(false);
+  });
+});
+
+describe('archive count ledger', () => {
+  beforeEach(() => adjustFolderCounts.mockReset().mockResolvedValue(undefined));
+
+  it.each([
+    [true, null, null, [-1, 0], [1, 0]],
+    [false, null, null, [-1, -1], [1, 1]],
+    [true, 'live', true, [-1, 0], [0, 0]],
+    [true, 'live', false, [-1, 0], [0, -1]],
+    [false, 'live', true, [-1, -1], [0, 1]],
+    [false, 'live', false, [-1, -1], [0, 0]],
+    [false, 'quarantined', false, [-1, -1], [1, 1]],
+    [false, 'deleted', false, [-1, -1], [1, 1]],
+  ])('derives source=%s occupant=%s/%s deltas from locked row states', async (
+    sourceRead, occupantKind, occupantRead, sourceDelta, destinationDelta,
+  ) => {
+    const source = { ...sourceRow, is_read: sourceRead };
+    const occupant = occupantKind ? {
+      ...liveOccupant,
+      is_read: occupantRead,
+      metadata_complete: occupantKind !== 'quarantined',
+      is_deleted: occupantKind === 'deleted',
+    } : null;
+    const tx = transaction({ source, occupant, updateRow: { ...source, folder: 'Archive', uid: 88 } });
+
+    await materialize(tx);
+
+    expect(adjustFolderCounts).toHaveBeenCalledWith(
+      'acct-1', 'INBOX', ...sourceDelta, expect.objectContaining({ strict: true }),
+    );
+    if (destinationDelta[0] === 0 && destinationDelta[1] === 0) {
+      expect(adjustFolderCounts).not.toHaveBeenCalledWith(
+        'acct-1', 'Archive', expect.anything(), expect.anything(), expect.anything(),
+      );
+    } else {
+      expect(adjustFolderCounts).toHaveBeenCalledWith(
+        'acct-1', 'Archive', ...destinationDelta, expect.objectContaining({ strict: true }),
+      );
+    }
+  });
+
+  it('coalesces same-folder source and destination into one exact ledger delta', async () => {
+    const sameSourceToken = { ...sourceToken };
+    const sameDestinationToken = { folder: 'INBOX', uidValidity: '101', generation: '4' };
+    const sameReceipt = {
+      ...receipt, folder: 'INBOX', uidValidity: '101',
+      sourceToken: sameSourceToken, destinationToken: sameDestinationToken,
+    };
+    const sameOperation = {
+      ...operation, source: sameSourceToken, destination: sameDestinationToken,
+    };
+    const tx = transaction({
+      folders: [folderRows[1]],
+      occupant: { ...liveOccupant, folder: 'INBOX', is_read: false },
+      updateRow: { ...sourceRow, folder: 'INBOX', uid: 88 },
+    });
+
+    await materialize(tx, {
+      destinationFolder: 'INBOX', receipt: sameReceipt, operation: sameOperation,
+    });
+
+    expect(adjustFolderCounts).toHaveBeenCalledOnce();
+    expect(adjustFolderCounts).toHaveBeenCalledWith(
+      'acct-1', 'INBOX', -1, -1, expect.objectContaining({ strict: true }),
+    );
+  });
+
+  it('deletes only the source and decrements only INBOX for All Mail materialization', async () => {
+    const tx = transaction();
+    await materialize(tx, { allMail: true });
+    expect(tx.query.mock.calls.filter(([sql]) => /DELETE FROM messages/.test(sql))).toHaveLength(1);
+    expect(tx.query.mock.calls.some(([sql]) => /UPDATE messages/.test(sql))).toBe(false);
+    expect(adjustFolderCounts).toHaveBeenCalledOnce();
+    expect(adjustFolderCounts).toHaveBeenCalledWith(
+      'acct-1', 'INBOX', -1, -1, expect.objectContaining({ strict: true }),
+    );
+  });
+
+  it.each(['delete', 'update'])('propagates %s failure before count updates', async failOn => {
+    const tx = transaction({ occupant: liveOccupant, failOn });
+    await expect(materialize(tx)).rejects.toThrow(failOn === 'delete' ? 'duplicate delete failed' : 'source update failed');
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+  });
+
+  it('propagates strict count failure to roll back materialization and completion', async () => {
+    adjustFolderCounts.mockRejectedValueOnce(new Error('count update failed'));
+    const tx = transaction();
+    await expect(materialize(tx)).rejects.toThrow('count update failed');
+  });
+});

--- a/backend/src/services/categorizer.boundary.test.js
+++ b/backend/src/services/categorizer.boundary.test.js
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => ({ query: vi.fn() }));
+vi.mock('./aiProvider.js', () => ({ completeText: vi.fn() }));
+
+import { query } from './db.js';
+import { backfillCategories, invalidateSocialDomainCache } from './categorizer.js';
+
+describe('backfillCategories folder boundary', () => {
+  beforeEach(() => query.mockReset());
+
+  it('reads only rows owned by a present folder with a known UID epoch', async () => {
+    invalidateSocialDomainCache('user-1');
+    query.mockImplementation(async (sql) => {
+      if (typeof sql !== 'string') return { rows: [] };
+      if (sql.includes('FROM category_list_sources')) return { rows: [] };
+      if (sql.includes('SELECT m.id, m.from_email, m.is_bulk')) {
+        return { rows: [{ id: 'row-1', from_email: 'news@example.com', is_bulk: true }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(backfillCategories('acct-1', 'user-1')).resolves.toBe(1);
+
+    const selectSql = query.mock.calls.find(
+      ([sql]) => sql.includes('SELECT m.id, m.from_email, m.is_bulk'),
+    )[0];
+    expect(selectSql).toMatch(/JOIN folders f/);
+    expect(selectSql).toMatch(/f\.account_id = m\.account_id/);
+    expect(selectSql).toMatch(/f\.path = m\.folder/);
+    expect(selectSql).toMatch(/f\.is_present = true/);
+    expect(selectSql).toMatch(/f\.uid_validity IS NOT NULL/);
+  });
+});

--- a/backend/src/services/categorizer.js
+++ b/backend/src/services/categorizer.js
@@ -181,19 +181,24 @@ export async function backfillCategories(accountId, userId) {
 
   for (;;) {
     const result = await query(
-      `SELECT id, from_email, is_bulk
-       FROM messages
-       WHERE account_id = $1
-         AND category IS NULL
-         AND is_deleted = false
-       ORDER BY date DESC
+      `SELECT m.id, m.from_email, m.is_bulk, m.account_id, m.uid, m.folder,
+              m.read_revision, m.star_revision,
+              f.uid_validity AS folder_uid_validity,
+              f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+         AND f.is_present = true AND f.uid_validity IS NOT NULL
+       WHERE m.account_id = $1
+         AND m.category IS NULL
+         AND m.is_deleted = false
+         AND m.metadata_complete = true
+       ORDER BY m.date DESC
        LIMIT $2 OFFSET $3`,
       [accountId, BATCH, offset]
     );
     if (!result.rows.length) break;
 
-    const ids = [];
-    const categories = [];
+    const desired = [];
 
     for (const row of result.rows) {
       // For backfill without re-fetching IMAP headers, derive from is_bulk
@@ -214,18 +219,68 @@ export async function backfillCategories(accountId, userId) {
       }
 
       if (category !== 'primary') {
-        ids.push(row.id);
-        categories.push(category);
+        desired.push({
+          id: row.id,
+          category,
+          uid: Number(row.uid),
+          folder: row.folder,
+          uid_validity: String(row.folder_uid_validity),
+          folder_generation: String(row.folder_observation_generation),
+          read_revision: Number(row.read_revision),
+          star_revision: Number(row.star_revision),
+        });
       }
     }
 
-    if (ids.length > 0) {
-      await query(
-        `UPDATE messages SET category = v.category
-         FROM (SELECT unnest($1::uuid[]) AS id, unnest($2::text[]) AS category) AS v
-         WHERE messages.id = v.id`,
-        [ids, categories]
+    if (desired.length > 0) {
+      const updated = await query(
+        `WITH desired AS (
+           SELECT * FROM jsonb_to_recordset($2::jsonb) AS d(
+             id uuid, category text, uid bigint, folder text, uid_validity numeric,
+             folder_generation bigint, read_revision bigint, star_revision bigint
+           )
+         ), folder_fence AS MATERIALIZED (
+           SELECT f.path, f.uid_validity, f.observation_generation, f.is_present
+             FROM folders f
+            WHERE f.account_id = $1
+              AND f.path = ANY(ARRAY(SELECT folder FROM desired))
+            ORDER BY f.path
+            FOR SHARE OF f
+         ), live AS MATERIALIZED (
+           SELECT desired.*
+             FROM desired
+             JOIN folder_fence f ON f.path = desired.folder
+                                AND f.is_present = true
+                                AND f.uid_validity IS NOT NULL
+                                AND f.uid_validity = desired.uid_validity
+                                AND f.observation_generation = desired.folder_generation
+             JOIN messages m ON m.id = desired.id AND m.account_id = $1
+                            AND m.uid = desired.uid AND m.folder = desired.folder
+                            AND m.read_revision = desired.read_revision
+                            AND m.star_revision = desired.star_revision
+                            AND m.category IS NULL
+                            AND m.is_deleted = false AND m.metadata_complete = true
+            ORDER BY m.id
+            FOR UPDATE OF m
+         )
+         UPDATE messages SET category = live.category
+           FROM live
+          WHERE messages.id = live.id AND messages.account_id = $1
+            AND messages.uid = live.uid AND messages.folder = live.folder
+            AND messages.read_revision = live.read_revision
+            AND messages.star_revision = live.star_revision
+            AND messages.category IS NULL
+            AND messages.is_deleted = false AND messages.metadata_complete = true
+            AND (SELECT COUNT(*) FROM live) = (SELECT COUNT(*) FROM desired)
+         RETURNING messages.id`,
+        [accountId, JSON.stringify(desired)]
       );
+      if (updated?.rowCount != null && updated.rowCount !== desired.length) {
+        const error = new Error('Category source snapshot was superseded');
+        error.code = 'MESSAGE_SNAPSHOT_SUPERSEDED';
+        error.retryable = true;
+        throw error;
+      }
     }
 
     processed += result.rows.length;

--- a/backend/src/services/categorizerBoundary.test.js
+++ b/backend/src/services/categorizerBoundary.test.js
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => ({ query: vi.fn() }));
+vi.mock('./aiProvider.js', () => ({ completeText: vi.fn() }));
+
+import { query } from './db.js';
+import { backfillCategories, invalidateSocialDomainCache } from './categorizer.js';
+
+describe('categorizer mutation boundary', () => {
+  beforeEach(() => {
+    query.mockReset();
+    invalidateSocialDomainCache('user-1');
+  });
+
+  it('fails the whole category write when one frozen row snapshot is superseded', async () => {
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM category_list_sources')) return { rows: [] };
+      if (sql.includes('SELECT m.id, m.from_email, m.is_bulk')) {
+        return { rows: [{
+          id: '00000000-0000-4000-8000-000000000001',
+          account_id: 'acct-1', uid: 7, folder: 'INBOX',
+          from_email: 'news@example.com', is_bulk: true,
+          read_revision: 3, star_revision: 5,
+          folder_uid_validity: 101, folder_observation_generation: 9,
+        }] };
+      }
+      if (sql.includes('UPDATE messages')) return { rows: [], rowCount: 0 };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await expect(backfillCategories('acct-1', 'user-1'))
+      .rejects.toMatchObject({ code: 'MESSAGE_SNAPSHOT_SUPERSEDED' });
+
+    const select = query.mock.calls.find(([sql]) => sql.includes('SELECT m.id'));
+    expect(select[0]).toMatch(/m\.account_id[\s\S]*m\.uid[\s\S]*m\.folder/);
+    expect(select[0]).toMatch(/m\.read_revision[\s\S]*m\.star_revision/);
+    expect(select[0]).toMatch(/folder_uid_validity[\s\S]*folder_observation_generation/);
+
+    const update = query.mock.calls.find(([sql]) => sql.includes('UPDATE messages'));
+    expect(update[0]).toMatch(/jsonb_to_recordset/);
+    expect(update[0]).toMatch(/m\.uid = desired\.uid[\s\S]*m\.folder = desired\.folder/);
+    expect(update[0]).toMatch(/m\.read_revision = desired\.read_revision/);
+    expect(update[0]).toMatch(/m\.star_revision = desired\.star_revision/);
+    expect(update[0]).toMatch(/f\.uid_validity = desired\.uid_validity/);
+    expect(update[0]).toMatch(/f\.observation_generation = desired\.folder_generation/);
+    expect(update[0]).toMatch(/m\.is_deleted = false[\s\S]*m\.metadata_complete = true/);
+  });
+});

--- a/backend/src/services/db.js
+++ b/backend/src/services/db.js
@@ -24,6 +24,18 @@ export async function query(text, params) {
   return pool.query(text, params);
 }
 
+// Hold one physical PostgreSQL session for callbacks that need session-scoped
+// primitives such as advisory locks, without opening a transaction around
+// provider I/O.
+export async function withSession(fn) {
+  const client = await pool.connect();
+  try {
+    return await fn(client);
+  } finally {
+    client.release();
+  }
+}
+
 // Run fn(client) inside a serializable transaction. Commits on success, rolls
 // back on throw. The client exposes a .query(text, params) method identical to
 // the top-level query() helper.

--- a/backend/src/services/desiredFlags.js
+++ b/backend/src/services/desiredFlags.js
@@ -1,0 +1,771 @@
+import { randomUUID } from 'node:crypto';
+import { query, withSession, withTransaction } from './db.js';
+
+const FLAG_DEFINITIONS = Object.freeze({
+  read: Object.freeze({ value: 'is_read', revision: 'read_revision', imap: '\\Seen' }),
+  star: Object.freeze({ value: 'is_starred', revision: 'star_revision', imap: '\\Flagged' }),
+});
+
+// ImapFlow commands are bounded at 30 seconds. Renewing a three-minute durable
+// lease immediately before STORE leaves enough room for STORE plus the checked
+// post-observation without permitting an abandoned attempt to block forever.
+export const DESIRED_FLAG_LEASE_MS = 180_000;
+
+export class DesiredFlagError extends Error {
+  constructor(message, { code, retryable = false, uncertain = false, cause } = {}) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = 'DesiredFlagError';
+    this.code = code;
+    this.retryable = retryable;
+    this.uncertain = uncertain;
+  }
+}
+
+export function normalizeDesiredFlag(flag) {
+  if (flag === 'read' || flag === '\\Seen') return 'read';
+  if (flag === 'star' || flag === '\\Flagged') return 'star';
+  throw new DesiredFlagError(`Unsupported durable desired flag ${flag}`, {
+    code: 'DESIRED_FLAG_UNSUPPORTED',
+  });
+}
+
+export function flagColumn(flag) {
+  const logical = normalizeDesiredFlag(flag);
+  const { value, revision } = FLAG_DEFINITIONS[logical];
+  return { value, revision };
+}
+
+export function desiredFlagImapName(flag) {
+  return FLAG_DEFINITIONS[normalizeDesiredFlag(flag)].imap;
+}
+
+export function createImapDesiredFlagSession(client, delivery) {
+  const logical = normalizeDesiredFlag(delivery.flag);
+  const imapFlag = desiredFlagImapName(logical);
+  const uid = String(delivery.uid);
+  const condstore = client.enabled?.has?.('CONDSTORE') === true &&
+    client.mailbox?.noModseq !== true;
+  return {
+    condstore,
+    async observe() {
+      const message = await client.fetchOne(
+        uid,
+        { uid: true, flags: true, modseq: true },
+        { uid: true },
+      );
+      if (!message || Number(message.uid) !== Number(delivery.uid)) {
+        throw new DesiredFlagError(`Desired flag UID ${uid} is no longer present`, {
+          code: 'DESIRED_FLAG_UID_NOT_FOUND', retryable: true, uncertain: true,
+        });
+      }
+      return {
+        value: message.flags?.has?.(imapFlag) === true,
+        modseq: condstore && message.modseq != null ? String(message.modseq) : null,
+      };
+    },
+    async store(value, { unchangedSince } = {}) {
+      const options = { uid: true };
+      if (condstore && unchangedSince != null) options.unchangedSince = BigInt(unchangedSince);
+      return value
+        ? client.messageFlagsAdd(uid, [imapFlag], options)
+        : client.messageFlagsRemove(uid, [imapFlag], options);
+    },
+  };
+}
+
+function ownershipLost(err) {
+  return err?.code === 'DESIRED_FLAG_OWNERSHIP_LOST';
+}
+
+function deliveryUncertain(err) {
+  if (err instanceof DesiredFlagError && err.uncertain) return err;
+  return new DesiredFlagError(`Desired flag delivery is uncertain: ${err?.message || 'provider failure'}`, {
+    code: 'DESIRED_FLAG_DELIVERY_UNCERTAIN',
+    retryable: true,
+    uncertain: true,
+    cause: err,
+  });
+}
+
+export function createDesiredFlagExecutor({
+  repository,
+  ownerFactory = randomUUID,
+} = {}) {
+  if (!repository) throw new Error('Desired flag repository is required');
+
+  return {
+    async accept({ messageId, flag, value, ...snapshot }) {
+      const logical = normalizeDesiredFlag(flag);
+      const desiredValue = value === true;
+      const accepted = await repository.acceptIntent({
+        messageId,
+        flag: logical,
+        value: desiredValue,
+        ...snapshot,
+      });
+      return {
+        ...accepted,
+        unreadDelta: logical === 'read' && accepted.changed
+          ? (desiredValue ? -1 : 1)
+          : 0,
+      };
+    },
+
+    async deliver(messageId, flag, provider) {
+      const logical = normalizeDesiredFlag(flag);
+      if (!provider?.withSession) {
+        throw deliveryUncertain(new Error('Desired flag provider session is required'));
+      }
+      if (!repository.withDeliveryLease) {
+        throw deliveryUncertain(new Error('Desired flag repository delivery lease is required'));
+      }
+      let candidate;
+      try {
+        candidate = await repository.load(messageId, logical);
+      } catch (err) {
+        throw deliveryUncertain(err);
+      }
+      if (!candidate || candidate.state === 'confirmed') return candidate;
+
+      // Acquire the provider connection before the DB advisory lease. The lease
+      // then serializes claim, observation, STORE, and checked completion across
+      // processes without holding row locks or a transaction during provider I/O.
+      try {
+        return await provider.withSession(candidate, session =>
+          repository.withDeliveryLease(messageId, logical, async lease => {
+            const attempt = await repository.claim(messageId, logical, ownerFactory(), lease);
+            if (!attempt || attempt.state === 'confirmed') return attempt;
+            let baselineRecorded = false;
+            let providerCommandStarted = false;
+            try {
+              const before = await session.observe();
+              const condstore = session.condstore === true && before.modseq != null;
+              const owned = await repository.recordBaseline(
+                attempt,
+                before.modseq == null ? null : String(before.modseq),
+                condstore,
+              );
+              baselineRecorded = true;
+
+              const mustReassert = owned.uncertaintyTombstones?.length > 0 ||
+                before.value !== owned.desiredValue;
+              if (mustReassert) {
+                await lease.assertActive();
+                await repository.renewLease(attempt);
+                await lease.assertActive();
+                await repository.markProviderStarted(attempt);
+                providerCommandStarted = true;
+                const stored = await session.store(owned.desiredValue, {
+                  unchangedSince: condstore ? String(before.modseq) : undefined,
+                });
+                if (stored === false) {
+                  throw new DesiredFlagError('Provider did not confirm desired flag STORE', {
+                    code: 'DESIRED_FLAG_STORE_UNCONFIRMED', retryable: true, uncertain: true,
+                  });
+                }
+              }
+
+              const after = mustReassert ? await session.observe() : before;
+              await lease.assertActive();
+              await repository.renewLease(attempt);
+              await lease.assertActive();
+              return repository.complete(attempt, {
+                value: after.value,
+                modseq: after.modseq == null ? null : String(after.modseq),
+                condstore,
+              });
+            } catch (err) {
+              if (ownershipLost(err)) throw err;
+              const uncertain = deliveryUncertain(err);
+              try {
+                if (!providerCommandStarted) {
+                  await repository.releasePending(attempt, {
+                    code: uncertain.code,
+                    message: uncertain.message,
+                    at: new Date().toISOString(),
+                  });
+                } else {
+                  await repository.markUncertain(attempt, {
+                    code: uncertain.code,
+                    message: uncertain.message,
+                    baselineRecorded,
+                    at: new Date().toISOString(),
+                  });
+                }
+              } catch (markErr) {
+                if (ownershipLost(markErr)) throw markErr;
+                throw new DesiredFlagError('Could not persist desired flag uncertainty', {
+                  code: 'DESIRED_FLAG_UNCERTAINTY_PERSIST_FAILED',
+                  retryable: true,
+                  uncertain: true,
+                  cause: markErr,
+                });
+              }
+              throw uncertain;
+            }
+          })
+        );
+      } catch (err) {
+        throw deliveryUncertain(err);
+      }
+    },
+  };
+}
+
+function parseJsonArray(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function deliveryFromRow(row) {
+  if (!row) return null;
+  return {
+    messageId: row.message_id,
+    flag: row.flag,
+    accountId: row.account_id,
+    uid: Number(row.uid),
+    folder: row.folder,
+    uidValidity: String(row.uid_validity),
+    folderGeneration: String(row.folder_generation),
+    revision: Number(row.revision),
+    desiredValue: row.desired_value === true,
+    state: row.state,
+    capturedModseq: row.captured_modseq == null ? null : String(row.captured_modseq),
+    condstore: row.condstore === true,
+    uncertaintyTombstones: parseJsonArray(row.uncertainty_tombstones),
+    attemptGeneration: Number(row.attempt_generation),
+    attemptOwner: row.attempt_owner,
+    leaseExpiresAt: row.lease_expires_at == null ? null : String(row.lease_expires_at),
+    providerStartedAt: row.provider_started_at == null ? null : String(row.provider_started_at),
+  };
+}
+
+function rowSuperseded(messageId) {
+  return new DesiredFlagError(`Desired flag row ${messageId} is no longer actionable`, {
+    code: 'DESIRED_FLAG_ROW_SUPERSEDED', retryable: true, uncertain: true,
+  });
+}
+
+function lostOwnership() {
+  return new DesiredFlagError('Desired flag ownership was lost', {
+    code: 'DESIRED_FLAG_OWNERSHIP_LOST', retryable: true, uncertain: true,
+  });
+}
+
+function sameFact(expected, actual) {
+  return expected === undefined || expected === null || String(expected) === String(actual);
+}
+
+function checkedDeliveryParams(attempt) {
+  return [
+    attempt.messageId,
+    normalizeDesiredFlag(attempt.flag),
+    attempt.revision,
+    attempt.attemptGeneration,
+    attempt.attemptOwner,
+  ];
+}
+
+export function createPostgresDesiredFlagRepository({
+  runQuery = query,
+  runTransaction = withTransaction,
+  runSession = withSession,
+} = {}) {
+  const activeLeaseTokens = new WeakSet();
+  const loadChecked = async (tx, attempt, { requireLease = false } = {}) => {
+    const current = await tx.query(
+      `SELECT * FROM message_flag_deliveries
+        WHERE message_id = $1 AND flag = $2
+          AND revision = $3 AND attempt_generation = $4 AND attempt_owner = $5
+          ${requireLease ? "AND state = 'delivering' AND lease_expires_at > NOW()" : ''}
+        FOR UPDATE`,
+      checkedDeliveryParams(attempt),
+    );
+    if (!current.rows[0]) throw lostOwnership();
+    return deliveryFromRow(current.rows[0]);
+  };
+
+  return {
+    async withDeliveryLease(messageId, flag, callback) {
+      const key = `${messageId}:${normalizeDesiredFlag(flag)}`;
+      return runSession(async client => {
+        await client.query('SELECT pg_advisory_lock(hashtextextended($1, 0))', [key]);
+        const lease = {
+          key,
+          async assertActive() {
+            if (!activeLeaseTokens.has(lease)) {
+              throw new DesiredFlagError('Desired flag advisory lease is no longer active', {
+                code: 'DESIRED_FLAG_LEASE_SESSION_LOST', retryable: true, uncertain: true,
+              });
+            }
+            let result;
+            try {
+              result = await client.query(
+                `SELECT EXISTS (
+                   SELECT 1 FROM pg_locks
+                    WHERE pid = pg_backend_pid() AND locktype = 'advisory' AND granted = true
+                      AND objsubid = 1
+                      AND classid = (((hashtextextended($1, 0) >> 32) & 4294967295)::oid)
+                      AND objid = ((hashtextextended($1, 0) & 4294967295)::oid)
+                 ) AS held`,
+                [key],
+              );
+            } catch (cause) {
+              throw new DesiredFlagError('Desired flag advisory session was lost', {
+                code: 'DESIRED_FLAG_LEASE_SESSION_LOST', retryable: true, uncertain: true, cause,
+              });
+            }
+            if (result.rows[0]?.held !== true) {
+              throw new DesiredFlagError('Desired flag advisory lock was lost', {
+                code: 'DESIRED_FLAG_LEASE_SESSION_LOST', retryable: true, uncertain: true,
+              });
+            }
+          },
+        };
+        activeLeaseTokens.add(lease);
+        try {
+          return await callback(lease);
+        } finally {
+          activeLeaseTokens.delete(lease);
+          await client.query('SELECT pg_advisory_unlock(hashtextextended($1, 0))', [key])
+            .catch(() => {});
+        }
+      });
+    },
+
+    async acceptIntent({
+      messageId, flag, value, accountId, uid, folder, uidValidity, folderGeneration,
+    }) {
+      const logical = normalizeDesiredFlag(flag);
+      const columns = flagColumn(logical);
+      return runTransaction(async tx => {
+        const locked = await tx.query(
+          `SELECT m.id, m.account_id, m.uid, m.folder, m.is_read, m.is_starred,
+                  m.read_revision, m.star_revision,
+                  f.uid_validity, f.observation_generation
+             FROM messages m
+             JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                            AND f.is_present = true AND f.uid_validity IS NOT NULL
+            WHERE m.id = $1 AND m.is_deleted = false AND m.metadata_complete = true
+            FOR UPDATE OF f, m`,
+          [messageId],
+        );
+        const message = locked.rows[0];
+        if (!message ||
+            !sameFact(accountId, message.account_id) ||
+            !sameFact(uid, message.uid) ||
+            !sameFact(folder, message.folder) ||
+            !sameFact(uidValidity, message.uid_validity) ||
+            !sameFact(folderGeneration, message.observation_generation)) {
+          throw rowSuperseded(messageId);
+        }
+
+        const previousResult = await tx.query(
+          `SELECT * FROM message_flag_deliveries
+            WHERE message_id = $1 AND flag = $2
+            FOR UPDATE`,
+          [messageId, logical],
+        );
+        const previous = deliveryFromRow(previousResult.rows[0]);
+        const previousValue = logical === 'read' ? message.is_read === true : message.is_starred === true;
+        const changed = previousValue !== (value === true);
+        const updated = await tx.query(
+          `UPDATE messages
+              SET ${columns.value} = $2,
+                  ${columns.revision} = ${columns.revision} + 1,
+                  ${logical === 'read' ? 'read_changed_at' : 'star_changed_at'} = NOW()
+            WHERE id = $1
+            RETURNING ${columns.revision} AS revision, ${columns.value} AS visible_value`,
+          [messageId, value === true],
+        );
+        if (!updated.rows[0]) throw rowSuperseded(messageId);
+
+        if (logical === 'read' && changed) {
+          const unreadDelta = value === true ? -1 : 1;
+          const count = await tx.query(
+            `UPDATE folders
+                SET unread_count = GREATEST(0, unread_count + $1)
+              WHERE account_id = $2 AND path = $3`,
+            [unreadDelta, message.account_id, message.folder],
+          );
+          if (count.rowCount !== 1) throw rowSuperseded(messageId);
+        }
+
+        const tombstones = [...(previous?.uncertaintyTombstones || [])];
+        if (previous && (previous.state === 'uncertain' ||
+            (previous.state === 'delivering' && previous.providerStartedAt != null)) &&
+            !tombstones.some(item => Number(item.revision) === previous.revision)) {
+          tombstones.push({
+            revision: previous.revision,
+            value: previous.desiredValue,
+            baseline: previous.capturedModseq,
+            attemptGeneration: previous.attemptGeneration,
+            reason: 'superseded',
+          });
+        }
+        const revision = updated.rows[0].revision;
+        const inserted = await tx.query(
+          `INSERT INTO message_flag_deliveries (
+             message_id, flag, account_id, folder, uid, uid_validity, folder_generation,
+             revision, desired_value, state, captured_modseq, condstore,
+             uncertainty_tombstones, attempt_generation, attempt_owner, updated_at
+           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'pending', NULL, NULL,
+                     $10::jsonb, $11, NULL, NOW())
+           ON CONFLICT (message_id, flag) DO UPDATE SET
+             account_id = EXCLUDED.account_id,
+             folder = EXCLUDED.folder,
+             uid = EXCLUDED.uid,
+             uid_validity = EXCLUDED.uid_validity,
+             folder_generation = EXCLUDED.folder_generation,
+             revision = EXCLUDED.revision,
+             desired_value = EXCLUDED.desired_value,
+             state = 'pending',
+             captured_modseq = NULL,
+             condstore = NULL,
+             uncertainty_tombstones = EXCLUDED.uncertainty_tombstones,
+             attempt_generation = EXCLUDED.attempt_generation,
+             attempt_owner = NULL,
+             lease_expires_at = NULL,
+             provider_started_at = NULL,
+             confirmed_at = NULL,
+             updated_at = NOW()
+           RETURNING *`,
+          [
+            messageId, logical, message.account_id, message.folder, message.uid,
+            message.uid_validity, message.observation_generation, revision, value === true,
+            JSON.stringify(tombstones), previous?.attemptGeneration || 0,
+          ],
+        );
+        return { delivery: deliveryFromRow(inserted.rows[0]), changed };
+      });
+    },
+
+    async claim(messageId, flag, owner, lease) {
+      const logical = normalizeDesiredFlag(flag);
+      if (!activeLeaseTokens.has(lease) || lease.key !== `${messageId}:${logical}`) {
+        throw new DesiredFlagError('Desired flag claim requires its active delivery lease', {
+          code: 'DESIRED_FLAG_LEASE_REQUIRED', retryable: true, uncertain: true,
+        });
+      }
+      return runTransaction(async tx => {
+        const locked = await tx.query(
+          `SELECT * FROM message_flag_deliveries
+            WHERE message_id = $1 AND flag = $2
+            FOR UPDATE`,
+          [messageId, logical],
+        );
+        const current = deliveryFromRow(locked.rows[0]);
+        if (!current || current.state === 'confirmed') return current;
+        const tombstones = [...current.uncertaintyTombstones];
+        if (current.state === 'delivering' && current.providerStartedAt != null &&
+            !tombstones.some(item => Number(item.revision) === current.revision &&
+              Number(item.attemptGeneration) === current.attemptGeneration)) {
+          tombstones.push({
+            revision: current.revision,
+            value: current.desiredValue,
+            baseline: current.capturedModseq,
+            attemptGeneration: current.attemptGeneration,
+            reason: 'ownership-takeover',
+          });
+        }
+        const claimed = await tx.query(
+          `UPDATE message_flag_deliveries
+              SET state = 'delivering',
+                  attempt_generation = attempt_generation + 1,
+                  attempt_owner = $3,
+                  uncertainty_tombstones = $4::jsonb,
+                  lease_expires_at = NOW() + ($6::bigint * INTERVAL '1 millisecond'),
+                  captured_modseq = NULL,
+                  condstore = NULL,
+                  provider_started_at = NULL,
+                  updated_at = NOW()
+            WHERE message_id = $1 AND flag = $2 AND revision = $5
+              AND (state <> 'delivering' OR lease_expires_at IS NULL OR lease_expires_at <= NOW())
+            RETURNING *`,
+          [
+            messageId, logical, owner, JSON.stringify(tombstones), current.revision,
+            DESIRED_FLAG_LEASE_MS,
+          ],
+        );
+        if (!claimed.rows[0]) {
+          if (current.state === 'delivering') {
+            throw new DesiredFlagError('Desired flag delivery lease is still active', {
+              code: 'DESIRED_FLAG_LEASE_ACTIVE', retryable: true, uncertain: true,
+            });
+          }
+          throw lostOwnership();
+        }
+        return deliveryFromRow(claimed.rows[0]);
+      });
+    },
+
+    async renewLease(attempt) {
+      return runTransaction(async tx => {
+        const renewed = await tx.query(
+          `UPDATE message_flag_deliveries
+              SET lease_expires_at = NOW() + ($6::bigint * INTERVAL '1 millisecond'),
+                  updated_at = NOW()
+            WHERE message_id = $1 AND flag = $2
+              AND revision = $3 AND attempt_generation = $4 AND attempt_owner = $5
+              AND state = 'delivering' AND lease_expires_at > NOW()
+            RETURNING *`,
+          [...checkedDeliveryParams(attempt), DESIRED_FLAG_LEASE_MS],
+        );
+        if (!renewed.rows[0]) throw lostOwnership();
+        return deliveryFromRow(renewed.rows[0]);
+      });
+    },
+
+    async recordBaseline(attempt, baseline, condstore) {
+      return runTransaction(async tx => {
+        const result = await tx.query(
+          `UPDATE message_flag_deliveries
+              SET captured_modseq = $6,
+                  condstore = $7,
+                  updated_at = NOW()
+            WHERE message_id = $1 AND flag = $2
+              AND revision = $3 AND attempt_generation = $4 AND attempt_owner = $5
+              AND state = 'delivering' AND lease_expires_at > NOW()
+            RETURNING *`,
+          [...checkedDeliveryParams(attempt), baseline, condstore],
+        );
+        if (!result.rows[0]) throw lostOwnership();
+        return deliveryFromRow(result.rows[0]);
+      });
+    },
+
+    async markProviderStarted(attempt) {
+      return runTransaction(async tx => {
+        const result = await tx.query(
+          `UPDATE message_flag_deliveries
+              SET provider_started_at = NOW(), updated_at = NOW()
+            WHERE message_id = $1 AND flag = $2
+              AND revision = $3 AND attempt_generation = $4 AND attempt_owner = $5
+              AND state = 'delivering' AND lease_expires_at > NOW()
+              AND condstore IS NOT NULL
+            RETURNING *`,
+          checkedDeliveryParams(attempt),
+        );
+        if (!result.rows[0]) throw lostOwnership();
+        return deliveryFromRow(result.rows[0]);
+      });
+    },
+
+    async complete(attempt, result) {
+      return runTransaction(async tx => {
+        const current = await loadChecked(tx, attempt, { requireLease: true });
+        const tombstones = [...current.uncertaintyTombstones];
+        const strictProof = tombstones.length > 0 && result.condstore === true &&
+          result.modseq != null && tombstones.every(item =>
+            item.baseline != null && BigInt(result.modseq) > BigInt(item.baseline));
+        const confirmed = result.value === current.desiredValue &&
+          (tombstones.length === 0 || strictProof);
+        if (!confirmed && tombstones.length === 0) {
+          tombstones.push({
+            revision: current.revision,
+            value: current.desiredValue,
+            baseline: current.capturedModseq,
+            attemptGeneration: current.attemptGeneration,
+            reason: 'post-store-mismatch',
+          });
+        }
+        const updated = await tx.query(
+          `UPDATE message_flag_deliveries
+              SET state = $6,
+                  uncertainty_tombstones = $7::jsonb,
+                  attempt_owner = NULL,
+                  lease_expires_at = NULL,
+                  provider_started_at = NULL,
+                  confirmed_at = CASE WHEN $6 = 'confirmed' THEN NOW() ELSE NULL END,
+                  updated_at = NOW()
+            WHERE message_id = $1 AND flag = $2
+              AND revision = $3 AND attempt_generation = $4 AND attempt_owner = $5
+            RETURNING *`,
+          [
+            ...checkedDeliveryParams(attempt), confirmed ? 'confirmed' : 'uncertain',
+            JSON.stringify(confirmed ? [] : tombstones),
+          ],
+        );
+        if (!updated.rows[0]) throw lostOwnership();
+        return deliveryFromRow(updated.rows[0]);
+      });
+    },
+
+    async markUncertain(attempt, uncertainty) {
+      return runTransaction(async tx => {
+        const current = await loadChecked(tx, attempt);
+        const tombstones = [...current.uncertaintyTombstones];
+        if (!tombstones.some(item => Number(item.revision) === current.revision &&
+            Number(item.attemptGeneration) === current.attemptGeneration)) {
+          tombstones.push({
+            revision: current.revision,
+            value: current.desiredValue,
+            baseline: current.capturedModseq,
+            attemptGeneration: current.attemptGeneration,
+            uncertainty,
+          });
+        }
+        const updated = await tx.query(
+          `UPDATE message_flag_deliveries
+              SET state = 'uncertain', uncertainty_tombstones = $6::jsonb,
+                  attempt_owner = NULL, lease_expires_at = NULL,
+                  provider_started_at = NULL, updated_at = NOW()
+            WHERE message_id = $1 AND flag = $2
+              AND revision = $3 AND attempt_generation = $4 AND attempt_owner = $5
+            RETURNING *`,
+          [...checkedDeliveryParams(attempt), JSON.stringify(tombstones)],
+        );
+        if (!updated.rows[0]) throw lostOwnership();
+        return deliveryFromRow(updated.rows[0]);
+      });
+    },
+
+    async releasePending(attempt) {
+      return runTransaction(async tx => {
+        const current = await loadChecked(tx, attempt);
+        const state = current.uncertaintyTombstones.length > 0 ? 'uncertain' : 'pending';
+        const updated = await tx.query(
+          `UPDATE message_flag_deliveries
+              SET state = $6, attempt_owner = NULL, lease_expires_at = NULL,
+                  provider_started_at = NULL, updated_at = NOW()
+            WHERE message_id = $1 AND flag = $2
+              AND revision = $3 AND attempt_generation = $4 AND attempt_owner = $5
+            RETURNING *`,
+          [...checkedDeliveryParams(attempt), state],
+        );
+        if (!updated.rows[0]) throw lostOwnership();
+        return deliveryFromRow(updated.rows[0]);
+      });
+    },
+
+    async load(messageId, flag) {
+      const result = await runQuery(
+        'SELECT * FROM message_flag_deliveries WHERE message_id = $1 AND flag = $2',
+        [messageId, normalizeDesiredFlag(flag)],
+      );
+      return deliveryFromRow(result.rows[0]);
+    },
+
+    async listPending(limit = 100) {
+      const result = await runQuery(
+        `SELECT d.*
+           FROM message_flag_deliveries d
+           JOIN messages m ON m.id = d.message_id
+           JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+          WHERE d.state IN ('pending', 'delivering', 'uncertain')
+            AND (d.state <> 'delivering' OR d.lease_expires_at IS NULL
+                 OR d.lease_expires_at <= NOW())
+            AND (d.state <> 'delivering' OR NOT EXISTS (
+              SELECT 1
+                FROM pg_locks l
+               WHERE l.locktype = 'advisory' AND l.granted = true
+                 AND l.objsubid = 1
+                 AND l.classid = (((hashtextextended(d.message_id::text || ':' || d.flag, 0) >> 32)
+                                    & 4294967295)::oid)
+                 AND l.objid = ((hashtextextended(d.message_id::text || ':' || d.flag, 0)
+                                 & 4294967295)::oid)
+            ))
+            AND m.is_deleted = false AND m.metadata_complete = true
+            AND f.is_present = true AND f.uid_validity IS NOT NULL
+            AND m.account_id = d.account_id
+            AND m.uid = d.uid AND m.folder = d.folder
+            AND f.uid_validity = d.uid_validity
+            AND f.observation_generation = d.folder_generation
+          ORDER BY d.updated_at, d.message_id, d.flag
+          LIMIT $1`,
+        [limit],
+      );
+      return result.rows.map(deliveryFromRow);
+    },
+
+    async applyPull({ accountId, folder, uidValidity, folderGeneration, rows }) {
+      if (!rows?.length) return 0;
+      return runTransaction(async tx => {
+        const observed = await tx.query(
+          `SELECT uid_validity, observation_generation, is_present
+             FROM folders
+            WHERE account_id = $1 AND path = $2
+            FOR SHARE`,
+          [accountId, folder],
+        );
+        const state = observed.rows[0];
+        if (!state || state.is_present === false || state.uid_validity == null ||
+            String(state.uid_validity) !== String(uidValidity) ||
+            String(state.observation_generation) !== String(folderGeneration)) {
+          throw rowSuperseded(`folder:${folder}`);
+        }
+        const payload = rows.map(row => ({
+          id: row.id,
+          uid: Number(row.uid),
+          read_revision: Number(row.readRevision),
+          star_revision: Number(row.starRevision),
+          is_read: row.isRead === true,
+          is_starred: row.isStarred === true,
+          modseq: row.modseq == null ? null : String(row.modseq),
+        }));
+        const result = await tx.query(
+          `WITH pulled AS (
+             SELECT * FROM jsonb_to_recordset($3::jsonb) AS p(
+               id uuid, uid bigint, read_revision bigint, star_revision bigint,
+               is_read boolean, is_starred boolean, modseq numeric
+             )
+           ), candidates AS (
+             SELECT m.id, m.is_read AS old_is_read, m.is_starred AS old_is_starred,
+                    pulled.is_read, pulled.is_starred, pulled.modseq,
+                    m.read_revision = pulled.read_revision AND NOT EXISTS (
+                      SELECT 1 FROM message_flag_deliveries d
+                       WHERE d.message_id = m.id AND d.flag = 'read'
+                         AND d.state IN ('pending', 'delivering', 'uncertain')
+                    ) AS apply_read,
+                    m.star_revision = pulled.star_revision AND NOT EXISTS (
+                      SELECT 1 FROM message_flag_deliveries d
+                       WHERE d.message_id = m.id AND d.flag = 'star'
+                         AND d.state IN ('pending', 'delivering', 'uncertain')
+                    ) AS apply_star
+               FROM messages m
+               JOIN pulled ON m.id = pulled.id AND m.uid = pulled.uid
+              WHERE m.account_id = $1 AND m.folder = $2
+                AND m.is_deleted = false AND m.metadata_complete = true
+           )
+           UPDATE messages m
+              SET is_read = CASE WHEN candidates.apply_read THEN candidates.is_read ELSE m.is_read END,
+                  is_starred = CASE WHEN candidates.apply_star THEN candidates.is_starred ELSE m.is_starred END,
+                  provider_modseq = CASE
+                    WHEN candidates.modseq IS NULL THEN m.provider_modseq
+                    WHEN m.provider_modseq IS NULL OR candidates.modseq > m.provider_modseq
+                    THEN candidates.modseq ELSE m.provider_modseq END
+             FROM candidates
+            WHERE m.id = candidates.id
+            RETURNING m.folder, candidates.old_is_read, m.is_read,
+                      candidates.old_is_starred, m.is_starred`,
+          [accountId, folder, JSON.stringify(payload)],
+        );
+        const changedRows = result.rows.filter(row =>
+          row.old_is_read !== row.is_read || row.old_is_starred !== row.is_starred);
+        const unreadDelta = result.rows.reduce((sum, row) => {
+          if (row.old_is_read === row.is_read) return sum;
+          return sum + (row.is_read === true ? -1 : 1);
+        }, 0);
+        if (unreadDelta !== 0) {
+          const count = await tx.query(
+            `UPDATE folders
+                SET unread_count = GREATEST(0, unread_count + $1)
+              WHERE account_id = $2 AND path = $3`,
+            [unreadDelta, accountId, folder],
+          );
+          if (count.rowCount !== 1) throw rowSuperseded(`folder:${folder}`);
+        }
+        return changedRows.length;
+      });
+    },
+  };
+}
+
+export const desiredFlagRepository = createPostgresDesiredFlagRepository();
+export const desiredFlagExecutor = createDesiredFlagExecutor({ repository: desiredFlagRepository });

--- a/backend/src/services/desiredFlags.leaseMigration.test.js
+++ b/backend/src/services/desiredFlags.leaseMigration.test.js
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL('../../migrations/0055_desired_flag_leases.sql', import.meta.url),
+  'utf8',
+);
+
+describe('desired flag delivery lease migration', () => {
+  it('adds a durable bounded lease expiry used by reconciliation and takeover', () => {
+    expect(migration).toMatch(/ALTER TABLE message_flag_deliveries[\s\S]*lease_expires_at\s+TIMESTAMPTZ/i);
+    expect(migration).toMatch(/message_flag_deliveries_reconcile_idx/i);
+    expect(migration).toMatch(/lease_expires_at/i);
+  });
+});

--- a/backend/src/services/desiredFlags.migration.test.js
+++ b/backend/src/services/desiredFlags.migration.test.js
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL('../../migrations/0054_desired_message_flags.sql', import.meta.url),
+  'utf8',
+);
+
+describe('desired message flags migration', () => {
+  it('adds independent monotonic read and star revisions to every message row', () => {
+    expect(migration).toMatch(/ALTER TABLE messages[\s\S]*read_revision\s+BIGINT\s+NOT NULL\s+DEFAULT\s+0/i);
+    expect(migration).toMatch(/ALTER TABLE messages[\s\S]*star_revision\s+BIGINT\s+NOT NULL\s+DEFAULT\s+0/i);
+    expect(migration).toMatch(/provider_modseq\s+NUMERIC\s*\(\s*20\s*,\s*0\s*\)/i);
+  });
+
+  it('persists one checked delivery record for each exact row and logical flag', () => {
+    expect(migration).toMatch(/CREATE TABLE message_flag_deliveries/i);
+    expect(migration).toMatch(/message_id\s+UUID\s+NOT NULL\s+REFERENCES messages\s*\(id\)\s+ON DELETE CASCADE/i);
+    expect(migration).toMatch(/flag\s+TEXT\s+NOT NULL[\s\S]*CHECK\s*\(\s*flag\s+IN\s*\(\s*'read'\s*,\s*'star'\s*\)\s*\)/i);
+    expect(migration).toMatch(/PRIMARY KEY\s*\(\s*message_id\s*,\s*flag\s*\)/i);
+    expect(migration).toMatch(/revision\s+BIGINT\s+NOT NULL/i);
+    expect(migration).toMatch(/desired_value\s+BOOLEAN\s+NOT NULL/i);
+    expect(migration).toMatch(/uid_validity\s+BIGINT\s+NOT NULL/i);
+    expect(migration).toMatch(/folder_generation\s+BIGINT\s+NOT NULL/i);
+  });
+
+  it('retains ownership, provider baseline, and predecessor uncertainty across restarts', () => {
+    expect(migration).toMatch(/attempt_generation\s+BIGINT\s+NOT NULL/i);
+    expect(migration).toMatch(/attempt_owner\s+UUID/i);
+    expect(migration).toMatch(/captured_modseq\s+NUMERIC\s*\(\s*20\s*,\s*0\s*\)/i);
+    expect(migration).toMatch(/uncertainty_tombstones\s+JSONB\s+NOT NULL\s+DEFAULT\s+'\[\]'/i);
+    expect(migration).toMatch(/state\s+TEXT\s+NOT NULL[\s\S]*pending[\s\S]*delivering[\s\S]*uncertain[\s\S]*confirmed/i);
+  });
+});

--- a/backend/src/services/desiredFlags.test.js
+++ b/backend/src/services/desiredFlags.test.js
@@ -1,0 +1,946 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DESIRED_FLAG_LEASE_MS,
+  DesiredFlagError,
+  createDesiredFlagExecutor,
+  createImapDesiredFlagSession,
+  createPostgresDesiredFlagRepository,
+  flagColumn,
+  normalizeDesiredFlag,
+} from './desiredFlags.js';
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(r => { resolve = r; });
+  return { promise, resolve };
+}
+
+function memoryRepository({
+  read = false,
+  star = false,
+  clock = { now: 0 },
+  leaseMs = 300_000,
+  onLease = null,
+  beforeRenew = null,
+} = {}) {
+  const message = {
+    id: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+    uidValidity: '101', folderGeneration: '4', read, star,
+    readRevision: 0, starRevision: 0,
+  };
+  const deliveries = new Map();
+  let tail = Promise.resolve();
+  const leaseTails = new Map();
+  const keyFor = (messageId, flag) => `${messageId}:${flag}`;
+  const clone = value => value == null ? value : structuredClone(value);
+  const assertAttempt = (row, attempt) => {
+    if (row.revision !== attempt.revision ||
+        row.attemptGeneration !== attempt.attemptGeneration ||
+        row.attemptOwner !== attempt.attemptOwner) {
+      throw new DesiredFlagError('Desired flag ownership was lost', {
+        code: 'DESIRED_FLAG_OWNERSHIP_LOST', retryable: true, uncertain: true,
+      });
+    }
+  };
+  const withTurn = async callback => {
+    const previous = tail;
+    const turn = deferred();
+    tail = turn.promise;
+    await previous;
+    try { return await callback(); } finally { turn.resolve(); }
+  };
+
+  return {
+    message,
+    deliveries,
+    clock,
+    async withDeliveryLease(messageId, flag, callback) {
+      const key = keyFor(messageId, flag);
+      const previous = leaseTails.get(key) || Promise.resolve();
+      const lease = deferred();
+      leaseTails.set(key, lease.promise);
+      await previous;
+      let active = true;
+      let released = false;
+      const release = () => {
+        if (released) return;
+        released = true;
+        lease.resolve();
+      };
+      const token = {
+        key,
+        async assertActive() {
+          if (!active) throw new DesiredFlagError('Delivery advisory session was lost', {
+            code: 'DESIRED_FLAG_LEASE_SESSION_LOST', retryable: true, uncertain: true,
+          });
+        },
+        drop() { active = false; release(); },
+      };
+      onLease?.(token);
+      try { return await callback(token); } finally {
+        active = false;
+        release();
+        if (leaseTails.get(key) === lease.promise) leaseTails.delete(key);
+      }
+    },
+    async acceptIntent({ messageId, flag, value }) {
+      return withTurn(async () => {
+        if (messageId !== message.id) throw new Error('missing row');
+        const revisionKey = `${flag}Revision`;
+        const valueKey = flag;
+        const previousValue = message[valueKey];
+        message[revisionKey] += 1;
+        message[valueKey] = value;
+        const key = keyFor(messageId, flag);
+        const previous = deliveries.get(key);
+        const tombstones = [...(previous?.uncertaintyTombstones || [])];
+        if (previous && (previous.state === 'uncertain' ||
+            (previous.state === 'delivering' && previous.providerStartedAt != null))) {
+          tombstones.push({
+            revision: previous.revision,
+            value: previous.desiredValue,
+            baseline: previous.capturedModseq,
+          });
+        }
+        const row = {
+          messageId, flag, desiredValue: value, revision: message[revisionKey],
+          accountId: message.accountId, uid: message.uid, folder: message.folder,
+          uidValidity: message.uidValidity, folderGeneration: message.folderGeneration,
+          state: 'pending', attemptGeneration: previous?.attemptGeneration || 0,
+          attemptOwner: null, capturedModseq: null,
+          uncertaintyTombstones: tombstones,
+        };
+        deliveries.set(key, row);
+        return { delivery: clone(row), changed: previousValue !== value };
+      });
+    },
+    async claim(messageId, flag, owner, lease) {
+      return withTurn(async () => {
+        if (lease?.key !== keyFor(messageId, flag)) throw new Error('delivery lease required');
+        const row = deliveries.get(keyFor(messageId, flag));
+        if (!row || row.state === 'confirmed') return clone(row);
+        if (row.state === 'delivering' && row.leaseExpiresAt > clock.now) {
+          throw new DesiredFlagError('Desired flag delivery lease is still active', {
+            code: 'DESIRED_FLAG_LEASE_ACTIVE', retryable: true, uncertain: true,
+          });
+        }
+        if (row.state === 'delivering' && row.providerStartedAt != null &&
+            !row.uncertaintyTombstones.some(item =>
+              Number(item.revision) === row.revision &&
+              Number(item.attemptGeneration) === row.attemptGeneration)) {
+          row.uncertaintyTombstones.push({
+            revision: row.revision,
+            value: row.desiredValue,
+            baseline: row.capturedModseq,
+            attemptGeneration: row.attemptGeneration,
+            reason: 'ownership-takeover',
+          });
+        }
+        row.state = 'delivering';
+        row.attemptGeneration += 1;
+        row.attemptOwner = owner;
+        row.leaseExpiresAt = clock.now + leaseMs;
+        row.capturedModseq = null;
+        row.condstore = null;
+        row.providerStartedAt = null;
+        return clone(row);
+      });
+    },
+    async renewLease(attempt) {
+      if (beforeRenew) await beforeRenew();
+      return withTurn(async () => {
+        const row = deliveries.get(keyFor(attempt.messageId, attempt.flag));
+        assertAttempt(row, attempt);
+        if (row.leaseExpiresAt <= clock.now) throw new DesiredFlagError('Delivery lease expired', {
+          code: 'DESIRED_FLAG_OWNERSHIP_LOST', retryable: true, uncertain: true,
+        });
+        row.leaseExpiresAt = clock.now + leaseMs;
+        return clone(row);
+      });
+    },
+    async recordBaseline(attempt, baseline, condstore) {
+      return withTurn(async () => {
+        const row = deliveries.get(keyFor(attempt.messageId, attempt.flag));
+        assertAttempt(row, attempt);
+        if (row.leaseExpiresAt <= clock.now) throw new DesiredFlagError('Delivery lease expired', {
+          code: 'DESIRED_FLAG_OWNERSHIP_LOST', retryable: true, uncertain: true,
+        });
+        row.capturedModseq = baseline;
+        row.condstore = condstore;
+        return clone(row);
+      });
+    },
+    async markProviderStarted(attempt) {
+      return withTurn(async () => {
+        const row = deliveries.get(keyFor(attempt.messageId, attempt.flag));
+        assertAttempt(row, attempt);
+        if (row.leaseExpiresAt <= clock.now || row.condstore == null) {
+          throw new DesiredFlagError('Delivery lease or baseline was lost', {
+            code: 'DESIRED_FLAG_OWNERSHIP_LOST', retryable: true, uncertain: true,
+          });
+        }
+        row.providerStartedAt = new Date(clock.now).toISOString();
+        return clone(row);
+      });
+    },
+    async complete(attempt, result) {
+      return withTurn(async () => {
+        const row = deliveries.get(keyFor(attempt.messageId, attempt.flag));
+        assertAttempt(row, attempt);
+        const strictProof = result.condstore && result.modseq != null &&
+          row.uncertaintyTombstones.every(item =>
+            item.baseline != null && BigInt(result.modseq) > BigInt(item.baseline));
+        const hasUncertainty = row.uncertaintyTombstones.length > 0;
+        if (result.value === row.desiredValue && (!hasUncertainty || strictProof)) {
+          row.state = 'confirmed';
+          row.uncertaintyTombstones = [];
+        } else {
+          row.state = 'uncertain';
+          if (!hasUncertainty) row.uncertaintyTombstones.push({
+            revision: row.revision,
+            value: row.desiredValue,
+            baseline: row.capturedModseq,
+            attemptGeneration: row.attemptGeneration,
+            reason: 'post-store-mismatch',
+          });
+        }
+        row.leaseExpiresAt = null;
+        row.providerStartedAt = null;
+        return clone(row);
+      });
+    },
+    async releasePending(attempt) {
+      return withTurn(async () => {
+        const row = deliveries.get(keyFor(attempt.messageId, attempt.flag));
+        assertAttempt(row, attempt);
+        row.state = row.uncertaintyTombstones.length > 0 ? 'uncertain' : 'pending';
+        row.attemptOwner = null;
+        row.leaseExpiresAt = null;
+        row.providerStartedAt = null;
+        return clone(row);
+      });
+    },
+    async markUncertain(attempt, uncertainty) {
+      return withTurn(async () => {
+        const row = deliveries.get(keyFor(attempt.messageId, attempt.flag));
+        assertAttempt(row, attempt);
+        row.state = 'uncertain';
+        row.leaseExpiresAt = null;
+        row.providerStartedAt = null;
+        row.uncertaintyTombstones.push({
+          revision: row.revision,
+          value: row.desiredValue,
+          baseline: row.capturedModseq,
+          uncertainty,
+        });
+        return clone(row);
+      });
+    },
+    async load(messageId, flag) {
+      return clone(deliveries.get(keyFor(messageId, flag)));
+    },
+  };
+}
+
+function provider({ value = false, modseq = '10', condstore = true } = {}) {
+  const state = { value, modseq: BigInt(modseq), stores: [] };
+  return {
+    state,
+    async withSession(_delivery, callback) {
+      return callback({
+        condstore,
+        async observe() {
+          return { value: state.value, modseq: condstore ? String(state.modseq) : null };
+        },
+        async store(next, { unchangedSince } = {}) {
+          state.stores.push({ value: next, unchangedSince: unchangedSince ?? null });
+          if (condstore && unchangedSince != null && BigInt(unchangedSince) < state.modseq) return false;
+          if (state.value !== next) {
+            state.value = next;
+            state.modseq += 1n;
+          }
+          return true;
+        },
+      });
+    },
+  };
+}
+
+describe('desired flag model', () => {
+  it('normalizes only the two durable logical flags', () => {
+    expect(normalizeDesiredFlag('\\Seen')).toBe('read');
+    expect(normalizeDesiredFlag('\\Flagged')).toBe('star');
+    expect(flagColumn('read')).toEqual({ value: 'is_read', revision: 'read_revision' });
+    expect(() => normalizeDesiredFlag('\\Deleted')).toThrow(/unsupported/i);
+  });
+
+  it('increments read and star revisions independently and records exact row facts', async () => {
+    const repository = memoryRepository();
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+
+    const read = await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const star = await executor.accept({ messageId: 'row-1', flag: '\\Flagged', value: true });
+    const unread = await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: false });
+
+    expect([read.delivery.revision, star.delivery.revision, unread.delivery.revision]).toEqual([1, 1, 2]);
+    expect(unread.delivery).toMatchObject({
+      messageId: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+      uidValidity: '101', folderGeneration: '4', desiredValue: false,
+    });
+    expect(repository.message).toMatchObject({ read: false, star: true, readRevision: 2, starRevision: 1 });
+  });
+
+  it('reports one unread-count transition only when the local read CAS changes value', async () => {
+    const repository = memoryRepository({ read: false });
+    const executor = createDesiredFlagExecutor({ repository });
+
+    await expect(executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true }))
+      .resolves.toMatchObject({ changed: true, unreadDelta: -1 });
+    await expect(executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true }))
+      .resolves.toMatchObject({ changed: false, unreadDelta: 0 });
+    await expect(executor.accept({ messageId: 'row-1', flag: '\\Seen', value: false }))
+      .resolves.toMatchObject({ changed: true, unreadDelta: 1 });
+    await expect(executor.accept({ messageId: 'row-1', flag: '\\Flagged', value: true }))
+      .resolves.toMatchObject({ changed: true, unreadDelta: 0 });
+  });
+
+  it('uses UNCHANGEDSINCE and confirms a clean CONDSTORE delivery', async () => {
+    const repository = memoryRepository();
+    const remote = provider({ value: false, modseq: '10', condstore: true });
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'confirmed' });
+    expect(remote.state.stores).toEqual([{ value: true, unchangedSince: '10' }]);
+    expect(remote.state.modseq).toBe(11n);
+  });
+
+  it('retains a same-MODSEQ predecessor tombstone and reasserts instead of accepting a no-op', async () => {
+    const repository = memoryRepository();
+    const remote = provider({ value: false, modseq: '10', condstore: true });
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-2' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const first = repository.deliveries.get('row-1:read');
+    first.state = 'uncertain';
+    first.capturedModseq = '10';
+    first.uncertaintyTombstones = [{ revision: 1, value: true, baseline: '10' }];
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: false });
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'uncertain' });
+    expect(remote.state.stores).toEqual([{ value: false, unchangedSince: '10' }]);
+  });
+
+  it('clears a predecessor tombstone only after the desired value is proven at a strictly greater MODSEQ', async () => {
+    const repository = memoryRepository();
+    const remote = provider({ value: true, modseq: '11', condstore: true });
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-2' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const first = repository.deliveries.get('row-1:read');
+    first.state = 'uncertain';
+    first.capturedModseq = '10';
+    first.uncertaintyTombstones = [{ revision: 1, value: true, baseline: '10' }];
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: false });
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'confirmed' });
+    expect(remote.state.stores).toEqual([{ value: false, unchangedSince: '11' }]);
+    expect(remote.state.modseq).toBe(12n);
+  });
+
+  it('keeps non-CONDSTORE uncertainty and reasserts the latest value on every reconciliation', async () => {
+    const repository = memoryRepository();
+    const remote = provider({ value: false, condstore: false });
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-2' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const first = repository.deliveries.get('row-1:read');
+    first.state = 'uncertain';
+    first.uncertaintyTombstones = [{ revision: 1, value: true, baseline: null }];
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: false });
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'uncertain' });
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'uncertain' });
+    expect(remote.state.stores).toEqual([
+      { value: false, unchangedSince: null },
+      { value: false, unchangedSince: null },
+    ]);
+  });
+
+  it('keeps an uncertainty tombstone when the provider disconnects after baseline capture', async () => {
+    const repository = memoryRepository();
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Flagged', value: true });
+    const remote = provider({ value: false, modseq: '20' });
+    remote.withSession = async (_delivery, callback) => callback({
+      condstore: true,
+      observe: async () => ({ value: false, modseq: '20' }),
+      store: async () => { throw new Error('socket disconnected'); },
+    });
+
+    await expect(executor.deliver('row-1', '\\Flagged', remote)).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_DELIVERY_UNCERTAIN', retryable: true, uncertain: true,
+    });
+    expect(repository.deliveries.get('row-1:star')).toMatchObject({ state: 'uncertain' });
+    expect(repository.deliveries.get('row-1:star').uncertaintyTombstones).toHaveLength(1);
+  });
+
+  it('keeps STORE timeout uncertainty under a lease longer than provider command timeout', async () => {
+    expect(DESIRED_FLAG_LEASE_MS).toBeGreaterThan(60_000);
+    const repository = memoryRepository();
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const store = vi.fn().mockRejectedValue(Object.assign(new Error('STORE timed out'), {
+      code: 'ETIMEDOUT',
+    }));
+    const remote = {
+      withSession: async (_delivery, callback) => callback({
+        condstore: true,
+        observe: async () => ({ value: false, modseq: '25' }),
+        store,
+      }),
+    };
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_DELIVERY_UNCERTAIN', retryable: true, uncertain: true,
+    });
+    expect(store).toHaveBeenCalledOnce();
+    expect(repository.deliveries.get('row-1:read')).toMatchObject({
+      state: 'uncertain', leaseExpiresAt: null,
+      uncertaintyTombstones: [expect.objectContaining({ baseline: '25' })],
+    });
+  });
+
+  it('does not append a permanent tombstone when observation fails before a baseline or STORE', async () => {
+    const repository = memoryRepository();
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const remote = {
+      withSession: async (_delivery, callback) => callback({
+        condstore: true,
+        observe: async () => { throw new Error('fetch failed before STORE'); },
+        store: vi.fn(),
+      }),
+    };
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_DELIVERY_UNCERTAIN',
+    });
+    expect(repository.deliveries.get('row-1:read')).toMatchObject({
+      state: 'pending', uncertaintyTombstones: [],
+    });
+  });
+
+  it.each([
+    ['provider session acquisition', ({ remote }) => {
+      remote.withSession = async () => { throw new Error('provider connect failed'); };
+    }],
+    ['advisory lock acquisition', ({ repository }) => {
+      repository.withDeliveryLease = async () => { throw new Error('advisory lock timeout'); };
+    }],
+    ['claim transaction', ({ repository }) => {
+      repository.claim = async () => { throw new Error('claim database failure'); };
+    }],
+  ])('types %s failure and preserves the accepted pending intent without a tombstone', async (_name, arrange) => {
+    const repository = memoryRepository();
+    const remote = provider();
+    const executor = createDesiredFlagExecutor({ repository });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    arrange({ repository, remote });
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_DELIVERY_UNCERTAIN', retryable: true, uncertain: true,
+    });
+    expect(repository.deliveries.get('row-1:read')).toMatchObject({
+      state: 'pending', uncertaintyTombstones: [],
+    });
+  });
+
+  it('prevents STORE and takeover when the advisory session drops inside the durable lease', async () => {
+    const renewEntered = deferred();
+    const releaseRenew = deferred();
+    let firstLease;
+    const repository = memoryRepository({
+      onLease: lease => { if (!firstLease) firstLease = lease; },
+      beforeRenew: async () => { renewEntered.resolve(); await releaseRenew.promise; },
+    });
+    const remote = provider({ value: false, modseq: '20' });
+    const store = vi.fn().mockResolvedValue(true);
+    remote.withSession = async (_delivery, callback) => callback({
+      condstore: true,
+      observe: async () => ({ value: false, modseq: '20' }),
+      store,
+    });
+    await createDesiredFlagExecutor({ repository }).accept({
+      messageId: 'row-1', flag: '\\Seen', value: true,
+    });
+    const worker1 = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    const worker2 = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-2' });
+
+    const first = worker1.deliver('row-1', '\\Seen', remote);
+    await renewEntered.promise;
+    firstLease.drop();
+    const second = worker2.deliver('row-1', '\\Seen', remote);
+    await expect(second).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_LEASE_ACTIVE', retryable: true, uncertain: true,
+    });
+    releaseRenew.resolve();
+
+    await expect(first).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_LEASE_SESSION_LOST', retryable: true, uncertain: true,
+    });
+    expect(store).not.toHaveBeenCalled();
+    expect(repository.deliveries.get('row-1:read')).toMatchObject({
+      state: 'pending', uncertaintyTombstones: [],
+    });
+  });
+
+  it('allows abandoned delivering work to be reclaimed only after durable lease expiry', async () => {
+    const clock = { now: 0 };
+    const repository = memoryRepository({ clock, leaseMs: 100 });
+    await createDesiredFlagExecutor({ repository }).accept({
+      messageId: 'row-1', flag: '\\Seen', value: true,
+    });
+    const abandoned = repository.deliveries.get('row-1:read');
+    abandoned.state = 'delivering';
+    abandoned.attemptGeneration = 1;
+    abandoned.attemptOwner = 'dead-worker';
+    abandoned.capturedModseq = '20';
+    abandoned.leaseExpiresAt = 100;
+    const remote = provider({ value: false, modseq: '21' });
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-2' });
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_LEASE_ACTIVE',
+    });
+    clock.now = 101;
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({
+      state: 'confirmed', attemptOwner: 'worker-2',
+    });
+    expect(remote.state.stores).toHaveLength(1);
+  });
+
+  it('reclaims a post-claim/pre-observe crash without creating a null-baseline tombstone', async () => {
+    const clock = { now: 101 };
+    const repository = memoryRepository({ clock, leaseMs: 100 });
+    await createDesiredFlagExecutor({ repository }).accept({
+      messageId: 'row-1', flag: '\\Seen', value: true,
+    });
+    Object.assign(repository.deliveries.get('row-1:read'), {
+      state: 'delivering', attemptGeneration: 1, attemptOwner: 'dead-worker',
+      leaseExpiresAt: 100, capturedModseq: null, providerStartedAt: null,
+    });
+    const originalClaim = repository.claim.bind(repository);
+    let claimed;
+    repository.claim = async (...args) => {
+      claimed = await originalClaim(...args);
+      return claimed;
+    };
+    const remote = provider({ value: false, modseq: '20' });
+
+    await expect(createDesiredFlagExecutor({
+      repository, ownerFactory: () => 'worker-2',
+    }).deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'confirmed' });
+    expect(claimed.uncertaintyTombstones).toEqual([]);
+    expect(remote.state.stores).toHaveLength(1);
+  });
+
+  it('reclaims a post-baseline/pre-STORE crash without manufacturing uncertainty', async () => {
+    const clock = { now: 101 };
+    const repository = memoryRepository({ clock, leaseMs: 100 });
+    await createDesiredFlagExecutor({ repository }).accept({
+      messageId: 'row-1', flag: '\\Seen', value: true,
+    });
+    Object.assign(repository.deliveries.get('row-1:read'), {
+      state: 'delivering', attemptGeneration: 1, attemptOwner: 'dead-worker',
+      leaseExpiresAt: 100, capturedModseq: '20', condstore: true,
+      providerStartedAt: null,
+    });
+    const originalClaim = repository.claim.bind(repository);
+    let claimed;
+    repository.claim = async (...args) => {
+      claimed = await originalClaim(...args);
+      return claimed;
+    };
+    const remote = provider({ value: false, modseq: '20' });
+
+    await expect(createDesiredFlagExecutor({
+      repository, ownerFactory: () => 'worker-2',
+    }).deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'confirmed' });
+    expect(claimed.uncertaintyTombstones).toEqual([]);
+    expect(remote.state.stores).toHaveLength(1);
+  });
+
+  it('preserves a post-STORE ambiguous takeover tombstone and rejects same-MODSEQ equality', async () => {
+    const clock = { now: 101 };
+    const repository = memoryRepository({ clock, leaseMs: 100 });
+    await createDesiredFlagExecutor({ repository }).accept({
+      messageId: 'row-1', flag: '\\Seen', value: true,
+    });
+    Object.assign(repository.deliveries.get('row-1:read'), {
+      state: 'delivering', attemptGeneration: 1, attemptOwner: 'dead-worker',
+      leaseExpiresAt: 100, capturedModseq: '20', condstore: true,
+      providerStartedAt: '2026-08-26T08:00:00.000Z',
+    });
+    const originalClaim = repository.claim.bind(repository);
+    let claimed;
+    repository.claim = async (...args) => {
+      claimed = await originalClaim(...args);
+      return claimed;
+    };
+    const remote = provider({ value: true, modseq: '20' });
+
+    await expect(createDesiredFlagExecutor({
+      repository, ownerFactory: () => 'worker-2',
+    }).deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({ state: 'uncertain' });
+    expect(claimed.uncertaintyTombstones).toEqual([
+      expect.objectContaining({ baseline: '20', attemptGeneration: 1 }),
+    ]);
+    expect(remote.state.stores).toHaveLength(1);
+  });
+
+  it('serializes simultaneous cross-worker claims through one provider STORE boundary', async () => {
+    const repository = memoryRepository();
+    const firstStore = deferred();
+    let enteredStores = 0;
+    const remote = provider({ value: false, modseq: '20', condstore: true });
+    remote.withSession = async (_delivery, callback) => callback({
+      condstore: true,
+      observe: async () => ({ value: remote.state.value, modseq: String(remote.state.modseq) }),
+      store: async value => {
+        enteredStores += 1;
+        await firstStore.promise;
+        remote.state.value = value;
+        remote.state.modseq += 1n;
+        return true;
+      },
+    });
+    await createDesiredFlagExecutor({ repository }).accept({
+      messageId: 'row-1', flag: '\\Seen', value: true,
+    });
+    const worker1 = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    const worker2 = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-2' });
+
+    const delivering1 = worker1.deliver('row-1', '\\Seen', remote);
+    await vi.waitFor(() => expect(enteredStores).toBe(1));
+    const delivering2 = worker2.deliver('row-1', '\\Seen', remote);
+    await Promise.resolve();
+    expect(enteredStores).toBe(1);
+    expect(repository.deliveries.get('row-1:read')).toMatchObject({ attemptOwner: 'worker-1' });
+
+    firstStore.resolve();
+    await expect(Promise.all([delivering1, delivering2])).resolves.toEqual([
+      expect.objectContaining({ state: 'confirmed' }),
+      expect.objectContaining({ state: 'confirmed' }),
+    ]);
+    expect(enteredStores).toBe(1);
+  });
+
+  it('tombstones a captured baseline when STORE succeeds but the post-value is wrong', async () => {
+    const repository = memoryRepository();
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const observe = vi.fn()
+      .mockResolvedValueOnce({ value: false, modseq: '40' })
+      .mockResolvedValueOnce({ value: false, modseq: '40' });
+    const store = vi.fn().mockResolvedValue(true);
+    const remote = { withSession: async (_delivery, callback) => callback({
+      condstore: true, observe, store,
+    }) };
+
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({
+      state: 'uncertain',
+      uncertaintyTombstones: [expect.objectContaining({ baseline: '40' })],
+    });
+
+    observe.mockReset()
+      .mockResolvedValueOnce({ value: true, modseq: '40' })
+      .mockResolvedValueOnce({ value: true, modseq: '40' });
+    await expect(executor.deliver('row-1', '\\Seen', remote)).resolves.toMatchObject({
+      state: 'uncertain',
+    });
+    expect(store).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects stale owner completion without clearing the newer desired revision', async () => {
+    const repository = memoryRepository();
+    const remote = provider({ value: false, modseq: '30' });
+    const executor = createDesiredFlagExecutor({ repository, ownerFactory: () => 'worker-1' });
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: true });
+    const gate = deferred();
+    remote.withSession = async (delivery, callback) => callback({
+      condstore: true,
+      observe: vi.fn()
+        .mockResolvedValueOnce({ value: false, modseq: '30' })
+        .mockImplementationOnce(() => gate.promise),
+      store: async () => true,
+    });
+
+    const stale = executor.deliver('row-1', '\\Seen', remote);
+    await vi.waitFor(() => expect(repository.deliveries.get('row-1:read').capturedModseq).toBe('30'));
+    await executor.accept({ messageId: 'row-1', flag: '\\Seen', value: false });
+    gate.resolve({ value: true, modseq: '31' });
+
+    await expect(stale).rejects.toMatchObject({ code: 'DESIRED_FLAG_OWNERSHIP_LOST' });
+    expect(repository.deliveries.get('row-1:read')).toMatchObject({ revision: 2, desiredValue: false, state: 'pending' });
+  });
+
+  it('adapts one exact UID to CONDSTORE observations and UNCHANGEDSINCE STORE', async () => {
+    const client = {
+      enabled: new Set(['CONDSTORE']),
+      mailbox: { noModseq: false },
+      fetchOne: vi.fn()
+        .mockResolvedValueOnce({ uid: 7, flags: new Set(), modseq: 40n })
+        .mockResolvedValueOnce({ uid: 7, flags: new Set(['\\Seen']), modseq: 41n }),
+      messageFlagsAdd: vi.fn().mockResolvedValue(true),
+      messageFlagsRemove: vi.fn(),
+    };
+    const session = createImapDesiredFlagSession(client, {
+      uid: 7, flag: 'read', desiredValue: true,
+    });
+
+    expect(session.condstore).toBe(true);
+    await expect(session.observe()).resolves.toEqual({ value: false, modseq: '40' });
+    await expect(session.store(true, { unchangedSince: '40' })).resolves.toBe(true);
+    await expect(session.observe()).resolves.toEqual({ value: true, modseq: '41' });
+    expect(client.messageFlagsAdd).toHaveBeenCalledWith('7', ['\\Seen'], {
+      uid: true, unchangedSince: 40n,
+    });
+  });
+
+  it('treats a missing exact UID observation as typed uncertainty', async () => {
+    const client = {
+      enabled: new Set(), mailbox: {}, fetchOne: vi.fn().mockResolvedValue(false),
+      messageFlagsAdd: vi.fn(), messageFlagsRemove: vi.fn(),
+    };
+    const session = createImapDesiredFlagSession(client, { uid: 7, flag: 'star' });
+    await expect(session.observe()).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_UID_NOT_FOUND', retryable: true, uncertain: true,
+    });
+  });
+});
+
+describe('Postgres desired flag repository', () => {
+  it('lists durable pending, uncertain, and abandoned delivering work for cross-process reconciliation', async () => {
+    const runQuery = vi.fn().mockResolvedValue({ rows: [{
+      message_id: 'row-1', flag: 'read', account_id: 'acct-1', uid: '7', folder: 'INBOX',
+      uid_validity: '101', folder_generation: '9', revision: '5', desired_value: true,
+      state: 'uncertain', attempt_generation: '3', attempt_owner: 'dead-worker',
+      captured_modseq: '40', condstore: true, uncertainty_tombstones: [],
+    }] });
+    const repository = createPostgresDesiredFlagRepository({ runQuery });
+
+    await expect(repository.listPending(25)).resolves.toEqual([
+      expect.objectContaining({ messageId: 'row-1', state: 'uncertain', revision: 5 }),
+    ]);
+    expect(runQuery.mock.calls[0][0]).toMatch(/state IN \('pending', 'delivering', 'uncertain'\)/);
+    expect(runQuery.mock.calls[0][0]).toMatch(/pg_locks/);
+    expect(runQuery.mock.calls[0][0]).toMatch(/locktype = 'advisory'/);
+    expect(runQuery.mock.calls[0][0]).toMatch(/lease_expires_at IS NULL[\s\S]*lease_expires_at <= NOW\(\)/);
+    expect(runQuery.mock.calls[0][0]).toMatch(/m\.is_deleted = false/);
+    expect(runQuery.mock.calls[0][0]).toMatch(/f\.is_present = true/);
+    expect(runQuery).toHaveBeenCalledWith(expect.any(String), [25]);
+  });
+
+  it('uses a session advisory lease keyed by message and flag', async () => {
+    const client = { query: vi.fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ held: true }] })
+      .mockResolvedValueOnce({ rows: [] }) };
+    const runSession = vi.fn(callback => callback(client));
+    const repository = createPostgresDesiredFlagRepository({ runSession });
+    const callback = vi.fn(async lease => {
+      await lease.assertActive();
+      return 'done';
+    });
+
+    await expect(repository.withDeliveryLease('row-1', 'read', callback)).resolves.toBe('done');
+    expect(client.query.mock.calls[0]).toEqual([
+      'SELECT pg_advisory_lock(hashtextextended($1, 0))', ['row-1:read'],
+    ]);
+    expect(client.query.mock.calls.at(-1)).toEqual([
+      'SELECT pg_advisory_unlock(hashtextextended($1, 0))', ['row-1:read'],
+    ]);
+    expect(client.query.mock.calls[1][0]).toMatch(/FROM pg_locks[\s\S]*pg_backend_pid/);
+    expect(callback).toHaveBeenCalledOnce();
+  });
+
+  it('does not reclaim a delivering row while its durable lease is unexpired', async () => {
+    const deliveryRow = {
+      message_id: 'row-1', flag: 'read', account_id: 'acct-1', uid: '7', folder: 'INBOX',
+      uid_validity: '101', folder_generation: '9', revision: '5', desired_value: true,
+      state: 'delivering', attempt_generation: '3', attempt_owner: 'worker-1',
+      lease_expires_at: '2026-08-26T08:00:00.000Z',
+      captured_modseq: '40', condstore: true, uncertainty_tombstones: [],
+    };
+    const tx = { query: vi.fn()
+      .mockResolvedValueOnce({ rows: [deliveryRow] })
+      .mockResolvedValueOnce({ rows: [] }) };
+    const client = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const repository = createPostgresDesiredFlagRepository({
+      runSession: callback => callback(client),
+      runTransaction: callback => callback(tx),
+    });
+
+    await expect(repository.withDeliveryLease('row-1', 'read', lease =>
+      repository.claim('row-1', 'read', 'worker-2', lease)
+    )).rejects.toMatchObject({ code: 'DESIRED_FLAG_LEASE_ACTIVE', retryable: true });
+    expect(tx.query.mock.calls[1][0]).toMatch(/lease_expires_at IS NULL[\s\S]*lease_expires_at <= NOW\(\)/);
+  });
+
+  it.each([
+    ['post-claim/pre-observe', null, null, 0],
+    ['post-baseline/pre-STORE', '40', null, 0],
+    ['post-STORE ambiguous', '40', '2026-08-26T08:00:00.000Z', 1],
+  ])('uses durable provider-start evidence for %s expired takeover', async (
+    _window, capturedModseq, providerStartedAt, expectedTombstones,
+  ) => {
+    const deliveryRow = {
+      message_id: 'row-1', flag: 'read', account_id: 'acct-1', uid: '7', folder: 'INBOX',
+      uid_validity: '101', folder_generation: '9', revision: '5', desired_value: true,
+      state: 'delivering', attempt_generation: '3', attempt_owner: 'worker-1',
+      lease_expires_at: '2026-08-26T07:59:00.000Z',
+      captured_modseq: capturedModseq, condstore: true,
+      provider_started_at: providerStartedAt, uncertainty_tombstones: [],
+    };
+    let updateParams;
+    const tx = { query: vi.fn(async (sql, params) => {
+      if (sql.includes('FOR UPDATE')) return { rows: [deliveryRow] };
+      if (sql.includes('UPDATE message_flag_deliveries')) {
+        updateParams = params;
+        return { rows: [{
+          ...deliveryRow,
+          state: 'delivering',
+          attempt_generation: '4',
+          attempt_owner: 'worker-2',
+          captured_modseq: null,
+          condstore: null,
+          provider_started_at: null,
+          uncertainty_tombstones: JSON.parse(params[3]),
+        }] };
+      }
+      throw new Error(`unexpected SQL: ${sql}`);
+    }) };
+    const client = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const repository = createPostgresDesiredFlagRepository({
+      runSession: callback => callback(client),
+      runTransaction: callback => callback(tx),
+    });
+
+    const claimed = await repository.withDeliveryLease('row-1', 'read', lease =>
+      repository.claim('row-1', 'read', 'worker-2', lease)
+    );
+
+    expect(JSON.parse(updateParams[3])).toHaveLength(expectedTombstones);
+    expect(claimed.uncertaintyTombstones).toHaveLength(expectedTombstones);
+    expect(tx.query.mock.calls[1][0]).toMatch(/provider_started_at = NULL/);
+  });
+
+  it('refuses to claim delivering ownership outside the advisory lease callback', async () => {
+    const runTransaction = vi.fn();
+    const repository = createPostgresDesiredFlagRepository({ runTransaction });
+
+    await expect(repository.claim('row-1', 'read', 'worker-1')).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_LEASE_REQUIRED', retryable: true,
+    });
+    expect(runTransaction).not.toHaveBeenCalled();
+  });
+
+  it('accepts one exact live row intent and adjusts unread count in the same transaction', async () => {
+    const calls = [];
+    const tx = { query: vi.fn(async (sql, params) => {
+      calls.push([sql, params]);
+      if (sql.includes('FOR UPDATE OF f, m')) return { rows: [{
+        id: 'row-1', account_id: 'acct-1', uid: '7', folder: 'INBOX',
+        is_read: false, is_starred: false, read_revision: '4', star_revision: '2',
+        uid_validity: '101', observation_generation: '9',
+      }] };
+      if (sql.includes('FROM message_flag_deliveries')) return { rows: [] };
+      if (sql.includes('UPDATE messages') && sql.includes('read_revision = read_revision + 1')) {
+        return { rowCount: 1, rows: [{ revision: '5', visible_value: true }] };
+      }
+      if (sql.includes('UPDATE folders') && sql.includes('unread_count')) return { rowCount: 1, rows: [] };
+      if (sql.includes('INSERT INTO message_flag_deliveries')) return { rowCount: 1, rows: [{
+        message_id: 'row-1', flag: 'read', account_id: 'acct-1', uid: '7', folder: 'INBOX',
+        uid_validity: '101', folder_generation: '9', revision: '5', desired_value: true,
+        state: 'pending', attempt_generation: '0', attempt_owner: null,
+        captured_modseq: null, uncertainty_tombstones: [],
+      }] };
+      throw new Error(`unexpected SQL: ${sql}`);
+    }) };
+    const repository = createPostgresDesiredFlagRepository({
+      runQuery: vi.fn(),
+      runTransaction: callback => callback(tx),
+    });
+
+    await expect(repository.acceptIntent({
+      messageId: 'row-1', flag: 'read', value: true,
+      accountId: 'acct-1', uid: 7, folder: 'INBOX', uidValidity: '101', folderGeneration: '9',
+    })).resolves.toMatchObject({ changed: true, delivery: { revision: 5, desiredValue: true } });
+
+    expect(calls[0][0]).toMatch(/JOIN folders f[\s\S]*is_present = true[\s\S]*uid_validity IS NOT NULL[\s\S]*metadata_complete = true[\s\S]*FOR UPDATE OF f, m/);
+    expect(calls.some(([sql]) => /read_revision = read_revision \+ 1/.test(sql))).toBe(true);
+    expect(calls.find(([sql]) => sql.includes('UPDATE folders'))[1]).toEqual([-1, 'acct-1', 'INBOX']);
+  });
+
+  it('rejects incomplete, deleted, absent, epochless, relocated, and reused-UID rows before mutation', async () => {
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    const repository = createPostgresDesiredFlagRepository({
+      runQuery: vi.fn(), runTransaction: callback => callback(tx),
+    });
+
+    await expect(repository.acceptIntent({
+      messageId: 'row-1', flag: 'star', value: true,
+      accountId: 'acct-1', uid: 7, folder: 'INBOX', uidValidity: '101', folderGeneration: '9',
+    })).rejects.toMatchObject({ code: 'DESIRED_FLAG_ROW_SUPERSEDED', retryable: true });
+    expect(tx.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks revision, attempt owner, and generation on every delivery transition', async () => {
+    const tx = { query: vi.fn(async (sql) => {
+      if (sql.includes('UPDATE message_flag_deliveries') && sql.includes('captured_modseq')) {
+        return { rows: [] };
+      }
+      throw new Error(`unexpected SQL: ${sql}`);
+    }) };
+    const repository = createPostgresDesiredFlagRepository({
+      runQuery: vi.fn(), runTransaction: callback => callback(tx),
+    });
+
+    await expect(repository.recordBaseline({
+      messageId: 'row-1', flag: 'read', revision: 3,
+      attemptGeneration: 7, attemptOwner: '00000000-0000-4000-8000-000000000001',
+    }, '44', true)).rejects.toMatchObject({ code: 'DESIRED_FLAG_OWNERSHIP_LOST' });
+    expect(tx.query.mock.calls[0][0]).toMatch(/revision = \$[0-9]+[\s\S]*attempt_generation = \$[0-9]+[\s\S]*attempt_owner = \$[0-9]+/);
+  });
+
+  it('applies a bulk pull only to exact rows whose captured per-flag revisions still match', async () => {
+    const calls = [];
+    const tx = { query: vi.fn(async (sql, params) => {
+      calls.push([sql, params]);
+      if (sql.includes('FOR SHARE')) return { rows: [{ uid_validity: '101', observation_generation: '9', is_present: true }] };
+      if (sql.includes('WITH pulled AS')) return { rows: [{ folder: 'INBOX', old_is_read: false, is_read: true }] };
+      if (sql.includes('UPDATE folders')) return { rowCount: 1, rows: [] };
+      throw new Error(`unexpected SQL: ${sql}`);
+    }) };
+    const repository = createPostgresDesiredFlagRepository({
+      runQuery: vi.fn(), runTransaction: callback => callback(tx),
+    });
+
+    const changed = await repository.applyPull({
+      accountId: 'acct-1', folder: 'INBOX', uidValidity: '101', folderGeneration: '9',
+      rows: [{
+        id: 'row-1', uid: 7, readRevision: 3, starRevision: 5,
+        isRead: true, isStarred: false, modseq: '51',
+      }],
+    });
+
+    expect(changed).toBe(1);
+    const update = calls.find(([sql]) => sql.includes('WITH pulled AS'));
+    expect(update[0]).toMatch(/m\.id = pulled\.id/);
+    expect(update[0]).toMatch(/m\.uid = pulled\.uid/);
+    expect(update[0]).toMatch(/m\.read_revision = pulled\.read_revision[\s\S]*AS apply_read/);
+    expect(update[0]).toMatch(/m\.star_revision = pulled\.star_revision[\s\S]*AS apply_star/);
+    expect(update[0]).not.toMatch(/WHERE[\s\S]*m\.read_revision = pulled\.read_revision[\s\S]*m\.star_revision = pulled\.star_revision/);
+    expect(update[0]).toMatch(/message_flag_deliveries[\s\S]*state IN \('pending', 'delivering', 'uncertain'\)/);
+    expect(calls.find(([sql]) => sql.includes('UPDATE folders'))[1]).toEqual([-1, 'acct-1', 'INBOX']);
+  });
+});

--- a/backend/src/services/folderObservation.js
+++ b/backend/src/services/folderObservation.js
@@ -1,0 +1,275 @@
+import { query, withTransaction } from './db.js';
+
+function tokenFromRow(row) {
+  return {
+    folder: row.path,
+    uidValidity: row.uid_validity == null ? null : String(row.uid_validity),
+    generation: String(row.observation_generation),
+    ...(row.topology_identity == null ? {} : {
+      topologyIdentity: String(row.topology_identity),
+    }),
+    isPresent: row.is_present === true,
+  };
+}
+
+function tokenList(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function throwSuperseded(folder) {
+  const err = new Error(`Newer folder observation superseded ${folder}`);
+  err.code = 'FOLDER_OBSERVATION_SUPERSEDED';
+  throw err;
+}
+
+function assertExpectedRow(row, token) {
+  if (!row || String(row.observation_generation) !== String(token.generation)) {
+    throwSuperseded(token.folder);
+  }
+  const actualValidity = row.uid_validity == null ? null : String(row.uid_validity);
+  const expectedValidity = token.uidValidity == null ? null : String(token.uidValidity);
+  if (actualValidity !== expectedValidity) {
+    const err = new Error(`UIDVALIDITY changed during ${token.folder} observation`);
+    err.code = 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED';
+    throw err;
+  }
+  if (token.topologyIdentity != null && (
+    row.topology_identity == null ||
+    String(row.topology_identity) !== String(token.topologyIdentity)
+  )) {
+    const err = new Error(`Folder topology changed during ${token.folder} observation`);
+    err.code = 'FOLDER_OBSERVATION_TOPOLOGY_CHANGED';
+    throw err;
+  }
+}
+
+export async function claimFolderObservations(accountId, paths, { context = [], expected = [] } = {}) {
+  const contextTokens = tokenList(context);
+  const expectedTokens = tokenList(expected);
+  const owned = new Set(contextTokens.map(token => token.folder));
+  const requested = [...new Set((paths || []).filter(Boolean))].sort();
+  const ordered = [...new Set([
+    ...requested,
+    ...contextTokens.map(token => token.folder),
+    ...expectedTokens.map(token => token.folder),
+  ])].sort();
+  if (ordered.length === 0) return [];
+  return withTransaction(async (tx) => {
+    const locked = await tx.query(
+      `SELECT path, uid_validity, observation_generation, topology_identity, is_present
+         FROM folders
+        WHERE account_id = $1 AND path = ANY($2::text[])
+        ORDER BY path
+        FOR UPDATE`,
+      [accountId, ordered],
+    );
+    if (locked.rows.length !== ordered.length) {
+      throw new Error('Cannot observe one or more missing folders');
+    }
+    const byPath = new Map(locked.rows.map(row => [row.path, row]));
+    for (const token of [...contextTokens, ...expectedTokens]) {
+      assertExpectedRow(byPath.get(token.folder), token);
+    }
+
+    const newlyOwned = requested.filter(folder => !owned.has(folder));
+    if (newlyOwned.length > 0) {
+      const result = await tx.query(
+        `UPDATE folders
+            SET observation_generation = observation_generation + 1
+          WHERE account_id = $1 AND path = ANY($2::text[])
+          RETURNING path, uid_validity, observation_generation, topology_identity, is_present`,
+        [accountId, newlyOwned],
+      );
+      for (const row of result.rows) byPath.set(row.path, row);
+    }
+    return ordered.map(folder => tokenFromRow(byPath.get(folder)));
+  });
+}
+
+export async function claimFolderObservation(accountId, folder, options) {
+  return (await claimFolderObservations(accountId, [folder], options))
+    .find(token => token.folder === folder);
+}
+
+export async function claimMailboxTopology(accountId) {
+  return withTransaction(async (tx) => {
+    const result = await tx.query(
+      `UPDATE email_accounts
+          SET mailbox_topology_generation = mailbox_topology_generation + 1
+        WHERE id = $1
+        RETURNING mailbox_topology_generation`,
+      [accountId],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error(`Cannot claim mailbox topology for missing account ${accountId}`);
+    return { accountId, generation: String(row.mailbox_topology_generation) };
+  });
+}
+
+export async function assertMailboxTopology(tx, accountId, token) {
+  const result = await tx.query(
+    `SELECT mailbox_topology_generation
+       FROM email_accounts
+      WHERE id = $1
+      FOR UPDATE`,
+    [accountId],
+  );
+  const generation = result.rows[0]?.mailbox_topology_generation;
+  if (generation == null || String(generation) !== String(token?.generation)) {
+    const err = new Error(`Newer mailbox topology superseded account ${accountId}`);
+    err.code = 'MAILBOX_TOPOLOGY_SUPERSEDED';
+    throw err;
+  }
+  return result.rows[0];
+}
+
+export async function commitMailboxTopology(accountId, token, mailboxes) {
+  const ordered = [...(mailboxes || [])]
+    .filter(mailbox => mailbox?.path)
+    .sort((a, b) => a.path.localeCompare(b.path));
+  const paths = ordered.map(mailbox => mailbox.path);
+  return withTransaction(async (tx) => {
+    await assertMailboxTopology(tx, accountId, token);
+    await tx.query(
+      `WITH candidate_paths AS (
+         SELECT unnest($2::text[]) AS path
+         UNION
+         SELECT path
+           FROM folders
+          WHERE account_id = $1
+       )
+       SELECT f.path
+         FROM folders f
+         JOIN candidate_paths candidate ON candidate.path = f.path
+        WHERE f.account_id = $1
+        ORDER BY f.path
+        FOR UPDATE OF f`,
+      [accountId, paths],
+    );
+    await tx.query(
+      `WITH incoming AS (
+         SELECT *
+           FROM jsonb_to_recordset($2::jsonb) AS mb(
+             path text, name text, delimiter text, special_use text, no_select boolean
+           )
+       )
+       INSERT INTO folders (
+         account_id, path, name, delimiter, special_use, no_select, is_present
+       )
+       SELECT $1, path, name, delimiter, special_use, no_select, true
+         FROM incoming
+        ORDER BY path
+       ON CONFLICT (account_id, path) DO UPDATE
+       SET name = EXCLUDED.name,
+           delimiter = EXCLUDED.delimiter,
+           special_use = EXCLUDED.special_use,
+           no_select = EXCLUDED.no_select,
+           uid_validity = CASE WHEN folders.is_present = false THEN NULL
+                               ELSE folders.uid_validity END,
+           highest_modseq = CASE WHEN folders.is_present = false THEN NULL
+                                 ELSE folders.highest_modseq END,
+           observation_generation = folders.observation_generation +
+             CASE WHEN folders.is_present = false THEN 1 ELSE 0 END,
+           topology_identity = CASE WHEN folders.is_present = false THEN gen_random_uuid()
+                                    ELSE folders.topology_identity END,
+           is_present = true,
+           updated_at = NOW()`,
+      [accountId, JSON.stringify(ordered.map(mailbox => ({
+        path: mailbox.path,
+        name: mailbox.name || mailbox.path,
+        delimiter: mailbox.delimiter ?? null,
+        special_use: mailbox.specialUse ?? mailbox.special_use ?? null,
+        no_select: mailbox.noSelect === true || mailbox.no_select === true,
+      })))],
+    );
+    const tombstoned = await tx.query(
+      `UPDATE folders
+          SET is_present = false,
+              uid_validity = NULL,
+              highest_modseq = NULL,
+              observation_generation = observation_generation + 1,
+              updated_at = NOW()
+        WHERE account_id = $1
+          AND is_present = true
+          AND path <> ALL($2::text[])
+        RETURNING path`,
+      [accountId, paths],
+    );
+    await tx.query(
+      `UPDATE messages m
+          SET metadata_complete = false
+        WHERE m.account_id = $1
+          AND m.metadata_complete = true
+          AND NOT EXISTS (
+            SELECT 1
+              FROM folders f
+             WHERE f.account_id = m.account_id
+               AND f.path = m.folder
+               AND f.is_present = true
+               AND f.uid_validity IS NOT NULL
+          )`,
+      [accountId],
+    );
+    return { tombstoned: tombstoned.rows.map(row => row.path).sort() };
+  });
+}
+
+export async function readFolderObservation(accountId, folder) {
+  const result = await query(
+    `SELECT uid_validity, observation_generation, topology_identity, is_present
+       FROM folders
+      WHERE account_id = $1 AND path = $2`,
+    [accountId, folder],
+  );
+  const row = result.rows[0];
+  if (!row) throw new Error(`Cannot observe missing folder ${folder}`);
+  return tokenFromRow({ ...row, path: folder });
+}
+
+export async function assertFolderObservation(tx, accountId, token, { checkUidValidity = true } = {}) {
+  const result = await tx.query(
+    `SELECT uid_validity, observation_generation, topology_identity, is_present
+       FROM folders
+      WHERE account_id = $1 AND path = $2
+      FOR UPDATE`,
+    [accountId, token.folder],
+  );
+  const row = result.rows[0];
+  if (!row || (token.generation != null &&
+      String(row.observation_generation) !== String(token.generation))) throwSuperseded(token.folder);
+  if (checkUidValidity) assertExpectedRow(row, token);
+  return row;
+}
+
+export async function seedFolderUidValidity(tx, accountId, token, uidValidity) {
+  if (uidValidity == null) throw new Error('Authoritative UIDVALIDITY is required');
+  const row = await assertFolderObservation(tx, accountId, token);
+  if (row.is_present !== true) {
+    const err = new Error(`Cannot seed absent folder ${token.folder}`);
+    err.code = 'FOLDER_NOT_PRESENT';
+    throw err;
+  }
+  if (row.uid_validity != null) return tokenFromRow({ ...row, path: token.folder });
+
+  await tx.query(
+    `DELETE FROM messages
+      WHERE account_id = $1 AND folder = $2
+        AND metadata_complete = false`,
+    [accountId, token.folder],
+  );
+  const seeded = await tx.query(
+    `UPDATE folders
+        SET uid_validity = $3,
+            highest_modseq = NULL,
+            updated_at = NOW()
+      WHERE account_id = $1 AND path = $2
+        AND is_present = true
+        AND uid_validity IS NULL
+        AND observation_generation = $4
+      RETURNING path, uid_validity, observation_generation, topology_identity, is_present`,
+    [accountId, token.folder, uidValidity, token.generation],
+  );
+  if (!seeded.rows[0]) throwSuperseded(token.folder);
+  return tokenFromRow(seeded.rows[0]);
+}

--- a/backend/src/services/folderObservation.test.js
+++ b/backend/src/services/folderObservation.test.js
@@ -1,0 +1,246 @@
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => ({
+  query: vi.fn(),
+  withTransaction: vi.fn(callback => callback({ query: vi.fn() })),
+}));
+
+import { query, withTransaction } from './db.js';
+import { claimFolderObservations, readFolderObservation } from './folderObservation.js';
+import * as folderObservations from './folderObservation.js';
+
+const migration = readFileSync(
+  new URL('../../migrations/0052_folder_observation_generation.sql', import.meta.url),
+  'utf8',
+);
+
+describe('folder lifecycle migration', () => {
+  it('adds durable folder presence and account topology generations and quarantines unsafe rows', () => {
+    expect(migration).toMatch(/folders[\s\S]*is_present\s+BOOLEAN\s+NOT NULL\s+DEFAULT true/i);
+    expect(migration).toMatch(/email_accounts[\s\S]*mailbox_topology_generation\s+BIGINT\s+NOT NULL\s+DEFAULT 0/i);
+    expect(migration).toMatch(/UPDATE messages[\s\S]*metadata_complete\s*=\s*false/i);
+    expect(migration).toMatch(/NOT EXISTS[\s\S]*FROM folders/i);
+    expect(migration).toMatch(/uid_validity\s+IS\s+NOT\s+NULL/i);
+    expect(migration).toMatch(/is_present\s*=\s*true/i);
+    expect(migration).toMatch(/topology_identity\s+UUID\s+NOT NULL/i);
+    expect(migration).toMatch(
+      /UPDATE folders[\s\S]*is_present\s*=\s*false[\s\S]*uid_validity\s*=\s*NULL/i,
+    );
+  });
+});
+
+describe('folder observation snapshots', () => {
+  beforeEach(() => {
+    query.mockReset();
+    withTransaction.mockReset();
+  });
+
+  it('reads a non-advancing snapshot including presence without opening a transaction', async () => {
+    query.mockResolvedValueOnce({
+      rows: [{ uid_validity: '42', observation_generation: '7', is_present: true }],
+    });
+
+    await expect(readFolderObservation('acct-1', 'INBOX')).resolves.toEqual({
+      folder: 'INBOX', uidValidity: '42', generation: '7', isPresent: true,
+    });
+
+    expect(withTransaction).not.toHaveBeenCalled();
+    expect(query.mock.calls[0][0]).toMatch(
+      /SELECT uid_validity, observation_generation, topology_identity, is_present/,
+    );
+  });
+});
+
+describe('advancing folder operation contexts', () => {
+  beforeEach(() => {
+    query.mockReset();
+    withTransaction.mockReset();
+  });
+
+  it('extends a context under sorted locks while advancing only newly owned paths', async () => {
+    const txQuery = vi.fn()
+      .mockResolvedValueOnce({ rows: [
+        { path: 'Archive', uid_validity: '22', observation_generation: '3', is_present: true },
+        { path: 'INBOX', uid_validity: '11', observation_generation: '8', is_present: true },
+      ] })
+      .mockResolvedValueOnce({ rows: [
+        { path: 'Archive', uid_validity: '22', observation_generation: '4', is_present: true },
+      ] });
+    withTransaction.mockImplementationOnce(callback => callback({ query: txQuery }));
+
+    const context = [{
+      folder: 'INBOX', uidValidity: '11', generation: '8', isPresent: true,
+    }];
+    const expected = [{
+      folder: 'Archive', uidValidity: '22', generation: '3', isPresent: true,
+    }];
+
+    await expect(claimFolderObservations('acct-1', ['Archive'], { context, expected }))
+      .resolves.toEqual([
+        { folder: 'Archive', uidValidity: '22', generation: '4', isPresent: true },
+        { folder: 'INBOX', uidValidity: '11', generation: '8', isPresent: true },
+      ]);
+
+    expect(txQuery.mock.calls[0][1]).toEqual(['acct-1', ['Archive', 'INBOX']]);
+    expect(txQuery.mock.calls[0][0]).toMatch(/ORDER BY path[\s\S]*FOR UPDATE/);
+    expect(txQuery.mock.calls[1][1]).toEqual(['acct-1', ['Archive']]);
+  });
+
+  it('rejects an expected null epoch when the same generation now has a concrete epoch', async () => {
+    const txQuery = vi.fn()
+      .mockResolvedValueOnce({ rows: [{
+        path: 'Archive', uid_validity: '99', observation_generation: '3', is_present: true,
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        path: 'Archive', uid_validity: '99', observation_generation: '4', is_present: true,
+      }] });
+    withTransaction.mockImplementationOnce(callback => callback({ query: txQuery }));
+
+    const expected = [{
+      folder: 'Archive', uidValidity: null, generation: '3', isPresent: true,
+    }];
+    await expect(claimFolderObservations('acct-1', ['Archive'], { expected }))
+      .rejects.toMatchObject({ code: 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED' });
+    expect(txQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a recreated folder incarnation even when generation and UIDVALIDITY match', async () => {
+    const txQuery = vi.fn().mockResolvedValueOnce({ rows: [{
+      path: 'Archive', uid_validity: '99', observation_generation: '3',
+      topology_identity: 'new-incarnation', is_present: true,
+    }] });
+    withTransaction.mockImplementationOnce(callback => callback({ query: txQuery }));
+
+    await expect(claimFolderObservations('acct-1', [], { context: [{
+      folder: 'Archive', uidValidity: '99', generation: '3',
+      topologyIdentity: 'old-incarnation', isPresent: true,
+    }] })).rejects.toMatchObject({ code: 'FOLDER_OBSERVATION_TOPOLOGY_CHANGED' });
+  });
+});
+
+describe('mailbox topology claims', () => {
+  beforeEach(() => {
+    query.mockReset();
+    withTransaction.mockReset();
+  });
+
+  it('claims a durable account-level topology generation', async () => {
+    const txQuery = vi.fn().mockResolvedValueOnce({
+      rows: [{ mailbox_topology_generation: '12' }],
+    });
+    withTransaction.mockImplementationOnce(callback => callback({ query: txQuery }));
+
+    const result = await folderObservations.claimMailboxTopology?.('acct-1');
+    expect(result).toEqual({ accountId: 'acct-1', generation: '12' });
+    expect(txQuery.mock.calls[0][0]).toMatch(
+      /UPDATE email_accounts[\s\S]*mailbox_topology_generation = mailbox_topology_generation \+ 1/,
+    );
+  });
+
+  it('commits a complete LIST atomically by tombstoning absence and resetting reappearances', async () => {
+    const txQuery = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ mailbox_topology_generation: '12' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ path: 'Gone' }] })
+      .mockResolvedValueOnce({ rowCount: 3, rows: [] });
+    withTransaction.mockImplementationOnce(callback => callback({ query: txQuery }));
+
+    const result = await folderObservations.commitMailboxTopology?.(
+      'acct-1',
+      { accountId: 'acct-1', generation: '12' },
+      [{
+        path: 'Archive', name: 'Archive', delimiter: '/', specialUse: '\\Archive', noSelect: false,
+      }],
+    );
+
+    expect(result).toEqual({ tombstoned: ['Gone'] });
+    expect(withTransaction).toHaveBeenCalledOnce();
+    expect(query).not.toHaveBeenCalled();
+    expect(txQuery.mock.calls[0][0]).toMatch(/email_accounts[\s\S]*FOR UPDATE/);
+    expect(txQuery.mock.calls[1][0]).toMatch(/ORDER BY f\.path[\s\S]*FOR UPDATE OF f/);
+    expect(txQuery.mock.calls[2][0]).toMatch(/ON CONFLICT[\s\S]*is_present = true/);
+    expect(txQuery.mock.calls[2][0]).toMatch(
+      /uid_validity = CASE WHEN folders\.is_present = false THEN NULL/,
+    );
+    expect(txQuery.mock.calls[2][0]).toMatch(
+      /highest_modseq = CASE WHEN folders\.is_present = false THEN NULL/,
+    );
+    expect(txQuery.mock.calls[2][0]).toMatch(
+      /observation_generation = folders\.observation_generation \+[\s\S]*is_present = false/,
+    );
+    expect(txQuery.mock.calls[3][0]).toMatch(
+      /UPDATE folders[\s\S]*is_present = false[\s\S]*uid_validity = NULL[\s\S]*observation_generation = observation_generation \+ 1/,
+    );
+    expect(txQuery.mock.calls[3][0]).not.toMatch(/DELETE FROM folders/);
+    expect(txQuery.mock.calls[4][0]).toMatch(
+      /UPDATE messages[\s\S]*metadata_complete = false[\s\S]*uid_validity IS NOT NULL/,
+    );
+  });
+
+  it('locks the complete returned/current folder union before topology writes', async () => {
+    const txQuery = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ mailbox_topology_generation: '12' }] })
+      .mockResolvedValueOnce({ rows: [
+        { path: 'Archive', is_present: true },
+        { path: 'Gone', is_present: true },
+        { path: 'Old-Tombstone', is_present: false },
+      ] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ path: 'Gone' }] })
+      .mockResolvedValueOnce({ rowCount: 2, rows: [] });
+    withTransaction.mockImplementationOnce(callback => callback({ query: txQuery }));
+
+    await folderObservations.commitMailboxTopology?.(
+      'acct-1',
+      { accountId: 'acct-1', generation: '12' },
+      [
+        { path: 'New', name: 'New' },
+        { path: 'Archive', name: 'Archive' },
+      ],
+    );
+
+    const [lockSql, lockParams] = txQuery.mock.calls[1];
+    expect(lockParams).toEqual(['acct-1', ['Archive', 'New']]);
+    expect(lockSql).toMatch(
+      /WITH candidate_paths[\s\S]*unnest\(\$2::text\[\]\)[\s\S]*UNION[\s\S]*FROM folders[\s\S]*ORDER BY f\.path[\s\S]*FOR UPDATE OF f/,
+    );
+    expect(lockSql).not.toMatch(/is_present\s*=\s*true/);
+
+    const [upsertSql, upsertParams] = txQuery.mock.calls[2];
+    expect(upsertSql).toMatch(/INSERT INTO folders/);
+    expect(JSON.parse(upsertParams[1]).map(mailbox => mailbox.path)).toEqual(['Archive', 'New']);
+    expect(upsertSql).toMatch(/FROM incoming[\s\S]*ORDER BY path[\s\S]*ON CONFLICT/);
+    expect(txQuery.mock.calls[3][0]).toMatch(/UPDATE folders/);
+  });
+});
+
+describe('authoritative folder epoch seeding', () => {
+  it('purges quarantined rows before seeding a recreated null-epoch folder', async () => {
+    const txQuery = vi.fn()
+      .mockResolvedValueOnce({ rows: [{
+        uid_validity: null, observation_generation: '9', is_present: true,
+      }] })
+      .mockResolvedValueOnce({ rowCount: 2, rows: [] })
+      .mockResolvedValueOnce({ rows: [{
+        path: 'Archive', uid_validity: '77', observation_generation: '9', is_present: true,
+      }] });
+    const token = {
+      folder: 'Archive', uidValidity: null, generation: '9', isPresent: true,
+    };
+
+    const result = await folderObservations.seedFolderUidValidity?.(
+      { query: txQuery }, 'acct-1', token, '77',
+    );
+
+    expect(result).toEqual({
+      folder: 'Archive', uidValidity: '77', generation: '9', isPresent: true,
+    });
+    expect(txQuery.mock.calls[1][0]).toMatch(
+      /DELETE FROM messages[\s\S]*metadata_complete = false/,
+    );
+    expect(txQuery.mock.calls[2][0]).toMatch(/UPDATE folders[\s\S]*uid_validity = \$3/);
+    expect(txQuery.mock.calls[2][0].split('WHERE')[0]).not.toMatch(/observation_generation\s*=/);
+  });
+});

--- a/backend/src/services/gtdDoneOperations.js
+++ b/backend/src/services/gtdDoneOperations.js
@@ -1,0 +1,280 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { withTransaction } from './db.js';
+import { readPluginThreadSnapshot } from './mailAccess.js';
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(Object.keys(value).sort().map(key => [key, canonical(value[key])]));
+}
+
+function digest(value) {
+  return createHash('sha256').update(JSON.stringify(canonical(value))).digest('hex');
+}
+
+function operationKey(userId, actedMessageId, intent, lifecycleKey) {
+  return `gtd-done:${digest({ userId, actedMessageId, intent, lifecycleKey })}`;
+}
+
+function normalizeIntent(intent) {
+  if (!Array.isArray(intent)) return intent;
+  return [...new Set(intent)].sort();
+}
+
+function normalizeOperation(row) {
+  if (!row) return null;
+  return {
+    key: row.operation_key,
+    userId: row.user_id,
+    accountId: row.account_id,
+    actedMessageId: row.acted_message_id,
+    threadKey: row.thread_key,
+    intent: row.intent,
+    planDigest: row.plan_digest,
+    plan: row.plan,
+    phase: row.phase,
+    itemIndex: Number(row.item_index || 0),
+    outcomes: Array.isArray(row.outcomes) ? row.outcomes : [],
+    response: row.response || null,
+    claimOwner: row.claim_owner || null,
+  };
+}
+
+function rowOrder(left, right) {
+  return String(left.folder).localeCompare(String(right.folder)) ||
+    Number(left.uid) - Number(right.uid) || String(left.id).localeCompare(String(right.id));
+}
+
+function anchorLast(rows, anchorId) {
+  return [...rows.filter(row => row.id !== anchorId), ...rows.filter(row => row.id === anchorId)];
+}
+
+function buildPlan(snapshot, targetFolders, archive) {
+  const rows = [...snapshot.rows].sort(rowOrder);
+  const inbox = rows.filter(row => row.folder === 'INBOX');
+  const labels = rows.filter(row => targetFolders.includes(row.folder));
+  const inboxAnchor = inbox.find(row => row.id === snapshot.anchorId) || inbox[0] || null;
+  const labelAnchor = labels.find(row => row.id === snapshot.anchorId) || labels[0] || null;
+  return {
+    snapshotVersion: snapshot.version,
+    config: snapshot.config,
+    configUpdatedAt: snapshot.configUpdatedAt,
+    activated: snapshot.activated,
+    accountTopologyGeneration: snapshot.account?.mailbox_topology_generation ?? null,
+    rows,
+    targetFolders,
+    archiveFolder: archive?.path || null,
+    archiveAllMail: archive?.special_use === '\\All',
+    archiveObservation: archive ? {
+      folder: archive.path,
+      uidValidity: String(archive.uid_validity),
+      generation: String(archive.observation_generation),
+      topologyIdentity: String(archive.topology_identity),
+      isPresent: true,
+    } : null,
+    inboxAnchorId: inboxAnchor?.id || null,
+    labelAnchorId: labelAnchor?.id || null,
+    inboxRows: anchorLast(inbox, inboxAnchor?.id),
+    labelRows: anchorLast(labels, labelAnchor?.id),
+  };
+}
+
+function operationError(message, code, status = 409, retryable = status >= 409) {
+  const error = new Error(message);
+  error.code = code;
+  error.status = status;
+  error.retryable = retryable;
+  return error;
+}
+
+const RESERVED_TARGETS = new Set(['inbox', 'sent', 'drafts', 'trash', 'junk', 'spam', 'archive']);
+function unsafeTarget(folder) {
+  const lower = String(folder || '').toLowerCase();
+  return RESERVED_TARGETS.has(lower) || lower.startsWith('[gmail]/');
+}
+
+async function resolveFrozenArchiveFolder(tx, accountId, folderMappings) {
+  const mapped = folderMappings?.archive;
+  if (typeof mapped === 'string' && mapped) {
+    const result = await tx.query(
+      `SELECT path, special_use, uid_validity, observation_generation, topology_identity FROM folders
+        WHERE account_id = $1 AND path = $2
+          AND is_present = true AND no_select = false AND uid_validity IS NOT NULL`,
+      [accountId, mapped],
+    );
+    if (result.rows[0]) return result.rows[0];
+  }
+  const result = await tx.query(
+    `SELECT path, special_use, uid_validity, observation_generation, topology_identity FROM folders
+      WHERE account_id = $1 AND is_present = true AND no_select = false AND uid_validity IS NOT NULL
+        AND (special_use = '\\Archive' OR lower(name) LIKE '%archive%' OR special_use = '\\All')
+      ORDER BY CASE
+        WHEN special_use = '\\Archive' THEN 0
+        WHEN lower(name) LIKE '%archive%' THEN 1
+        ELSE 2
+      END
+      LIMIT 1`,
+    [accountId],
+  );
+  return result.rows[0] || null;
+}
+
+export async function createOrLoadGtdDoneOperation({
+  userId, actedMessageId, intent, lifecycleKey, deriveTargetFolders,
+}) {
+  if (typeof lifecycleKey !== 'string' || !lifecycleKey.trim()) {
+    throw operationError('X-Idempotency-Key required', 'GTD_DONE_IDEMPOTENCY_KEY_REQUIRED', 400);
+  }
+  const normalizedIntent = normalizeIntent(intent);
+  const stableLifecycleKey = lifecycleKey.trim();
+  const key = operationKey(userId, actedMessageId, normalizedIntent, stableLifecycleKey);
+  return withTransaction(async tx => {
+    await tx.query('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    await tx.query('SELECT pg_advisory_xact_lock(hashtextextended($1, 0))', [key]);
+    const existing = await tx.query(
+      'SELECT * FROM gtd_done_operations WHERE operation_key = $1 FOR UPDATE',
+      [key],
+    );
+    if (existing.rows[0]) {
+      const owned = await tx.query(
+        `SELECT id FROM email_accounts
+          WHERE id = $1 AND user_id = $2 AND enabled = true`,
+        [existing.rows[0].account_id, userId],
+      );
+      if (!owned.rows[0]) throw operationError('GTD Done account is no longer owned', 'GTD_DONE_NOT_OWNED', 404);
+      return normalizeOperation(existing.rows[0]);
+    }
+
+    const snapshot = await readPluginThreadSnapshot(tx, userId, actedMessageId, 'gtd');
+    if (!snapshot) throw operationError('Message not found', 'GTD_DONE_MESSAGE_NOT_FOUND', 404);
+    if (snapshot.account?.enabled === false) {
+      throw operationError('Account is disabled', 'GTD_DONE_ACCOUNT_DISABLED', 400);
+    }
+    const fullFolders = snapshot.config?.folders || {};
+    const derived = deriveTargetFolders({
+      enabled: snapshot.config?.enabled === true && snapshot.activated,
+      folders: fullFolders,
+      states: normalizedIntent,
+      existing: snapshot.rows.map(row => row.folder),
+    });
+    if (derived?.error) throw operationError(derived.error, 'GTD_DONE_INVALID_INTENT', derived.status || 400);
+    const targetFolders = [...new Set(derived?.folders || [])];
+    if (targetFolders.some(unsafeTarget)) {
+      throw operationError('A GTD Done label cannot be a system folder', 'GTD_DONE_UNSAFE_TARGET', 400);
+    }
+    const archive = await resolveFrozenArchiveFolder(
+      tx, snapshot.account.id, snapshot.account.folder_mappings,
+    );
+    const archiveFolder = archive?.path || null;
+    if (!archive && snapshot.rows.some(row => row.folder === 'INBOX')) {
+      throw operationError(
+        'No Archive destination is configured',
+        'GTD_DONE_ARCHIVE_UNAVAILABLE',
+        409,
+        false,
+      );
+    }
+    if (String(archiveFolder || '').toLowerCase() === 'inbox') {
+      throw operationError('Archive destination cannot be INBOX', 'GTD_DONE_UNSAFE_ARCHIVE', 400);
+    }
+    if (archiveFolder && targetFolders.includes(archiveFolder)) {
+      throw operationError(
+        'A GTD Done label cannot be the Archive destination',
+        'GTD_DONE_TARGET_IS_ARCHIVE',
+        400,
+      );
+    }
+    const plan = buildPlan(snapshot, targetFolders, archive);
+    const planDigest = digest(plan);
+    const inserted = await tx.query(
+      `INSERT INTO gtd_done_operations (
+         operation_key, user_id, account_id, acted_message_id, thread_key,
+         intent, plan_digest, plan
+       ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8::jsonb)
+       ON CONFLICT (operation_key) DO UPDATE
+         SET operation_key = gtd_done_operations.operation_key
+       RETURNING *`,
+      [
+        key, userId, snapshot.account.id, actedMessageId, snapshot.threadKey,
+        JSON.stringify(normalizedIntent), planDigest, JSON.stringify(plan),
+      ],
+    );
+    const stored = normalizeOperation(inserted.rows[0]);
+    if (!stored || stored.planDigest !== planDigest) {
+      throw operationError('GTD Done operation key collided with another plan', 'GTD_DONE_PLAN_COLLISION');
+    }
+    return stored;
+  });
+}
+
+export async function advanceGtdDoneOperation(operation, nextPhase, nextIndex, outcome = null, plan = null) {
+  return withTransaction(async tx => {
+    const updated = await tx.query(
+      `UPDATE gtd_done_operations
+          SET phase = $4, item_index = $5,
+              outcomes = outcomes || $6::jsonb,
+              plan = COALESCE($8::jsonb, plan),
+              completed_at = CASE WHEN $4 = 'completed' THEN NOW() ELSE completed_at END,
+              claim_expires_at = CASE WHEN $4 = 'completed' THEN NULL ELSE NOW() + INTERVAL '30 minutes' END,
+              claim_owner = CASE WHEN $4 = 'completed' THEN NULL ELSE claim_owner END,
+              updated_at = NOW()
+        WHERE operation_key = $1 AND phase = $2 AND item_index = $3
+          AND claim_owner = $7
+        RETURNING *`,
+      [
+        operation.key, operation.phase, operation.itemIndex, nextPhase, Number(nextIndex),
+        JSON.stringify(outcome == null ? [] : [outcome]), operation.claimOwner,
+        plan == null ? null : JSON.stringify(plan),
+      ],
+    );
+    if (!updated.rows[0]) {
+      throw operationError('GTD Done operation cursor was superseded', 'GTD_DONE_OPERATION_SUPERSEDED');
+    }
+    return normalizeOperation(updated.rows[0]);
+  });
+}
+
+export async function claimGtdDoneOperation(operation) {
+  const owner = randomUUID();
+  return withTransaction(async tx => {
+    const claimed = await tx.query(
+      `UPDATE gtd_done_operations
+          SET claim_owner = $4, claim_expires_at = NOW() + INTERVAL '30 minutes', updated_at = NOW()
+        WHERE operation_key = $1 AND phase = $2 AND item_index = $3
+          AND (claim_expires_at IS NULL OR claim_expires_at <= NOW())
+        RETURNING *`,
+      [operation.key, operation.phase, operation.itemIndex, owner],
+    );
+    if (!claimed.rows[0]) {
+      throw operationError('GTD Done operation is already running', 'GTD_DONE_OPERATION_BUSY');
+    }
+    return normalizeOperation(claimed.rows[0]);
+  });
+}
+
+export async function releaseGtdDoneOperation(operation) {
+  if (!operation?.claimOwner) return;
+  await withTransaction(tx => tx.query(
+    `UPDATE gtd_done_operations
+        SET claim_owner = NULL, claim_expires_at = NULL, updated_at = NOW()
+      WHERE operation_key = $1 AND claim_owner = $2`,
+    [operation.key, operation.claimOwner],
+  ));
+}
+
+export async function renewGtdDoneOperation(operation) {
+  return withTransaction(async tx => {
+    const renewed = await tx.query(
+      `UPDATE gtd_done_operations
+          SET claim_expires_at = NOW() + INTERVAL '30 minutes', updated_at = NOW()
+        WHERE operation_key = $1 AND phase = $2 AND item_index = $3
+          AND claim_owner = $4 AND claim_expires_at > NOW()
+        RETURNING *`,
+      [operation.key, operation.phase, operation.itemIndex, operation.claimOwner],
+    );
+    if (!renewed.rows[0]) {
+      throw operationError('GTD Done operation claim was lost', 'GTD_DONE_OPERATION_SUPERSEDED');
+    }
+    return normalizeOperation(renewed.rows[0]);
+  });
+}

--- a/backend/src/services/gtdDoneOperations.migration.test.js
+++ b/backend/src/services/gtdDoneOperations.migration.test.js
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('GTD Done operation migration', () => {
+  it('keeps the frozen worklist after the acted message row disappears and constrains phase cursors', () => {
+    const sql = readFileSync(new URL('../../migrations/0059_gtd_done_operations.sql', import.meta.url), 'utf8');
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS gtd_done_operations/);
+    expect(sql).toMatch(/acted_message_id UUID NOT NULL/);
+    expect(sql).not.toMatch(/FOREIGN KEY\s*\(acted_message_id\)/i);
+    expect(sql).toMatch(/plan JSONB NOT NULL/);
+    expect(sql).toMatch(/phase TEXT NOT NULL CHECK \(phase IN \('seen', 'archive', 'labels', 'completed'\)\)/);
+    expect(sql).toMatch(/UNIQUE \(operation_key\)/);
+    expect(sql).toMatch(/claim_owner UUID/);
+    expect(sql).toMatch(/claim_expires_at TIMESTAMPTZ/);
+  });
+});

--- a/backend/src/services/gtdDoneOperations.test.js
+++ b/backend/src/services/gtdDoneOperations.test.js
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => ({
+  withTransaction: vi.fn(),
+  query: vi.fn(),
+}));
+vi.mock('../utils/mailUtils.js', () => ({
+  resolveArchiveFolder: vi.fn(),
+  isAllMailFolder: vi.fn(),
+}));
+
+import { withTransaction } from './db.js';
+import { resolveArchiveFolder, isAllMailFolder } from '../utils/mailUtils.js';
+import {
+  advanceGtdDoneOperation,
+  claimGtdDoneOperation,
+  createOrLoadGtdDoneOperation,
+} from './gtdDoneOperations.js';
+
+const label = {
+  id: 'label-1', account_id: 'acct-1', thread_key: 'thread-1', folder: 'Watch', uid: 4,
+  is_read: true, read_revision: '2', star_revision: '0',
+  folder_uid_validity: '20', folder_observation_generation: '3',
+  folder_topology_identity: 'watch-incarnation',
+};
+const inboxA = {
+  id: 'inbox-a', account_id: 'acct-1', thread_key: 'thread-1', folder: 'INBOX', uid: 7,
+  is_read: false, read_revision: '1', star_revision: '0',
+  folder_uid_validity: '10', folder_observation_generation: '5',
+  folder_topology_identity: 'inbox-incarnation',
+};
+const inboxZ = { ...inboxA, id: 'inbox-z', uid: 8 };
+const anchor = {
+  anchor_id: 'label-1', account_id: 'acct-1', thread_key: 'thread-1',
+  account: {
+    id: 'acct-1', user_id: 'user-1', enabled: true,
+    folder_mappings: {}, mailbox_topology_generation: '9',
+  },
+  plugin_config: { enabled: true, folders: { watch: 'Watch', delegated: 'Delegated' } },
+  plugin_config_updated_at: '2026-08-26T10:00:00.000Z', enabled_plugins: ['gtd'],
+};
+
+describe('durable GTD Done plan', () => {
+  beforeEach(() => {
+    withTransaction.mockReset();
+    resolveArchiveFolder.mockReset().mockResolvedValue('Archive');
+    isAllMailFolder.mockReset().mockResolvedValue(false);
+  });
+
+  it('atomically persists the frozen rows, target folders, archive destination, and deterministic retry anchors', async () => {
+    const tx = { query: vi.fn() };
+    withTransaction.mockImplementation(callback => callback(tx));
+    tx.query.mockImplementation(async (sql, params) => {
+      if (sql.startsWith('SET TRANSACTION')) return { rows: [] };
+      if (sql.includes('pg_advisory_xact_lock')) return { rows: [] };
+      if (sql.startsWith('SELECT * FROM gtd_done_operations')) return { rows: [] };
+      if (sql.includes('FROM messages m') && sql.includes('anchor_id')) return { rows: [anchor] };
+      if (sql.includes('ORDER BY m.folder')) return { rows: [inboxZ, label, inboxA] };
+      if (sql.includes('special_use') && sql.includes('lower(name)')) return { rows: [{
+        path: 'Archive', special_use: '\\Archive',
+        uid_validity: '456', observation_generation: '8',
+        topology_identity: 'archive-incarnation',
+      }] };
+      if (sql.startsWith('INSERT INTO gtd_done_operations')) return { rows: [{
+        operation_key: params[0], user_id: params[1], account_id: params[2],
+        acted_message_id: params[3], thread_key: params[4], intent: JSON.parse(params[5]),
+        plan_digest: params[6], plan: JSON.parse(params[7]), phase: 'seen', item_index: 0, outcomes: [],
+      }] };
+      return { rows: [] };
+    });
+
+    const created = await createOrLoadGtdDoneOperation({
+      userId: 'user-1', actedMessageId: 'label-1', intent: ['watch', 'delegated', 'watch'],
+      lifecycleKey: 'done-lifecycle-1',
+      deriveTargetFolders: ({ enabled, folders, states }) => {
+        expect(enabled).toBe(true);
+        expect(states).toEqual(['delegated', 'watch']);
+        expect(folders).toMatchObject({ watch: 'Watch', delegated: 'Delegated' });
+        return { folders: ['Watch', 'Delegated'] };
+      },
+    });
+
+    expect(tx.query.mock.calls[0][0]).toBe('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+    const insertParams = tx.query.mock.calls.find(call => call[0].startsWith('INSERT INTO gtd_done_operations'))[1];
+    const plan = JSON.parse(insertParams[7]);
+    expect(plan.rows).toEqual([inboxA, inboxZ, label]);
+    expect(plan.inboxRows.map(row => row.id)).toEqual(['inbox-z', 'inbox-a']);
+    expect(plan.inboxAnchorId).toBe('inbox-a');
+    expect(plan.labelRows.map(row => row.id)).toEqual(['label-1']);
+    expect(plan.labelAnchorId).toBe('label-1');
+    expect(plan.targetFolders).toEqual(['Watch', 'Delegated']);
+    expect(plan.archiveFolder).toBe('Archive');
+    expect(plan.archiveObservation).toEqual({
+      folder: 'Archive', uidValidity: '456', generation: '8',
+      topologyIdentity: 'archive-incarnation', isPresent: true,
+    });
+    expect(plan.inboxRows[0].folder_topology_identity).toBe('inbox-incarnation');
+    expect(created.phase).toBe('seen');
+  });
+
+  it('loads an unfinished operation before looking up a now-moved or deleted acted row', async () => {
+    const stored = {
+      operation_key: 'stored-key', user_id: 'user-1', account_id: 'acct-1',
+      acted_message_id: 'label-1', thread_key: 'thread-1', intent: ['watch'],
+      plan_digest: 'digest', plan: {
+        rows: [label],
+        archiveObservation: {
+          folder: 'Archive', uidValidity: '456', generation: '8', isPresent: true,
+        },
+      }, phase: 'archive', item_index: 1, outcomes: [],
+    };
+    const tx = { query: vi.fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [stored] })
+      .mockResolvedValueOnce({ rows: [{ id: 'acct-1' }] }) };
+    withTransaction.mockImplementation(callback => callback(tx));
+
+    await expect(createOrLoadGtdDoneOperation({
+      userId: 'user-1', actedMessageId: 'label-1', intent: ['watch'],
+      lifecycleKey: 'done-lifecycle-1',
+      deriveTargetFolders: vi.fn(),
+    })).resolves.toMatchObject({
+      phase: 'archive', itemIndex: 1,
+      plan: { archiveObservation: {
+        folder: 'Archive', uidValidity: '456', generation: '8', isPresent: true,
+      } },
+    });
+    expect(tx.query).toHaveBeenCalledTimes(4);
+  });
+
+  it('advances one item with an exact phase/index CAS and rejects a competing stale runner', async () => {
+    const current = {
+      key: 'stored-key', phase: 'archive', itemIndex: 0,
+      plan: { rows: [] }, outcomes: [],
+    };
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    withTransaction.mockImplementation(callback => callback(tx));
+
+    await expect(advanceGtdDoneOperation(current, 'archive', 1, { archived: true }))
+      .rejects.toMatchObject({ code: 'GTD_DONE_OPERATION_SUPERSEDED', retryable: true });
+    expect(tx.query.mock.calls[0][0]).toMatch(/phase = \$2 AND item_index = \$3/);
+  });
+
+  it('claims a phase cursor before provider work and refuses a simultaneous live claimant', async () => {
+    const current = { key: 'stored-key', phase: 'archive', itemIndex: 0, plan: {}, outcomes: [] };
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    withTransaction.mockImplementation(callback => callback(tx));
+    await expect(claimGtdDoneOperation(current))
+      .rejects.toMatchObject({ code: 'GTD_DONE_OPERATION_BUSY', retryable: true });
+    expect(tx.query.mock.calls[0][0]).toMatch(/claim_expires_at IS NULL OR claim_expires_at <= NOW\(\)/);
+  });
+
+  it('rejects a missing Archive destination as a terminal configuration outcome before persisting a plan', async () => {
+    const tx = { query: vi.fn() };
+    withTransaction.mockImplementation(callback => callback(tx));
+    tx.query.mockImplementation(async (sql) => {
+      if (sql.startsWith('SET TRANSACTION') || sql.includes('pg_advisory_xact_lock')) return { rows: [] };
+      if (sql.startsWith('SELECT * FROM gtd_done_operations')) return { rows: [] };
+      if (sql.includes('FROM messages m') && sql.includes('anchor_id')) return { rows: [anchor] };
+      if (sql.includes('ORDER BY m.folder')) return { rows: [label, inboxA] };
+      if (sql.includes('special_use') && sql.includes('lower(name)')) return { rows: [] };
+      return { rows: [] };
+    });
+
+    await expect(createOrLoadGtdDoneOperation({
+      userId: 'user-1', actedMessageId: 'label-1', intent: ['watch'],
+      lifecycleKey: 'missing-archive-1', deriveTargetFolders: () => ({ folders: ['Watch'] }),
+    })).rejects.toMatchObject({
+      code: 'GTD_DONE_ARCHIVE_UNAVAILABLE', status: 409, retryable: false,
+    });
+    expect(tx.query.mock.calls.some(call => call[0].startsWith('INSERT INTO gtd_done_operations'))).toBe(false);
+  });
+
+  it('fails closed when a resolved GTD target is the frozen physical Archive destination', async () => {
+    const tx = { query: vi.fn() };
+    withTransaction.mockImplementation(callback => callback(tx));
+    tx.query.mockImplementation(async (sql) => {
+      if (sql.startsWith('SET TRANSACTION') || sql.includes('pg_advisory_xact_lock')) return { rows: [] };
+      if (sql.startsWith('SELECT * FROM gtd_done_operations')) return { rows: [] };
+      if (sql.includes('FROM messages m') && sql.includes('anchor_id')) return { rows: [anchor] };
+      if (sql.includes('ORDER BY m.folder')) return { rows: [{ ...label, folder: 'DoneVault' }, inboxA] };
+      if (sql.includes('special_use') && sql.includes('lower(name)')) {
+        return { rows: [{ path: 'DoneVault', special_use: '\\Archive', uid_validity: '30', observation_generation: '4' }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(createOrLoadGtdDoneOperation({
+      userId: 'user-1', actedMessageId: 'label-1', intent: ['watch'],
+      lifecycleKey: 'same-folder-1', deriveTargetFolders: () => ({ folders: ['DoneVault'] }),
+    })).rejects.toMatchObject({
+      code: 'GTD_DONE_TARGET_IS_ARCHIVE', status: 400, retryable: false,
+    });
+  });
+});

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -1,5 +1,14 @@
 import { ImapFlow } from 'imapflow';
-import { query } from './db.js';
+import { query, withTransaction } from './db.js';
+import {
+  assertFolderObservation,
+  claimFolderObservation,
+  claimFolderObservations,
+  claimMailboxTopology,
+  commitMailboxTopology,
+  seedFolderUidValidity,
+  readFolderObservation,
+} from './folderObservation.js';
 import { parseMessage, snippetFromBody, detectBulkFromParsedHeaders, parseHeadersInput, headersToRawString, decodeMimeWords, enrichParsedMetadata } from './messageParser.js';
 import { classifyMessage, loadSocialDomains, getGlobalCategorizationEnabled } from './categorizer.js';
 import { pluginRegistry } from '../plugins/registry.js';
@@ -11,16 +20,61 @@ import { recordBroadcast, recordWarning } from './diagnosticsRing.js';
 import { decrypt } from './encryption.js';
 import { sendPushToUser } from './pushNotifications.js';
 import { redactEmail } from '../utils/redact.js';
-import { adjustFolderCounts, resolveSpamFolder } from '../utils/mailUtils.js';
+import { adjustFolderCounts, folderCountDeltasInLockOrder, resolveArchiveFolder, isAllMailFolder, resolveSpamFolder } from '../utils/mailUtils.js';
 import { resolveForConnection, createPinnedLookup } from './hostValidation.js';
 import { getConnectionPolicy } from './connectionPolicy.js';
 import { applyInboxRules, applyBlockList } from './inboxRules.js';
 import { generateVCard } from '../utils/vcard.js';
 import { randomUUID } from 'crypto';
+import {
+  buildProviderOperationId,
+  buildProviderOperationIdentity,
+  ProviderOperationError,
+  providerOperationMarker,
+  providerOperationExecutor,
+} from './providerOperations.js';
+import { materializeArchiveReceipt } from './archiveInbox.js';
+import { assertLiveMessageSnapshots, snapshotFromMessageRow } from './messageSnapshots.js';
+import {
+  createImapDesiredFlagSession,
+  desiredFlagExecutor,
+  desiredFlagRepository,
+} from './desiredFlags.js';
+
+// Task 3 owns this observation-lock primitive. Keeping it beside provider operations makes
+// the staged production tree self-contained even when later task work in mailUtils is omitted.
+async function lockFolderRows(tx, accountId, paths) {
+  const ordered = [...new Set((paths || []).filter(Boolean))].sort();
+  if (!ordered.length) return [];
+  const { rows } = await tx.query(
+    `SELECT path, uid_validity, observation_generation
+       FROM folders
+      WHERE account_id = $1 AND path = ANY($2::text[])
+      ORDER BY path
+      FOR UPDATE`,
+    [accountId, ordered],
+  );
+  return rows;
+}
 
 
 // Shorthand for log lines — keeps domain visible while masking the local part.
 const logAccount = (account) => redactEmail(account?.email_address || '');
+
+function isFolderObservationError(err) {
+  return err?.code === 'FOLDER_OBSERVATION_SUPERSEDED' ||
+    err?.code === 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED';
+}
+
+async function assertObservationContext(tx, accountId, observationContext) {
+  const tokens = [...(observationContext?.tokens || [])]
+    .sort((a, b) => a.folder.localeCompare(b.folder));
+  const rows = new Map();
+  for (const token of tokens) {
+    rows.set(token.folder, await assertFolderObservation(tx, accountId, token));
+  }
+  return rows;
+}
 
 // Resolves the IMAP host for an account, applying server-level connection policy.
 // Returns { resolved, policy } so callers can pass policy to makeClientCfg.
@@ -264,6 +318,7 @@ const BODY_PREFETCH_PARTS = ['1', '1.1', '1.2', '2', '2.1', '2.2', '1.1.1', '1.2
 // race so it is never confused with a real fetch error.
 const FLAG_SCAN_TIMEOUT_MS = 20000;
 const FLAG_SCAN_TIMED_OUT = Symbol('flagScanTimedOut');
+const METADATA_SYNC_BATCH_SIZE = 100;
 
 // Upper bound on how far back the delta flag scan looks. iCloud advertises CONDSTORE (so we take
 // the delta path) but IGNORES the changedSince fetch modifier — it returns EVERY message in the
@@ -344,8 +399,8 @@ const SYNC_HUNG_MS = 30 * 1000;
 // is why we don't need to touch the three pull-sync guards. Give up (clear the marker so
 // the server's truth can show through) after MAX_ATTEMPTS connected failures.
 const FLAG_PUSH_RECONCILE_MS = 15 * 1000;
-const FLAG_PUSH_MAX_ATTEMPTS = 40;   // ~10 min of connected retries before honest revert
 const FLAG_PUSH_PER_CYCLE = 30;      // cap setFlag attempts per account per cycle (bounds cycle time)
+const PROVIDER_CLEANUP_PER_CYCLE = 20;
 
 // Unicode bidi override/embedding characters that can visually reverse a filename,
 // making "malware.exe" display as "malware.pdf" to the user.
@@ -632,6 +687,70 @@ function safeDate(d) {
   return new Date();
 }
 
+// Metadata ingestion explicitly requests ENVELOPE. ImapFlow omits this property when the
+// server returns only a partial FETCH record (for example during an EXPUNGE race), while a
+// legitimate all-NIL ENVELOPE is represented as an empty object and must remain ingestible.
+function hasFetchedEnvelope(msg) {
+  return !!msg
+    && Object.prototype.hasOwnProperty.call(msg, 'envelope')
+    && !!msg.envelope
+    && typeof msg.envelope === 'object'
+    && !Array.isArray(msg.envelope);
+}
+
+// Fetch a bounded UID batch without allowing one provider-side phantom to starve all later
+// mail. A UID omitted by UID FETCH is independently re-addressed through sequence numbers:
+// plain SEARCH returns sequence numbers for real messages, while an empty result confirms that
+// the omitted UID was expunged or is a provider phantom. Any inconclusive alternate path defers
+// the whole batch so callers never advance their retry watermark past a real incomplete message.
+async function fetchCompleteMetadataBatch(client, expectedUids, fetchQuery) {
+  const orderedExpected = [...new Set(expectedUids.map(Number))]
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  const expected = new Set(orderedExpected);
+  const messagesByUid = new Map();
+  const initiallyReturned = new Set();
+
+  for await (const msg of client.fetch(orderedExpected.join(','), fetchQuery, { uid: true })) {
+    const uid = Number(msg?.uid);
+    if (!expected.has(uid) || initiallyReturned.has(uid) || !hasFetchedEnvelope(msg)) return null;
+    initiallyReturned.add(uid);
+    messagesByUid.set(uid, msg);
+  }
+
+  const omitted = orderedExpected.filter(uid => !initiallyReturned.has(uid));
+  if (omitted.length === 0) return orderedExpected.map(uid => messagesByUid.get(uid));
+
+  const sequenceResult = await client.search({ uid: omitted.join(',') }, { uid: false });
+  if (!Array.isArray(sequenceResult)) return null;
+  const sequences = [...new Set(sequenceResult.map(Number))].sort((a, b) => a - b);
+  if (sequences.length !== sequenceResult.length || sequences.some(seq => !Number.isFinite(seq) || seq < 1)) {
+    return null;
+  }
+  if (sequences.length === 0) {
+    return orderedExpected.filter(uid => messagesByUid.has(uid)).map(uid => messagesByUid.get(uid));
+  }
+
+  const omittedSet = new Set(omitted);
+  const expectedSequences = new Set(sequences);
+  const returnedSequences = new Set();
+  const recovered = new Map();
+  for await (const msg of client.fetch(sequences.join(','), fetchQuery, { uid: false })) {
+    const seq = Number(msg?.seq);
+    const uid = Number(msg?.uid);
+    if (!expectedSequences.has(seq) || returnedSequences.has(seq)
+        || !omittedSet.has(uid) || recovered.has(uid) || !hasFetchedEnvelope(msg)) {
+      return null;
+    }
+    returnedSequences.add(seq);
+    recovered.set(uid, msg);
+  }
+  if (returnedSequences.size !== sequences.length || recovered.size !== sequences.length) return null;
+  for (const [uid, msg] of recovered) messagesByUid.set(uid, msg);
+
+  return orderedExpected.filter(uid => messagesByUid.has(uid)).map(uid => messagesByUid.get(uid));
+}
+
 // Per-provider capability flags and rate-limit tuning.
 //
 // fetchBody:           store body_html/body_text during backfill/sync.
@@ -774,53 +893,186 @@ export function relocateExemptGuard(exemptFolders, paramIndex) {
 // (RETURNING is empty if a sync beat us to it), and unread only when the copy is
 // unread. Extracted (like relocateExemptGuard) so the DB behavior is unit-testable
 // without a live IMAP pool.
-export async function insertCopiedSibling(accountId, uid, fromFolder, toFolder, newUid) {
-  const res = await query(`
+export async function insertCopiedSibling(
+  accountId, uid, fromFolder, toFolder, newUid, { tx = null, receipt = null } = {},
+) {
+  if (!receipt?.marker || Number(receipt.uid) !== Number(newUid) ||
+      receipt.destinationToken?.folder !== toFolder ||
+      receipt.destinationToken?.uidValidity == null ||
+      receipt.destinationToken?.generation == null) {
+    throw new ProviderOperationError('COPY requires an exact destination receipt', {
+      code: 'COPY_DESTINATION_RECEIPT_REQUIRED', retryable: false, uncertain: true,
+    });
+  }
+  const runQuery = tx ? tx.query.bind(tx) : query;
+  const res = await runQuery(`
     INSERT INTO messages (
       account_id, uid, folder, message_id, subject,
       from_name, from_email, to_addresses, cc_addresses,
       reply_to, in_reply_to, date, snippet, is_read, is_starred,
-      has_attachments, flags, body_html, body_text, attachments,
+      has_attachments, flags,
+      body_html, body_text, attachments,
       thread_references, thread_id, is_bulk,
       read_changed_at, star_changed_at, spam_score_sa, spam_score_ml,
       spam_verdict, spam_analyzed_at, spam_details, spam_user_override,
-      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email
+      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email,
+      metadata_complete
     )
     SELECT
       account_id, $4, $5, message_id, subject,
       from_name, from_email, to_addresses, cc_addresses,
       reply_to, in_reply_to, date, snippet, is_read, is_starred,
-      has_attachments, flags, body_html, body_text, attachments,
+      has_attachments, COALESCE(flags, '[]'::jsonb) || jsonb_build_array($6::text),
+      body_html, body_text, attachments,
       thread_references, thread_id, is_bulk,
       read_changed_at, star_changed_at, spam_score_sa, spam_score_ml,
       spam_verdict, spam_analyzed_at, spam_details, spam_user_override,
-      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email
+      category, list_unsubscribe, list_unsubscribe_post, unsubscribed_at, delivery_addresses, sender_name, sender_email,
+      metadata_complete
     FROM messages
     WHERE account_id = $1 AND folder = $2 AND uid = $3
     ON CONFLICT (account_id, uid, folder) DO NOTHING
     RETURNING id, is_read
-  `, [accountId, fromFolder, uid, newUid, toFolder]);
+  `, [accountId, fromFolder, uid, newUid, toFolder, receipt.marker]);
   const row = res.rows[0];
   if (row) {
-    adjustFolderCounts(accountId, toFolder, 1, row.is_read ? 0 : 1);
+    if (tx) {
+      await adjustFolderCounts(accountId, toFolder, 1, row.is_read ? 0 : 1, {
+        strict: true,
+        query: tx.query.bind(tx),
+      });
+    } else {
+      await adjustFolderCounts(accountId, toFolder, 1, row.is_read ? 0 : 1);
+    }
+    return row.id;
   }
-  return row ? row.id : null;
+
+  const existing = await runQuery(
+    `SELECT m.id
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                     AND f.is_present = true
+                     AND f.uid_validity = $5
+                     AND f.observation_generation = $6
+      WHERE m.account_id = $1 AND m.uid = $2 AND m.folder = $3
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND m.flags @> jsonb_build_array($4::text)
+      FOR SHARE OF f, m`,
+    [
+      accountId, Number(newUid), toFolder, receipt.marker,
+      String(receipt.destinationToken.uidValidity),
+      String(receipt.destinationToken.generation),
+    ],
+  );
+  if (existing.rows.length !== 1) {
+    throw new ProviderOperationError('COPY destination row is not exact and actionable', {
+      code: 'COPY_DESTINATION_NOT_ACTIONABLE', retryable: true, uncertain: true,
+    });
+  }
+  return existing.rows[0].id;
 }
 
 // DB half of removeMessageCopy: delete exactly one folder's copy of a message. Scoped
 // to (account_id, uid, folder) — the messages unique key — so sibling rows in other
 // folders are never touched. Decrements that folder's counts off the removed row's
 // read state. Returns the number of rows removed (0 if it was already gone).
-export async function deleteMessageCopyRow(accountId, uid, folder) {
-  const res = await query(
-    'DELETE FROM messages WHERE account_id = $1 AND uid = $2 AND folder = $3 RETURNING is_read',
-    [accountId, uid, folder]
-  );
-  const row = res.rows[0];
-  if (row) {
-    adjustFolderCounts(accountId, folder, -1, row.is_read ? 0 : -1);
+export async function deleteMessageCopyRow(accountId, uid, folder, expectedId = null, { tx = null } = {}) {
+  const idClause = expectedId ? ' AND id = $4' : '';
+  const params = expectedId
+    ? [accountId, uid, folder, expectedId]
+    : [accountId, uid, folder];
+  const remove = async transaction => {
+    await lockFolderRows(transaction, accountId, [folder]);
+    const res = await transaction.query(
+      `DELETE FROM messages
+        WHERE account_id = $1 AND uid = $2 AND folder = $3${idClause}
+        RETURNING is_read`,
+      params
+    );
+    const row = res.rows[0];
+    if (row) {
+      await adjustFolderCounts(accountId, folder, -1, row.is_read ? 0 : -1, {
+        strict: true,
+        query: transaction.query.bind(transaction),
+      });
+    }
+    return row ? 1 : 0;
+  };
+  return tx ? remove(tx) : withTransaction(remove);
+}
+
+export async function reconcileMovedMessageCopyRow(accountId, row, destinationReceipt) {
+  const destinationFolder = destinationReceipt.folder;
+  const destinationUid = destinationReceipt.uid;
+  return withTransaction(async (tx) => {
+    const locked = await lockFolderRows(tx, accountId, [row.folder, destinationFolder]);
+    const epochs = new Map((locked || []).map(folder => [folder.path, folder.uid_validity]));
+    if (Object.prototype.hasOwnProperty.call(row, 'folder_uid_validity')) {
+      const sourceEpoch = epochs.get(row.folder);
+      if (sourceEpoch == null || row.folder_uid_validity == null ||
+          Number(sourceEpoch) !== Number(row.folder_uid_validity)) {
+        const err = new Error('Snapshot UIDVALIDITY changed before recovery commit');
+        err.code = 'SNAPSHOT_UIDVALIDITY_CHANGED';
+        throw err;
+      }
+    }
+    const destinationEpoch = epochs.get(destinationFolder);
+    if (destinationEpoch == null || destinationReceipt.uidValidity == null ||
+        Number(destinationEpoch) !== Number(destinationReceipt.uidValidity)) {
+      const err = new Error('Destination UIDVALIDITY changed before recovery commit');
+      err.code = 'DESTINATION_UIDVALIDITY_CHANGED';
+      throw err;
+    }
+    const target = await tx.query(
+      'SELECT id FROM messages WHERE account_id = $1 AND folder = $2 AND uid = $3 AND id <> $4 LIMIT 1',
+      [accountId, destinationFolder, destinationUid, row.id]
+    );
+    if (target.rows.length > 0) {
+      const removed = await tx.query(
+        'DELETE FROM messages WHERE id = $1 AND account_id = $2 AND folder = $3 AND uid = $4 RETURNING is_read',
+        [row.id, accountId, row.folder, row.uid]
+      );
+      const deleted = removed.rows[0];
+      if (deleted) {
+        await adjustFolderCounts(accountId, row.folder, -1, deleted.is_read ? 0 : -1, {
+          strict: true,
+          query: tx.query.bind(tx),
+        });
+      }
+      // Zero rows can mean the exact source was concurrently relocated, not that another
+      // request completed this reconciliation. Let the outer full-id confirmation decide.
+      return { reconciled: Boolean(deleted), changed: deleted ? 1 : 0 };
+    }
+
+    const moved = await tx.query(
+      'UPDATE messages SET folder = $1, uid = $2, synced_at = NOW() WHERE id = $3 AND account_id = $4 AND folder = \'INBOX\' AND uid = $5 RETURNING is_read',
+      [destinationFolder, destinationUid, row.id, accountId, row.uid]
+    );
+    const updated = moved.rows[0] || (moved.rowCount > 0 ? { is_read: row.is_read } : null);
+    if (!updated) return { reconciled: false, changed: 0 };
+    const unreadDelta = updated.is_read ? 0 : 1;
+    const options = { strict: true, query: tx.query.bind(tx) };
+    const deltas = folderCountDeltasInLockOrder([
+      { path: 'INBOX', totalDelta: -1, unreadDelta: unreadDelta ? -unreadDelta : 0 },
+      { path: destinationFolder, totalDelta: 1, unreadDelta },
+    ]);
+    for (const { path, totalDelta, unreadDelta: folderUnreadDelta } of deltas) {
+      await adjustFolderCounts(accountId, path, totalDelta, folderUnreadDelta, options);
+    }
+    return { reconciled: true, changed: 1 };
+  });
+}
+
+async function confirmLocalMessageCopyGone(row) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const remaining = await query(
+      'SELECT 1 FROM messages WHERE id = $1 AND account_id = $2 LIMIT 1',
+      [row.id, row.account_id]
+    );
+    if (remaining.rows.length === 0) return true;
+    if (attempt < 2) await new Promise(resolve => setTimeout(resolve, 25));
   }
-  return row ? 1 : 0;
+  return false;
 }
 
 // Notify label-feed plugins that an ordinary mail mutation changed the messages table outside
@@ -874,44 +1126,63 @@ export function connectStaggerFor(profile, accountCount) {
 const connectionPools = new Map(); // accountId -> { clients: [], waiting: [] }
 const POOL_SIZE = 2;
 
-// When a message moves folders (same Message-ID, new UID), refresh metadata too —
-// otherwise a draft→sent relocate can leave subject/addresses stale forever.
-const RELOCATE_MESSAGE_SQL = `
-  UPDATE messages SET
-    folder = $1::text,
-    uid = $2::bigint,
-    is_deleted = false,
-    subject = CASE
-      WHEN $5::text IS NOT NULL AND $5::text <> '' AND $5::text <> '(no subject)'
-      THEN $5::text ELSE messages.subject END,
-    from_name = COALESCE(NULLIF($6::text, ''), messages.from_name),
-    from_email = COALESCE(NULLIF($7::text, ''), messages.from_email),
-    to_addresses = CASE
-      WHEN $8::jsonb::text IS NOT NULL AND $8::jsonb::text <> '[]'
-      THEN $8::jsonb ELSE messages.to_addresses END,
-    cc_addresses = CASE
-      WHEN $9::jsonb::text IS NOT NULL AND $9::jsonb::text <> '[]'
-      THEN $9::jsonb ELSE messages.cc_addresses END,
-    reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), $10::text)::jsonb,
-    date = $11::timestamptz
-  WHERE account_id = $3::uuid
-    AND message_id = $4::text
-    AND (folder != $1::text OR uid != $2::bigint)
-    AND 1 = (SELECT COUNT(*) FROM messages WHERE account_id = $3::uuid AND message_id = $4::text)
-    AND COALESCE((SELECT special_use FROM folders WHERE account_id = $3::uuid AND path = $1::text), '') NOT IN ('\\All', '\\Important')`;
-
-function relocateMessageParams(folder, parsed, accountId, msgId) {
-  return [
-    folder, parsed.uid, accountId, msgId,
-    sanitizeStr(parsed.subject),
-    sanitizeStr(parsed.fromName),
-    sanitizeStr(parsed.fromEmail),
-    JSON.stringify(parsed.to),
-    JSON.stringify(parsed.cc),
-    JSON.stringify(parsed.replyTo || []),
-    safeDate(parsed.date),
-  ];
-}
+// A verified FETCH that lands on an unverified legacy row must replace the complete
+// manufactured envelope, not merely fill a few empty strings before declaring the row
+// complete. Complete rows retain the historical conservative merge/local-wins behavior.
+export const COMPLETE_METADATA_CONFLICT_UPDATE_SQL = `
+  message_id = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.message_id ELSE messages.message_id END,
+  subject = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.subject ELSE
+    CASE WHEN EXCLUDED.subject IS NOT NULL AND EXCLUDED.subject != '' AND EXCLUDED.subject != '(no subject)'
+         THEN EXCLUDED.subject ELSE messages.subject END END,
+  from_name = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.from_name
+                   ELSE COALESCE(NULLIF(EXCLUDED.from_name, ''), messages.from_name) END,
+  from_email = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.from_email
+                    ELSE COALESCE(NULLIF(EXCLUDED.from_email, ''), messages.from_email) END,
+  to_addresses = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.to_addresses ELSE
+    CASE WHEN EXCLUDED.to_addresses::text IS NOT NULL AND EXCLUDED.to_addresses::text <> '[]'
+         THEN EXCLUDED.to_addresses ELSE messages.to_addresses END END,
+  cc_addresses = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.cc_addresses ELSE
+    CASE WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
+         THEN EXCLUDED.cc_addresses ELSE messages.cc_addresses END END,
+  reply_to = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.reply_to
+                  ELSE COALESCE(NULLIF(messages.reply_to::text, '[]'), EXCLUDED.reply_to::text)::jsonb END,
+  in_reply_to = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.in_reply_to
+                     ELSE COALESCE(messages.in_reply_to, EXCLUDED.in_reply_to) END,
+  date = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.date ELSE messages.date END,
+  snippet = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.snippet ELSE
+    CASE WHEN EXCLUDED.snippet != '' THEN EXCLUDED.snippet ELSE messages.snippet END END,
+  is_read = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.is_read ELSE messages.is_read END,
+  is_starred = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.is_starred ELSE messages.is_starred END,
+  has_attachments = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.has_attachments
+                         ELSE messages.has_attachments END,
+  flags = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.flags ELSE EXCLUDED.flags END,
+  body_html = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.body_html
+                   ELSE COALESCE(messages.body_html, EXCLUDED.body_html) END,
+  body_text = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.body_text
+                   ELSE COALESCE(messages.body_text, EXCLUDED.body_text) END,
+  attachments = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.attachments
+                     ELSE COALESCE(messages.attachments::text, EXCLUDED.attachments::text)::jsonb END,
+  thread_references = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.thread_references
+                           ELSE COALESCE(messages.thread_references, EXCLUDED.thread_references) END,
+  thread_id = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.thread_id ELSE
+    CASE WHEN messages.thread_id = messages.message_id AND EXCLUDED.thread_id IS NOT NULL
+                   AND EXCLUDED.thread_id <> messages.message_id
+         THEN EXCLUDED.thread_id ELSE COALESCE(messages.thread_id, EXCLUDED.thread_id) END END,
+  is_bulk = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.is_bulk
+                 ELSE COALESCE(messages.is_bulk, EXCLUDED.is_bulk) END,
+  category = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.category
+                  ELSE COALESCE(messages.category, EXCLUDED.category) END,
+  list_unsubscribe = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.list_unsubscribe
+                          ELSE COALESCE(messages.list_unsubscribe, EXCLUDED.list_unsubscribe) END,
+  list_unsubscribe_post = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.list_unsubscribe_post
+                               ELSE COALESCE(messages.list_unsubscribe_post, EXCLUDED.list_unsubscribe_post) END,
+  delivery_addresses = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.delivery_addresses
+                            ELSE COALESCE(messages.delivery_addresses, EXCLUDED.delivery_addresses) END,
+  sender_name = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.sender_name
+                     ELSE COALESCE(EXCLUDED.sender_name, messages.sender_name) END,
+  sender_email = CASE WHEN NOT messages.metadata_complete THEN EXCLUDED.sender_email
+                      ELSE COALESCE(EXCLUDED.sender_email, messages.sender_email) END,
+  metadata_complete = true`;
 
 // Label-aware relocate: exempt label folders are excluded from relocation because a labeled
 // message intentionally lives as sibling rows in several folders, and relocating in place would
@@ -927,14 +1198,6 @@ function relocateMessageParams(folder, parsed, accountId, msgId) {
 export async function collectRelocateExemptFolders(account) {
   const sets = await pluginRegistry.collectHook('relocateExemptFolders', { account, accountId: account.id });
   return [...new Set(sets.flat().filter(Boolean))];
-}
-
-function relocateMessageQuery(folder, parsed, accountId, msgId, exemptFolders) {
-  const guard = relocateExemptGuard(exemptFolders, 12);
-  return {
-    sql: `${RELOCATE_MESSAGE_SQL}${guard.clause}\n  RETURNING id`,
-    params: [...relocateMessageParams(folder, parsed, accountId, msgId), ...guard.params],
-  };
 }
 
 // Strip null bytes that PostgreSQL's UTF-8 encoding rejects (some emails contain them)
@@ -1100,7 +1363,9 @@ function drainWaiters(pool) {
 async function acquirePooledClient(account) {
   const id = account.id;
   if (!connectionPools.has(id)) {
-    connectionPools.set(id, { clients: [], inUse: new Set(), waiters: [] });
+    connectionPools.set(id, {
+      clients: [], inUse: new Set(), waiters: [], temporaryClients: new Set(), evicted: false,
+    });
   }
   const pool = connectionPools.get(id);
 
@@ -1128,6 +1393,12 @@ async function acquirePooledClient(account) {
         drainWaiters(p);
       }
     });
+    // The pool can be evicted while connectImapClient is awaiting the handshake. Do not
+    // resurrect that generation with a freshly connected but already stale session.
+    if (pool.evicted || connectionPools.get(id) !== pool) {
+      abortPoolClients([client]);
+      throw new Error('IMAP pool evicted during connect');
+    }
     pool.clients.push(client);
     pool.inUse.add(client);
     return client;
@@ -1142,6 +1413,10 @@ async function acquirePooledClient(account) {
         const freshAccount = await ensureFreshToken(account);
         const { resolved, policy } = await resolveAccountHost(freshAccount);
         const tmp = await connectImapClient(freshAccount, resolved, { policy }, 30000, 'IMAP temp connect');
+        if (!registerTemporaryPoolClient(pool, tmp)) {
+          reject(new Error('IMAP pool evicted during temporary connect'));
+          return;
+        }
         resolve(tmp);
       } catch (err) {
         reject(err);
@@ -1153,8 +1428,15 @@ async function acquirePooledClient(account) {
 
 function releasePooledClient(account, client) {
   const pool = connectionPools.get(account.id);
-  if (!pool) { client.logout().catch(() => {}); return; }
+  if (!pool) {
+    try { client.close(); } catch { /* already closed */ }
+    return;
+  }
   pool.inUse.delete(client);
+  if (pool.temporaryClients.delete(client)) {
+    client.logout().catch(() => {});
+    return;
+  }
   // If this client isn't in our pool (was a temp or already evicted on error),
   // log it out. logout() is async — must use .catch() not try/catch.
   if (!pool.clients.includes(client)) {
@@ -1164,13 +1446,88 @@ function releasePooledClient(account, client) {
   }
 }
 
+export function abortPoolClients(clients) {
+  for (const client of clients) {
+    // ImapFlow logout is graceful and queues LOGOUT behind an active command. Epoch
+    // eviction is a correctness fence: close the socket synchronously so a stale UID
+    // fetch cannot complete after UIDVALIDITY has changed.
+    try { client.close(); } catch { /* already closed */ }
+  }
+}
+
+export function registerTemporaryPoolClient(pool, client) {
+  if (pool.evicted) {
+    abortPoolClients([client]);
+    return false;
+  }
+  pool.temporaryClients.add(client);
+  return true;
+}
+
+export function abortConnectionPool(pool) {
+  pool.evicted = true;
+  abortPoolClients([...pool.clients, ...pool.temporaryClients]);
+  const evictErr = new Error('IMAP pool evicted');
+  for (const entry of pool.waiters) {
+    clearTimeout(entry.timer);
+    entry.reject(evictErr);
+  }
+}
+
 function evictPool(accountId) {
   const pool = connectionPools.get(accountId);
   if (!pool) return;
-  for (const c of pool.clients) { c.logout().catch(() => {}); }
-  const evictErr = new Error('IMAP pool evicted');
-  for (const entry of pool.waiters) { clearTimeout(entry.timer); entry.reject(evictErr); }
+  abortConnectionPool(pool);
   connectionPools.delete(accountId);
+}
+
+// Fence a pooled UID command against cross-process UIDVALIDITY transitions. The shared
+// folder-row lock is held for the entire IMAP operation: a transition's FOR UPDATE must
+// wait for an old-epoch command to finish, while a command arriving after the transition
+// sees the new durable epoch and aborts every process-local pooled session before using UID.
+export async function withUidEpochFence(
+  accountId, folder, client, operation, expectedUidValidity = undefined,
+  observationContext = null, messageSnapshots = []
+) {
+  const selectedValidity = client.mailbox?.uidValidity != null
+    ? Number(client.mailbox.uidValidity)
+    : null;
+  return withTransaction(async (tx) => {
+    const states = observationContext
+      ? await assertObservationContext(tx, accountId, observationContext)
+      : null;
+    const state = states?.get(folder) || await tx.query(
+      `SELECT uid_validity FROM folders
+        WHERE account_id = $1 AND path = $2
+        FOR SHARE`,
+      [accountId, folder]
+    ).then(result => result.rows[0]);
+    const durableValidity = state?.uid_validity != null
+      ? Number(state.uid_validity)
+      : null;
+    if (expectedUidValidity !== undefined && (
+      expectedUidValidity == null ||
+      durableValidity == null ||
+      Number(expectedUidValidity) !== durableValidity
+    )) {
+      evictPool(accountId);
+      try { client.close(); } catch { /* already closed */ }
+      const err = new Error(`Snapshot UIDVALIDITY changed before ${folder} operation`);
+      err.code = 'SNAPSHOT_UIDVALIDITY_CHANGED';
+      throw err;
+    }
+    if (durableValidity != null && selectedValidity !== durableValidity) {
+      evictPool(accountId);
+      try { client.close(); } catch { /* already closed */ }
+      const err = new Error(`UIDVALIDITY mismatch for pooled ${folder} operation`);
+      err.code = 'POOLED_UIDVALIDITY_CHANGED';
+      throw err;
+    }
+    if (messageSnapshots.length > 0) {
+      await assertLiveMessageSnapshots(tx, accountId, messageSnapshots);
+    }
+    return operation(tx);
+  });
 }
 
 async function withFreshClient(account, fn) {
@@ -1193,6 +1550,25 @@ async function withFreshClient(account, fn) {
   } finally {
     releasePooledClient(account, client);
   }
+}
+
+async function withFencedUidClient(account, folder, operation, {
+  acquire = withFreshClient,
+  expectedUidValidity = undefined,
+  observationContext = null,
+  messageSnapshots = [],
+} = {}) {
+  return acquire(account, async (client) => {
+    const lock = await client.getMailboxLock(folder);
+    try {
+      return await withUidEpochFence(
+        account.id, folder, client, (tx) => operation(client, tx), expectedUidValidity,
+        observationContext, messageSnapshots
+      );
+    } finally {
+      lock.release();
+    }
+  });
 }
 
 // Like withFreshClient, but bypasses the pool entirely: it opens a BRAND-NEW IMAP login,
@@ -1271,6 +1647,88 @@ export async function ensureMailbox(client, path, { resolvePath = false } = {}) 
   }
 }
 
+async function bufferMailboxTopology(client) {
+  const mailboxes = await client.list();
+  if (!Array.isArray(mailboxes)) throw new Error('IMAP LIST returned an incomplete result');
+  if (mailboxes.length === 0) throw new Error('IMAP LIST returned an empty LIST result');
+  const byPath = new Map();
+  for (const mb of mailboxes) {
+    if (!mb || typeof mb.path !== 'string' || !mb.path) {
+      throw new Error('IMAP LIST returned an invalid mailbox entry');
+    }
+    const noSelect = !!(mb.flags && (
+      mb.flags.has('\\Noselect') || mb.flags.has('\\NonExistent')
+    ));
+    byPath.set(mb.path, {
+      path: mb.path,
+      name: mb.name || mb.path,
+      delimiter: mb.delimiter ?? null,
+      specialUse: mb.specialUse || null,
+      noSelect,
+    });
+  }
+  if (![...byPath.keys()].some(path => path.toUpperCase() === 'INBOX')) {
+    throw new Error('IMAP LIST result is missing mandatory INBOX');
+  }
+  return [...byPath.values()];
+}
+
+export async function mutateMailboxTopology(account, client, providerMutation) {
+  const topologyToken = await claimMailboxTopology(account.id);
+  const result = await providerMutation(client);
+  const mailboxes = await bufferMailboxTopology(client);
+  await commitMailboxTopology(account.id, topologyToken, mailboxes);
+  return result;
+}
+
+// A freshly created or newly discovered mailbox has a durable topology row but no UID epoch
+// until it has been selected once. Provider operations cannot safely address that mailbox before
+// the epoch exists, so ensure-folder does not return the mailbox as usable until it has seeded the
+// exact observation from a SELECT. Existing authoritative observations avoid the extra round trip.
+export async function ensureMailboxTopology(account, client, path, opts = {}) {
+  const result = await mutateMailboxTopology(
+    account,
+    client,
+    current => ensureMailbox(current, path, opts),
+  );
+  const folder = result?.path || String(path);
+  const observation = await readFolderObservation(account.id, folder);
+  if (observation.uidValidity != null) return result;
+
+  const token = await claimFolderObservation(account.id, folder);
+  const lock = await client.getMailboxLock(folder);
+  try {
+    const uidValidity = client.mailbox?.uidValidity;
+    if (uidValidity == null) {
+      const err = new Error(`Could not establish UIDVALIDITY for ${folder}`);
+      err.code = 'FOLDER_UIDVALIDITY_UNAVAILABLE';
+      throw err;
+    }
+    await withTransaction(tx => seedFolderUidValidity(
+      tx, account.id, token, uidValidity,
+    ));
+  } finally {
+    lock.release();
+  }
+  return result;
+}
+
+export function createMailboxTopology(account, client, path) {
+  return mutateMailboxTopology(account, client, current => current.mailboxCreate(path));
+}
+
+export function deleteMailboxTopology(account, client, path) {
+  return mutateMailboxTopology(account, client, current => current.mailboxDelete(path));
+}
+
+export function renameMailboxTopology(account, client, oldPath, newPath) {
+  return mutateMailboxTopology(
+    account,
+    client,
+    current => current.mailboxRename(oldPath, newPath),
+  );
+}
+
 // Resolve the server's REAL casing for a mailbox that already exists, by case-insensitive
 // lookup against the folder LIST. On a case-insensitive server "TODO" can already exist when
 // "Todo" was requested; imapflow's already-exists result echoes the REQUESTED casing, which,
@@ -1289,9 +1747,385 @@ async function resolveServerFolderCasing(client, knownPath) {
   }
 }
 
+// Missing PERMANENTFLAGS means the server did not restrict keywords; an explicit \* permits
+// new keywords. A mailbox that advertises only named flags must explicitly include ours.
+export function recoveryKeywordAllowed(mailbox, keyword) {
+  const permanentFlags = mailbox?.permanentFlags;
+  return !permanentFlags || permanentFlags.has('\\*') || permanentFlags.has(keyword);
+}
+
+function terminalProviderCapability(message, code) {
+  return new ProviderOperationError(message, {
+    code, retryable: false, uncertain: false, manual: false,
+  });
+}
+
+export function validateFrozenMoveCapabilities(resource, marker, {
+  role = 'Source', requireMove = role === 'Source',
+} = {}) {
+  if (requireMove && !resource?.client?.capabilities?.has('MOVE')) {
+    throw terminalProviderCapability(
+      'Causal provider operation requires native IMAP MOVE support',
+      'PROVIDER_NATIVE_MOVE_UNSUPPORTED',
+    );
+  }
+  if (!recoveryKeywordAllowed(resource?.client?.mailbox, marker)) {
+    throw terminalProviderCapability(
+      `${role} mailbox does not support a safe provider recovery marker`,
+      'PROVIDER_RECOVERY_MARKER_UNSUPPORTED',
+    );
+  }
+}
+
+export function normalizeFrozenMailboxAcquisitionError(error, folders = []) {
+  const statuses = [error?.code, error?.responseStatus, error?.serverResponseCode]
+    .filter(Boolean)
+    .map(value => String(value).toUpperCase());
+  const text = String(error?.responseText || error?.message || '').toLowerCase();
+  const explicitlyMissing = statuses.includes('NONEXISTENT')
+    || /no such (mailbox|folder)/.test(text)
+    || /(mailbox|folder).*(does not exist|doesn't exist|not found|nonexistent)/.test(text);
+  if (!explicitlyMissing) return error;
+  return terminalProviderCapability(
+    `Frozen provider mailbox was deleted or renamed: ${folders.join(', ')}`,
+    'PROVIDER_MAILBOX_SUPERSEDED',
+  );
+}
+
+// SEARCH returning false is a command failure in ImapFlow, never proof of absence. Destination
+// recovery is valid only when one exact message carries the deterministic keyword.
+export async function findSingleRecoveryKeywordUid(client, keyword) {
+  const found = await client.search({ keyword }, { uid: true });
+  if (found === false) throw new Error(`IMAP SEARCH failed for recovery keyword ${keyword}`);
+  const uids = [...new Set((found || []).map(Number).filter(Number.isFinite))];
+  if (uids.length > 1) throw new Error(`Ambiguous recovery keyword ${keyword}: ${uids.length} matches`);
+  return uids[0] ?? null;
+}
+
+function normalizeMessageId(value) {
+  let normalized = String(value || '').trim();
+  if (normalized.startsWith('<') && normalized.endsWith('>')) {
+    normalized = normalized.slice(1, -1).trim();
+  }
+  return normalized;
+}
+
+export async function findSingleMessageIdUid(client, messageId) {
+  const expectedMessageId = normalizeMessageId(messageId);
+  if (!expectedMessageId) throw new Error('Message-ID is required for recovery');
+  const found = await client.search({ header: ['Message-ID', expectedMessageId] }, { uid: true });
+  if (found === false) throw new Error(`IMAP SEARCH failed for Message-ID ${expectedMessageId}`);
+  const uids = [...new Set((found || []).map(Number).filter(Number.isFinite))];
+  if (!uids.length) return null;
+
+  const exactUids = [];
+  for (const uid of uids) {
+    const candidate = await client.fetchOne(String(uid), { headers: ['message-id'] }, { uid: true });
+    if (!candidate) throw new Error(`Could not verify Message-ID ${expectedMessageId} at uid=${uid}`);
+    if (candidate.uid != null && Number(candidate.uid) !== uid) {
+      throw new Error(`Message-ID verification returned uid=${candidate.uid}, expected uid=${uid}`);
+    }
+    const candidateMessageId = normalizeMessageId(parseHeadersInput(candidate.headers)['message-id']);
+    if (candidateMessageId === expectedMessageId) exactUids.push(uid);
+  }
+  if (exactUids.length > 1) {
+    throw new Error(`Ambiguous Message-ID ${expectedMessageId}: ${exactUids.length} exact matches`);
+  }
+  if (!exactUids.length) {
+    throw new Error(`Message-ID candidate set does not exactly match ${expectedMessageId}`);
+  }
+  return exactUids[0];
+}
+
+export async function searchContainsExactUid(client, uid, extraQuery = {}) {
+  const found = await client.search({ uid: String(uid), ...extraQuery }, { uid: true });
+  if (found === false) throw new Error(`IMAP SEARCH failed for uid=${uid}`);
+  return (found || []).some(foundUid => Number(foundUid) === Number(uid));
+}
+
+export function validateRecoveryDestinationUid(uidPlusUid, keywordUid) {
+  if (keywordUid == null) throw new Error('Recovery keyword was not found in destination');
+  if (uidPlusUid != null && Number(uidPlusUid) !== Number(keywordUid)) {
+    throw new Error(`UIDPLUS destination ${uidPlusUid} disagrees with recovery keyword UID ${keywordUid}`);
+  }
+  return Number(keywordUid);
+}
+
+async function storeAndVerifyProviderMarker(client, uid, marker) {
+  if (!recoveryKeywordAllowed(client.mailbox, marker)) {
+    throw new Error(`Mailbox does not support provider operation marker ${marker}`);
+  }
+  const stored = await client.messageFlagsAdd(String(uid), [marker], { uid: true });
+  if (stored === false) throw new Error(`Server did not store provider operation marker for uid=${uid}`);
+  if (!(await searchContainsExactUid(client, uid, { keyword: marker }))) {
+    throw new Error(`Provider operation marker was not stored for uid=${uid}`);
+  }
+}
+
+async function removeProviderMarkerAtUid(client, uid, marker) {
+  if (!(await searchContainsExactUid(client, uid, { keyword: marker }))) return;
+  const removed = await client.messageFlagsRemove(String(uid), [marker], { uid: true });
+  if (removed === false || await searchContainsExactUid(client, uid, { keyword: marker })) {
+    throw new Error(`Provider operation marker cleanup failed for uid=${uid}`);
+  }
+}
+
+async function cleanupCompletedProviderMarkerSide(resource, token, uid, marker) {
+  if (!token || uid == null) return;
+  try {
+    await resource.switchTo(token.folder);
+  } catch (error) {
+    const normalized = normalizeFrozenMailboxAcquisitionError(error, [token.folder]);
+    if (normalized?.code === 'PROVIDER_MAILBOX_SUPERSEDED') return;
+    throw error;
+  }
+  const liveUidValidity = resource.client.mailbox?.uidValidity;
+  // A reset creates a new mailbox incarnation where the old marker cannot exist. Treat only
+  // that side as clean so MOVE/COPY can still remove a marker from the other live side.
+  if (liveUidValidity == null) {
+    throw new Error(`Provider cleanup cannot establish UIDVALIDITY for ${token.folder}`);
+  }
+  if (String(liveUidValidity) !== String(token.uidValidity)) return;
+  await removeProviderMarkerAtUid(resource.client, uid, marker);
+}
+
+async function cleanupCompletedProviderOperationMarkers(resource, marker, receipt, operation) {
+  if (operation.kind !== 'append') {
+    await cleanupCompletedProviderMarkerSide(
+      resource, operation.source, operation.source?.uid, marker,
+    );
+  }
+  if (operation.kind !== 'delete') {
+    await cleanupCompletedProviderMarkerSide(
+      resource, operation.destination, receipt?.uid, marker,
+    );
+  }
+}
+
+async function acquireProviderOperationCleanupResource(account, operation, callback) {
+  const folders = [...new Set([
+    operation.destination?.folder, operation.source?.folder,
+  ].filter(Boolean))];
+  let explicitlyMissing = null;
+  for (const folder of folders) {
+    try {
+      return await withSwitchableMailboxClient(account, folder, callback);
+    } catch (error) {
+      const normalized = normalizeFrozenMailboxAcquisitionError(error, [folder]);
+      if (normalized?.code !== 'PROVIDER_MAILBOX_SUPERSEDED') throw error;
+      explicitlyMissing = error;
+    }
+  }
+  if (!explicitlyMissing) throw new Error('Provider cleanup operation has no mailbox identity');
+  // Every frozen side was explicitly reported missing. Supply a resource whose switches preserve
+  // that proof so the side-aware cleanup can converge without inventing a live mailbox epoch.
+  return callback({
+    client: { mailbox: null },
+    switchTo: async () => { throw explicitlyMissing; },
+    uidValidities: new Map(),
+    folder: null,
+  });
+}
+
+async function assertProviderOperationObservations(tx, intent) {
+  const values = [intent.source, intent.destination]
+    .filter(Boolean)
+    .sort((a, b) => a.folder.localeCompare(b.folder));
+  for (const token of values) {
+    const row = await assertFolderObservation(tx, intent.accountId, token);
+    if (row.is_present !== true || row.uid_validity == null) {
+      const error = new Error(`Provider operation folder ${token.folder} is not authoritative`);
+      error.code = 'FOLDER_OBSERVATION_UNSAFE';
+      throw error;
+    }
+  }
+}
+
+async function assertProviderOperationDestination(tx, operation) {
+  const row = await assertFolderObservation(tx, operation.accountId, operation.destination);
+  if (row.is_present !== true || row.uid_validity == null) {
+    const error = new Error(
+      `Provider operation folder ${operation.destination.folder} is not authoritative`,
+    );
+    error.code = 'FOLDER_OBSERVATION_UNSAFE';
+    throw error;
+  }
+}
+
+const FROZEN_OBSERVATION_TERMINAL_CODES = new Set([
+  'FOLDER_OBSERVATION_SUPERSEDED',
+  'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED',
+  'FOLDER_OBSERVATION_TOPOLOGY_CHANGED',
+  'FOLDER_OBSERVATION_UNSAFE',
+]);
+
+async function preflightFrozenProviderOperation(intent) {
+  try {
+    await withTransaction(tx => assertProviderOperationObservations(tx, intent));
+  } catch (error) {
+    if (FROZEN_OBSERVATION_TERMINAL_CODES.has(error?.code)) error.retryable = false;
+    throw error;
+  }
+}
+
+function assertLiveProviderEpoch(resource, token, label = 'Destination') {
+  const live = resource.uidValidities?.get(token.folder) ??
+    (resource.folder === token.folder ? resource.client.mailbox?.uidValidity : null);
+  if (live == null || String(live) !== String(token.uidValidity)) {
+    const error = new Error(`${label} UIDVALIDITY changed for ${token.folder}`);
+    error.code = 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED';
+    throw error;
+  }
+}
+
+function requireExactMutationSnapshot(snapshot, accountId, uid, folder, label) {
+  if (!snapshot?.id || snapshot.accountId !== accountId ||
+      Number(snapshot.uid) !== Number(uid) || snapshot.folder !== folder ||
+      snapshot.uidValidity == null || snapshot.folderGeneration == null) {
+    throw new Error(`${label} requires an exact live message snapshot`);
+  }
+  return snapshot;
+}
+
+export function desiredFlagDeliverySnapshot(delivery) {
+  return {
+    id: delivery.messageId,
+    accountId: delivery.accountId,
+    uid: delivery.uid,
+    folder: delivery.folder,
+    uidValidity: delivery.uidValidity,
+    folderGeneration: delivery.folderGeneration,
+    readRevision: delivery.flag === 'read' ? Number(delivery.revision) : null,
+    starRevision: delivery.flag === 'star' ? Number(delivery.revision) : null,
+  };
+}
+
+async function readProviderOperationObservations(accountId, folders, supplied = []) {
+  const suppliedByFolder = new Map((supplied || []).map(token => [token.folder, token]));
+  return Promise.all([...new Set(folders)].map(folder => (
+    suppliedByFolder.get(folder) || readFolderObservation(accountId, folder)
+  )));
+}
+
+async function withSwitchableMailboxClient(account, initialFolder, callback) {
+  return withFreshClient(account, async client => {
+    let lock = null;
+    let currentFolder = null;
+    const uidValidities = new Map();
+    const switchTo = async folder => {
+      if (currentFolder === folder && lock) return;
+      lock?.release();
+      lock = await client.getMailboxLock(folder);
+      currentFolder = folder;
+      if (client.mailbox?.uidValidity != null) {
+        uidValidities.set(folder, String(client.mailbox.uidValidity));
+      }
+    };
+    await switchTo(initialFolder);
+    try {
+      return await callback({
+        client,
+        switchTo,
+        uidValidities,
+        get folder() { return currentFolder; },
+      });
+    } finally {
+      lock?.release();
+    }
+  });
+}
+
+export async function recoverProviderMarkerOnClient(client, marker) {
+  const found = await client.search({ keyword: marker }, { uid: true });
+  if (found === false) throw new Error(`IMAP SEARCH failed for provider operation marker ${marker}`);
+  const uids = [...new Set((found || []).map(Number).filter(Number.isFinite))].sort((a, b) => a - b);
+  if (uids.length === 0) return { status: 'absent' };
+  if (uids.length > 1) return { status: 'ambiguous', uids };
+  const uidValidity = client.mailbox?.uidValidity;
+  if (uidValidity == null) throw new Error('Provider marker recovery requires destination UIDVALIDITY');
+  return { status: 'unique', uid: uids[0], uidValidity: String(uidValidity) };
+}
+
+async function appendMessageOnClient(client, folder, rawMessage, flags, marker) {
+  if (!recoveryKeywordAllowed(client.mailbox, marker)) {
+    throw new Error(`Destination mailbox does not support provider operation marker ${marker}`);
+  }
+  const appendFlags = [...new Set([...(flags || []), marker])];
+  const result = await client.append(folder, rawMessage, appendFlags);
+  if (result === false) throw new Error('IMAP append returned false — server did not confirm message was stored');
+  const recovery = await recoverProviderMarkerOnClient(client, marker);
+  if (recovery.status !== 'unique') {
+    throw new Error(`APPEND provider marker is ${recovery.status}`);
+  }
+  if (result?.uid != null && Number(result.uid) !== recovery.uid) {
+    throw new ProviderOperationError(
+      `UIDPLUS destination ${result.uid} disagrees with provider marker UID ${recovery.uid}`,
+      {
+        code: 'PROVIDER_RECEIPT_MISMATCH', retryable: false, uncertain: true, manual: true,
+        details: { uidplus: Number(result.uid), markerUid: recovery.uid },
+      },
+    );
+  }
+  return { uid: recovery.uid, uidValidity: recovery.uidValidity };
+}
+
+function assertExactArchiveRecoveryOperation(operation, {
+  operationId, accountId, row, archiveFolder,
+}) {
+  const source = operation?.source;
+  const destination = operation?.destination;
+  const receipt = operation?.receipt;
+  const receiptRequired = ['provider_applied', 'completed'].includes(operation?.state);
+  const sameToken = (left, right, includeUid = false) => Boolean(left && right) &&
+    left.folder === right.folder &&
+    String(left.uidValidity) === String(right.uidValidity) &&
+    String(left.generation) === String(right.generation) &&
+    (!includeUid || Number(left.uid) === Number(right.uid));
+  const valid = operation?.id === operationId && operation.kind === 'move' &&
+    operation.accountId === accountId &&
+    operation.marker === providerOperationMarker(operationId) &&
+    source?.folder === row.folder && Number(source?.uid) === Number(row.uid) &&
+    String(source?.uidValidity) === String(row.folder_uid_validity) &&
+    source?.generation != null && destination?.folder === archiveFolder &&
+    destination?.uidValidity != null && destination?.generation != null &&
+    (!receiptRequired || (
+      receipt?.marker === operation.marker && receipt.folder === archiveFolder &&
+      Number.isSafeInteger(Number(receipt.uid)) && Number(receipt.uid) > 0 &&
+      String(receipt.uidValidity) === String(destination.uidValidity) &&
+      sameToken(receipt.sourceToken, source, true) &&
+      sameToken(receipt.destinationToken, destination)
+    ));
+  if (!valid) {
+    throw new ProviderOperationError(
+      'Stored provider operation is not the exact archive request',
+      { code: 'PROVIDER_OPERATION_IDENTITY_MISMATCH', retryable: true, uncertain: true },
+    );
+  }
+}
+
 export class ImapManager {
+  async extendFolderObservationContext(accountId, observationContext, paths) {
+    if (!observationContext) return null;
+    observationContext.tokens = await claimFolderObservations(accountId, paths, {
+      context: observationContext.tokens,
+    });
+    return observationContext;
+  }
+
+  async withFolderObservationContext(accountId, observationContext, callback) {
+    return withTransaction(async (tx) => {
+      if (observationContext) await assertObservationContext(tx, accountId, observationContext);
+      return callback(tx);
+    });
+  }
+
+  async _withFreshSyncSession(account, callback) {
+    return withFreshLogin(account, callback);
+  }
+
   constructor(wss) {
     this.wss = wss;
+    this.providerOperationExecutor = providerOperationExecutor;
     this.connections = new Map();   // accountId -> ImapFlow (persistent sync connection)
     this.syncIntervals = new Map();
     this.pluginSyncIntervals = new Map(); // `${accountId}::${pluginId}` -> timer for a plugin's periodic sync tick
@@ -1316,12 +2150,13 @@ export class ImapManager {
     this.lastUserActivity = new Map();      // accountId -> ms timestamp of last live body fetch
     this.syncTickCount = new Map(); // accountId -> successful sync ticks (for reconcile scheduling)
     this.lastSyncOkAt = new Map(); // accountId -> ms timestamp of last successful sync tick (staleness detection)
+    // Process-local durable mailbox epochs observed by the persistent sync path. Pools are
+    // generic UID consumers and cannot receive another backend process's transition directly;
+    // the next local sync observation fences any pool generation created under the prior epoch.
+    this._observedSyncEpochs = new Map(); // `${accountId}:${folder}` -> UIDVALIDITY
     this._flagDebounceTimers   = new Map(); // accountId -> debounce timer for flag-change syncs
     this._expungeDebounceTimers = new Map(); // accountId -> debounce timer for expunge reconciles
     this._pendingFlagSync = new Set(); // accountId — flag sync was skipped because a full sync was running; drain after sync
-    // accountId -> Map<`${messageId}:${flag}`, { messageId, flag, attempts }>: local read/star
-    // changes whose IMAP push failed and must be retried until the server confirms them.
-    this._pendingFlagPush = new Map();
     // Tracks UIDs that are actively being moved by inboxRules so reconcileDeletes
     // does not delete the DB row if an EXPUNGE arrives before the DB update completes,
     // or if the server is non-UIDPLUS and the DB temporarily holds a stale UID.
@@ -1582,125 +2417,82 @@ export class ImapManager {
     // until the server confirms it. Runs below the 30s local-wins window so its per-cycle
     // marker re-bump keeps a pull from reverting the change while the retry is outstanding.
     this._flagPushReconcilerTimer = setInterval(() => {
-      if (this._flagPushRunning) return;
-      this._flagPushRunning = true;
-      this._reconcileFlagPushes()
-        .catch(err => console.error('Flag-push reconciler error:', err.message))
-        .finally(() => { this._flagPushRunning = false; });
+      if (!this._flagPushRunning) {
+        this._flagPushRunning = true;
+        this._reconcileFlagPushes()
+          .catch(err => console.error('Flag-push reconciler error:', err.message))
+          .finally(() => { this._flagPushRunning = false; });
+      }
+      if (!this._providerCleanupRunning) {
+        this._providerCleanupRunning = true;
+        this._sweepProviderOperationCleanup(PROVIDER_CLEANUP_PER_CYCLE)
+          .catch(err => console.error('Provider marker cleanup reconciler error:', err.message))
+          .finally(() => { this._providerCleanupRunning = false; });
+      }
     }, FLAG_PUSH_RECONCILE_MS);
   }
 
-  // Record a local read/star change whose immediate IMAP push failed so the reconciler
-  // re-pushes it until the server confirms. Keyed by message+flag; a repeat toggle updates
-  // the intended `value` and preserves the attempt count. The reconciler pushes and
-  // re-asserts THIS value — never a re-read of the row, which a concurrent flag-pull could
-  // have reverted (that re-read was a silent-loss bug).
-  _enqueueFlagPush(accountId, messageId, flag, value) {
-    if (!accountId || !messageId) return;
-    let ops = this._pendingFlagPush.get(accountId);
-    if (!ops) { ops = new Map(); this._pendingFlagPush.set(accountId, ops); }
-    const key = `${messageId}:${flag}`;
-    const existing = ops.get(key);
-    ops.set(key, { messageId, flag, value: !!value, attempts: existing ? existing.attempts : 0 });
-  }
-
-  // A later push of the SAME message+flag succeeded — drop any queued op so the reconciler
-  // can't re-assert/re-push a now-stale value (e.g. mark-read failed, then mark-unread
-  // succeeded: the queued read=true must not resurrect).
-  _resolveFlagPush(accountId, messageId, flag) {
-    const ops = this._pendingFlagPush.get(accountId);
-    if (!ops) return;
-    const key = `${messageId}:${flag}`;
-    // Mark resolved as well as delete: a reconciler cycle may already hold this op object in
-    // its snapshot, parked on an await — the flag lets it bail before clobbering the newer value.
-    const op = ops.get(key);
-    if (op) op.resolved = true;
-    ops.delete(key);
-    if (ops.size === 0) this._pendingFlagPush.delete(accountId);
-  }
-
-  // Re-bump the *_changed_at marker for every pending message up-front, before any
-  // (possibly slow) setFlag, so the 30s "local wins" window can't lapse mid-cycle and let
-  // a concurrent pull revert an unconfirmed change.
-  async _rebumpFlagMarkers(ops) {
-    const readIds = [];
-    const starIds = [];
-    for (const op of ops.values()) {
-      (op.flag === '\\Seen' ? readIds : starIds).push(op.messageId);
-    }
-    if (readIds.length) {
-      await query('UPDATE messages SET read_changed_at = NOW() WHERE id = ANY($1::uuid[])', [readIds]).catch(() => {});
-    }
-    if (starIds.length) {
-      await query('UPDATE messages SET star_changed_at = NOW() WHERE id = ANY($1::uuid[])', [starIds]).catch(() => {});
-    }
-  }
-
-  // Clear the marker for a message+flag once the server has confirmed (or we give up), so a
-  // subsequent flag-sync pull resumes reflecting the server for that message.
-  async _clearFlagMarker(messageId, flag) {
-    const col = flag === '\\Seen' ? 'read_changed_at' : 'star_changed_at';
-    // col is a fixed internal literal (not user input) — safe to interpolate.
-    await query(`UPDATE messages SET ${col} = NULL WHERE id = $1`, [messageId]).catch(() => {});
-  }
-
   async _reconcileFlagPushes() {
-    for (const [accountId, ops] of this._pendingFlagPush) {
-      if (ops.size === 0) { this._pendingFlagPush.delete(accountId); continue; }
-
-      // Hold the local-wins window for all pending messages this cycle regardless of
-      // whether we can push right now.
-      await this._rebumpFlagMarkers(ops);
-
-      // Only attempt pushes while the account has a live connection; otherwise keep the
-      // ops queued (markers already re-bumped) and wait for reconnect. Not counted as an
-      // attempt, so an outage doesn't burn the give-up budget.
-      if (!this.connections.has(accountId)) continue;
-
-      const acct = await query('SELECT * FROM email_accounts WHERE id = $1', [accountId]);
-      const account = acct.rows[0];
-      if (!account) { this._pendingFlagPush.delete(accountId); continue; }
-
-      let processed = 0;
-      for (const [key, op] of [...ops]) {
-        if (processed >= FLAG_PUSH_PER_CYCLE) break; // rest wait for the next cycle
-        if (!ops.has(key)) continue; // resolved by a concurrent successful push mid-cycle
-        processed++;
-        // Re-read only uid/folder (a move changes them) + existence — NOT the flag value,
-        // which we own via op.value. A concurrent pull may have reverted the row, so
-        // re-assert our intended value locally (with a fresh marker) before pushing the
-        // same value, so a slow cycle can never let the change be silently lost.
-        const { rows: [msg] } = await query(
-          'SELECT uid, folder FROM messages WHERE id = $1',
-          [op.messageId]
+    const durable = await desiredFlagRepository.listPending(FLAG_PUSH_PER_CYCLE);
+    const accounts = new Map();
+    for (const delivery of durable) {
+      let account = accounts.get(delivery.accountId);
+      if (account === undefined) {
+        const result = await query(
+          "SELECT * FROM email_accounts WHERE id = $1 AND enabled = true AND protocol = 'imap'",
+          [delivery.accountId],
         );
-        if (!msg) { ops.delete(key); continue; } // message gone — nothing to push
-        // A concurrent successful push may have resolved this op during the await above —
-        // don't re-assert/re-push a now-stale value over the newer one.
-        if (op.resolved) continue;
-        if (op.flag === '\\Seen') {
-          await query('UPDATE messages SET is_read = $1, read_changed_at = NOW() WHERE id = $2', [op.value, op.messageId]).catch(() => {});
-        } else {
-          await query('UPDATE messages SET is_starred = $1, star_changed_at = NOW() WHERE id = $2', [op.value, op.messageId]).catch(() => {});
-        }
-        try {
-          await this.setFlag(account, msg.uid, msg.folder, op.flag, op.value);
-          // If a newer value was pushed elsewhere while our setFlag was in flight, leave its
-          // marker in place and let the pull reconcile, rather than clearing to our stale push.
-          if (!op.resolved) await this._clearFlagMarker(op.messageId, op.flag); // confirmed on server
-          ops.delete(key);
-        } catch (err) {
-          op.attempts += 1;
-          if (op.attempts >= FLAG_PUSH_MAX_ATTEMPTS) {
-            console.warn(`Flag-push giving up after ${op.attempts} attempts (${op.flag} msg=${op.messageId}): ${extractImapError(err)}`);
-            await this._clearFlagMarker(op.messageId, op.flag); // honest revert to server truth
-            ops.delete(key);
-          }
-          // else keep queued; marker + value re-asserted above so nothing is lost before retry
+        account = result.rows[0] || null;
+        accounts.set(delivery.accountId, account);
+      }
+      if (!account) continue;
+      try {
+        await desiredFlagExecutor.deliver(
+          delivery.messageId,
+          delivery.flag,
+          this._desiredFlagProvider(account),
+        );
+      } catch (err) {
+        if (!err?.retryable) {
+          console.warn(`Desired-flag reconciliation failed (${delivery.flag} msg=${delivery.messageId}): ${extractImapError(err)}`);
         }
       }
-      if (ops.size === 0) this._pendingFlagPush.delete(accountId);
     }
+
+  }
+
+  async _sweepProviderOperationCleanup(limit = PROVIDER_CLEANUP_PER_CYCLE) {
+    const pending = await this.providerOperationExecutor.listPendingCleanup(limit);
+    const accounts = new Map();
+    let completed = 0;
+    for (const operation of pending) {
+      let account = accounts.get(operation.accountId);
+      if (account === undefined) {
+        const result = await query(
+          "SELECT * FROM email_accounts WHERE id = $1 AND enabled = true AND protocol = 'imap'",
+          [operation.accountId],
+        );
+        account = result.rows[0] || null;
+        accounts.set(operation.accountId, account);
+      }
+      if (!account) continue;
+      try {
+        const replay = await this.providerOperationExecutor.completeExisting(operation.id, {
+          acquireProvider: callback => acquireProviderOperationCleanupResource(
+            account, operation, callback,
+          ),
+          cleanup: (resource, marker, receipt, ownedOperation) => (
+            cleanupCompletedProviderOperationMarkers(
+              resource, marker, receipt, ownedOperation,
+            )
+          ),
+        });
+        if (replay.status === 'completed') completed++;
+      } catch (error) {
+        console.warn(`Provider marker cleanup remains pending for ${operation.id}: ${error.message}`);
+      }
+    }
+    return completed;
   }
 
   // Attach the three IDLE event listeners shared by both the initial connect path
@@ -1929,6 +2721,22 @@ export class ImapManager {
     evictPool(accountId);
   }
 
+  _evictPool(accountId) {
+    evictPool(accountId);
+  }
+
+  _observeSyncEpoch(accountId, folder, uidValidity) {
+    if (uidValidity == null) return;
+    const key = `${accountId}:${folder}`;
+    const hadPrior = this._observedSyncEpochs.has(key);
+    const prior = this._observedSyncEpochs.get(key);
+    this._observedSyncEpochs.set(key, uidValidity);
+    // The first observation is conservative: a body/header request can have created a
+    // pool before this folder's first sync. Later changes cover transitions committed by
+    // another backend process even when durable and selected epochs already match here.
+    if (!hadPrior || prior !== uidValidity) this._evictPool(accountId);
+  }
+
   // Effective per-host persistent-connection cap for an account: the tighter of the env default and
   // any provider-profile cap. Infinity = unlimited (default), which short-circuits the whole
   // poll-only path in connectAccount so behavior is unchanged.
@@ -2074,6 +2882,11 @@ export class ImapManager {
   async _shouldAutoBackfillOnConnect(account) {
     const profile = providerProfile(account);
     if (profile.autoBackfillExistingOnConnect !== false) return true;
+    const incomplete = await query(
+      'SELECT 1 FROM folders WHERE account_id = $1 AND backfill_incomplete = true LIMIT 1',
+      [account.id]
+    );
+    if (incomplete.rows.length > 0) return true;
     const existing = await query('SELECT 1 FROM messages WHERE account_id = $1 LIMIT 1', [account.id]);
     return existing.rows.length === 0;
   }
@@ -2278,12 +3091,37 @@ export class ImapManager {
   // isn't clobbered by a stale server value, and only touches rows whose flags actually differ.
   // Returns the number of rows changed. Shared by _syncFlagsForRange and the delta flag scan so
   // the flag-conflict logic lives in exactly one place.
-  async _applyFlagUpdates(account, folder, flagsToUpdate) {
+  async _applyFlagUpdates(
+    account, folder, flagsToUpdate, expectedUidValidity = null,
+    observationContext = null, pullSnapshot = null
+  ) {
     if (!flagsToUpdate.length) return 0;
+    if (pullSnapshot) {
+      const byUid = new Map(pullSnapshot.rows.map(row => [Number(row.uid), row]));
+      const rows = flagsToUpdate.flatMap(update => {
+        const captured = byUid.get(Number(update.uid));
+        if (!captured) return [];
+        return [{
+          ...captured,
+          isRead: update.isRead === true,
+          isStarred: update.isStarred === true,
+          modseq: update.modseq == null ? null : String(update.modseq),
+        }];
+      });
+      if (rows.length === 0) return 0;
+      const repository = this?._desiredFlagRepository || desiredFlagRepository;
+      return repository.applyPull({
+        accountId: account.id,
+        folder,
+        uidValidity: pullSnapshot.uidValidity,
+        folderGeneration: pullSnapshot.folderGeneration,
+        rows,
+      });
+    }
     const uids    = flagsToUpdate.map(f => f.uid);
     const reads   = flagsToUpdate.map(f => f.isRead);
     const starred = flagsToUpdate.map(f => f.isStarred);
-    const result = await query(`
+    const apply = async (runQuery) => runQuery(`
       UPDATE messages SET
         is_read = CASE
           WHEN messages.read_changed_at IS NOT NULL
@@ -2317,7 +3155,57 @@ export class ImapManager {
         )`,
       [uids, reads, starred, account.id, folder]
     );
+    const result = expectedUidValidity == null && !observationContext
+      ? await apply(query)
+      : await withTransaction(async (tx) => {
+          const states = observationContext
+            ? await assertObservationContext(tx, account.id, observationContext)
+            : null;
+          const state = states?.get(folder) || await tx.query(
+            `SELECT uid_validity, highest_modseq FROM folders
+              WHERE account_id = $1 AND path = $2
+              FOR UPDATE`,
+            [account.id, folder]
+          ).then(current => current.rows[0]);
+          if (expectedUidValidity != null &&
+              Number(state?.uid_validity) !== Number(expectedUidValidity)) {
+            const err = new Error(`UIDVALIDITY changed before flag update for ${folder}`);
+            err.code = 'SYNC_UIDVALIDITY_CHANGED';
+            throw err;
+          }
+          return apply(tx.query.bind(tx));
+        });
     return result.rowCount;
+  }
+
+  async _captureFlagPullSnapshot(account, folder, expectedUidValidity = null, tokenOverride = null) {
+    const token = tokenOverride || await readFolderObservation(account.id, folder);
+    if (token.isPresent === false || token.uidValidity == null || token.generation == null ||
+        (expectedUidValidity != null && Number(token.uidValidity) !== Number(expectedUidValidity))) {
+      const err = new Error(`Cannot capture actionable flag rows for ${folder}`);
+      err.code = 'SYNC_UIDVALIDITY_CHANGED';
+      throw err;
+    }
+    const result = await query(
+      `SELECT m.id, m.uid, m.read_revision, m.star_revision
+         FROM messages m
+         JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                       AND f.is_present = true AND f.uid_validity IS NOT NULL
+        WHERE m.account_id = $1 AND m.folder = $2
+          AND m.is_deleted = false AND m.metadata_complete = true
+          AND f.uid_validity = $3 AND f.observation_generation = $4`,
+      [account.id, folder, token.uidValidity, token.generation],
+    );
+    return {
+      uidValidity: token.uidValidity,
+      folderGeneration: token.generation,
+      rows: result.rows.map(row => ({
+        id: row.id,
+        uid: Number(row.uid),
+        readRevision: Number(row.read_revision || 0),
+        starRevision: Number(row.star_revision || 0),
+      })),
+    };
   }
 
   // Lightweight flag-only sync: fetch uid+flags for the last 200 messages in INBOX
@@ -2344,6 +3232,10 @@ export class ImapManager {
         try {
           const mailbox = client.mailbox;
           if (!mailbox || !mailbox.exists) return;
+          const selectedValidity = mailbox.uidValidity != null ? Number(mailbox.uidValidity) : null;
+          const pullSnapshot = await this._captureFlagPullSnapshot(
+            account, 'INBOX', selectedValidity,
+          );
 
           const seqCount = 200;
           const fetchRange = mailbox.exists > seqCount
@@ -2356,12 +3248,15 @@ export class ImapManager {
               uid: msg.uid,
               isRead: msg.flags.has('\\Seen'),
               isStarred: msg.flags.has('\\Flagged'),
+              modseq: msg.modseq ?? null,
             });
           }
 
           if (flagsToUpdate.length === 0) return;
 
-          const changed = await this._applyFlagUpdates(account, 'INBOX', flagsToUpdate);
+          const changed = await this._applyFlagUpdates(
+            account, 'INBOX', flagsToUpdate, selectedValidity, null, pullSnapshot,
+          );
           if (changed > 0) {
             console.log(`Flag sync: ${changed} flag change(s) for ${logAccount(account)}, broadcasting`);
             this.broadcast({ type: 'flags_synced', accountId: account.id }, account.user_id);
@@ -2447,7 +3342,7 @@ export class ImapManager {
               COALESCE(SUM(uid), 0)::text AS uidsum,
               COALESCE(MAX(uid), 0)::text AS maxuid
        FROM messages
-       WHERE account_id = $1 AND folder = $2 AND is_deleted = false`,
+       WHERE account_id = $1 AND folder = $2 AND is_deleted = false AND metadata_complete = true`,
       [accountId, folder]
     );
     const r = rows[0] || {};
@@ -2487,48 +3382,14 @@ export class ImapManager {
   }
 
   async syncFolders(account, client) {
+    const topologyToken = await claimMailboxTopology(account.id);
     try {
-      const mailboxes = await client.list();
-      for (const mb of mailboxes) {
-        // \Noselect (e.g. Gmail's "[Gmail]" parent) and \NonExistent mailboxes cannot be
-        // SELECTed. Persist that so role resolvers never route to them and the folder-mapping
-        // UI can hide them — see migration 0047 and mailUtils.mappedFolderUsable.
-        const noSelect = !!(mb.flags && (mb.flags.has('\\Noselect') || mb.flags.has('\\NonExistent')));
-        await query(`
-          INSERT INTO folders (account_id, path, name, delimiter, special_use, no_select)
-          VALUES ($1, $2, $3, $4, $5, $6)
-          ON CONFLICT (account_id, path) DO UPDATE
-          SET name = $3, special_use = $5, no_select = $6, updated_at = NOW()
-        `, [account.id, mb.path, mb.name, mb.delimiter, mb.specialUse || null, noSelect]);
-      }
-      // Many IMAP servers omit INBOX from LIST responses (it is implicit per RFC 3501).
-      // Without a row in folders, subfolders like INBOX/Work have no parent in the map
-      // and fall to the sidebar root instead of nesting correctly.
-      if (!mailboxes.some(mb => mb.path === 'INBOX')) {
-        const delimiter = mailboxes[0]?.delimiter || '/';
-        await query(`
-          INSERT INTO folders (account_id, path, name, delimiter, special_use)
-          VALUES ($1, 'INBOX', 'INBOX', $2, NULL)
-          ON CONFLICT (account_id, path) DO NOTHING
-        `, [account.id, delimiter]);
-      }
-      // Prune rows for folders that no longer exist on the server (renamed or
-      // deleted by another client, or left behind by a pre-fix subtree rename).
-      // Without this, ghost folders duplicate the sidebar tree and every sync
-      // tick keeps trying — and failing — to open their stale paths. Message
-      // rows are left alone: in-app folder deletion already removes them
-      // explicitly, and orphans stop syncing once their folder row is gone.
-      // Guarded on a non-empty LIST so a pathological empty response can't
-      // wipe the account's folder tree.
-      if (mailboxes.length > 0) {
-        await query(
-          `DELETE FROM folders
-           WHERE account_id = $1 AND path != 'INBOX' AND NOT (path = ANY($2))`,
-          [account.id, mailboxes.map(mb => mb.path)]
-        );
-      }
+      const mailboxes = await bufferMailboxTopology(client);
+      await commitMailboxTopology(account.id, topologyToken, mailboxes);
+      return true;
     } catch (err) {
       console.error(`Folder sync error for ${logAccount(account)}:`, err.message);
+      throw err;
     }
   }
 
@@ -2543,19 +3404,38 @@ export class ImapManager {
   // noBodyParts: skip ALL body part fetches (uid/flags/envelope/bodyStructure only).
   // Used for the periodic sync interval so slow servers like purelymail.com don't time out
   // fetching 3+ body parts × 50 messages.  Snippets come from backfill or on-demand fetches.
-  async syncMessages(account, client, folder = 'INBOX', limit = 50, prefetchBody = true, noBodyParts = false) {
+  async syncMessages(
+    account, client, folder = 'INBOX', limit = 50, prefetchBody = true,
+    noBodyParts = false, supersessionRestartsRemaining = 1
+  ) {
     const provider = providerProfile(account);
+    const observationToken = await claimFolderObservation(account.id, folder);
+    const observationContext = { accountId: account.id, tokens: [observationToken] };
+    const observationStartedAt = new Date();
 
     try {
       const lock = await client.getMailboxLock(folder);
       try {
         const mailbox = client.mailbox;
-        if (!mailbox || mailbox.exists === 0) return { insertedCount: 0, broadcastedNewMessages: false };
-
+        if (!mailbox) return { insertedCount: 0, broadcastedNewMessages: false };
         // UIDVALIDITY check — detects server-side mailbox rebuilds (migration, restore).
         // If UIDVALIDITY changed, all stored UIDs for this folder are invalid; purge them
         // and let backfill re-populate from the new UID epoch.
         const currentValidity = mailbox.uidValidity ? Number(mailbox.uidValidity) : null;
+        const assertCurrentSyncEpoch = async (tx) => {
+          const states = await assertObservationContext(tx, account.id, observationContext);
+          const stateRow = states.get(folder);
+          const state = { rows: [stateRow] };
+          const durableValidity = state.rows[0]?.uid_validity != null
+            ? Number(state.rows[0].uid_validity)
+            : null;
+          if (currentValidity == null) return;
+          if (durableValidity !== currentValidity) {
+            const err = new Error(`UIDVALIDITY changed before sync write for ${folder}`);
+            err.code = 'SYNC_UIDVALIDITY_CHANGED';
+            throw err;
+          }
+        };
         // CONDSTORE HIGHESTMODSEQ read at SELECT time (M). ImapFlow auto-enables CONDSTORE on
         // connect, so this is populated on any server that supports it and null otherwise —
         // in which case delta sync transparently falls back to the full UID/sequence phases.
@@ -2570,57 +3450,179 @@ export class ImapManager {
           );
           const storedValidity = foldRow.rows[0]?.uid_validity ? Number(foldRow.rows[0].uid_validity) : null;
           storedModseq = foldRow.rows[0]?.highest_modseq ?? null;
+          if (storedValidity === null) {
+            const seeded = await withTransaction(tx => seedFolderUidValidity(
+              tx, account.id, observationToken, currentValidity,
+            ));
+            Object.assign(observationToken, seeded);
+          }
           if (storedValidity !== null && storedValidity !== currentValidity) {
-            uidValidityChanged = true;
-            console.warn(`UIDVALIDITY changed for ${logAccount(account)}/${folder}: ${storedValidity} → ${currentValidity}. Purging stale messages and re-backfilling.`);
-            const purged = await query('DELETE FROM messages WHERE account_id = $1 AND folder = $2', [account.id, folder]);
-            // The stored modseq belongs to the OLD UIDVALIDITY epoch and is no longer
-            // comparable — clear it so the next sync re-seeds cleanly from the new epoch.
-            await query('UPDATE folders SET highest_modseq = NULL WHERE account_id = $1 AND path = $2', [account.id, folder]);
-            storedModseq = null;
+            // A long-lived selected connection can retain the prior mailbox object after
+            // another connection observes the provider's new epoch. STATUS gives us a fresh
+            // server value before we are allowed to author a durable transition; never let a
+            // stale client rewind the DB to its cached UIDVALIDITY.
+            const status = await client.status(folder, { uidValidity: true });
+            const statusValidity = status?.uidValidity != null ? Number(status.uidValidity) : null;
+            if (statusValidity !== currentValidity) {
+              // The selected sync session is stale, so any process-local pooled session may
+              // be stale too. Fence it even though this sync cannot author the transition.
+              this._evictPool?.(account.id);
+              throw new Error(`UIDVALIDITY changed during sync selection for ${folder}`);
+            }
+            // Serialize the epoch transition with every backfill write by locking the
+            // folder row. Update the epoch before deleting: if an old backfill owns the
+            // lock first, this delete removes anything it committed; if this transition
+            // owns it first, the old backfill wakes, observes the new epoch, and aborts.
+            const transition = await withTransaction(async (tx) => {
+              const lockedRow = await assertFolderObservation(
+                tx, account.id, observationToken, { checkUidValidity: false }
+              );
+              const locked = { rows: [lockedRow] };
+              const lockedValidity = locked.rows[0]?.uid_validity != null
+                ? Number(locked.rows[0].uid_validity)
+                : null;
+              if (lockedValidity === currentValidity) {
+                return { changed: false, purgedCount: 0, modseq: locked.rows[0]?.highest_modseq ?? null };
+              }
+              if (lockedValidity !== storedValidity) {
+                throw new Error(`UIDVALIDITY changed concurrently for ${folder}`);
+              }
+              await tx.query(
+                `UPDATE folders
+                    SET uid_validity = $1, highest_modseq = NULL, backfill_incomplete = true
+                  WHERE account_id = $2 AND path = $3`,
+                [currentValidity, account.id, folder]
+              );
+              const purged = await tx.query(
+                'DELETE FROM messages WHERE account_id = $1 AND folder = $2',
+                [account.id, folder]
+              );
+              return { changed: true, purgedCount: purged.rowCount, modseq: null };
+            });
+            uidValidityChanged = transition.changed;
+            storedModseq = transition.modseq;
+            observationToken.uidValidity = String(currentValidity);
+            if (!transition.changed) {
+              // Another sync completed this epoch transition while we waited.
+              console.log(`UIDVALIDITY transition already applied for ${logAccount(account)}/${folder}`);
+            } else {
+              console.warn(`UIDVALIDITY changed for ${logAccount(account)}/${folder}: ${storedValidity} → ${currentValidity}. Purging stale messages and re-backfilling.`);
+            }
+            // Pooled UID consumers (body/header/attachment fetches and reconcile) may still
+            // be selected on the old epoch. Every process that observes the completed
+            // transition must evict its own process-local pool, not only the transaction
+            // winner. Hard close makes this an immediate fence for in-flight commands.
+            this._evictPool?.(account.id);
             // A UIDVALIDITY purge drops every row for this folder — including any GTD thread's copy
             // here — so refresh GTD section data like the other sync-delete paths. Backfill re-populates
             // below; the emit just avoids a stale gap. See emitSectionsChanged.
-            await emitSectionsChanged(this.pluginFacade, account, purged.rowCount);
+            await emitSectionsChanged(this.pluginFacade, account, transition.purgedCount);
             // Route through the per-host backfill cap too: a provider-side mailbox rebuild
             // can reset UIDVALIDITY across many accounts/folders at once, which would
             // otherwise flood connections on exactly the many-account-per-provider setup the
             // cap protects. Acquire at the call site (not inside backfillMessages) —
             // backfillAllFolders already holds the slot while calling it per folder, so an
             // internal acquire would self-deadlock at the limit.
-            const reindexHost = (account.imap_host || '').toLowerCase();
-            setImmediate(async () => {
-              await this._bgConnSem.acquire(reindexHost);
-              try {
-                await this.backfillMessages(account, folder);
-              } catch (err) {
-                console.error(`Post-UIDVALIDITY backfill error for ${logAccount(account)}/${folder}:`, err.message);
-              } finally {
-                this._bgConnSem.release(reindexHost);
-              }
-            });
+            if (transition.changed && mailbox.exists > 0) {
+              const reindexHost = (account.imap_host || '').toLowerCase();
+              const reindexKey = `${account.id}:${folder}`;
+              setImmediate(async () => {
+                // A transition can be discovered by normal sync while an old-epoch backfill
+                // still owns the per-folder slot. Wait for that run to observe the fence and
+                // unwind; otherwise the one scheduled repair would return false immediately.
+                while (this.backfillRunning?.has(reindexKey)) {
+                  await new Promise(resolve => setTimeout(resolve, 100));
+                }
+                await this._bgConnSem.acquire(reindexHost);
+                try {
+                  await this.backfillMessages(account, folder);
+                } catch (err) {
+                  console.error(`Post-UIDVALIDITY backfill error for ${logAccount(account)}/${folder}:`, err.message);
+                } finally {
+                  this._bgConnSem.release(reindexHost);
+                }
+              });
+            }
           }
+          // This also closes the cross-process observer gap: another process may already
+          // have committed the new epoch, making stored===selected here while our local
+          // pool still contains sessions selected under the prior epoch. Run for every
+          // folder, including INBOX, and also record locally-authored transitions.
+          this._observeSyncEpoch?.(account.id, folder, currentValidity);
+        }
+
+        if (mailbox.exists === 0) {
+          // An empty SELECT is still authoritative state. In particular, a provider can
+          // recreate a mailbox at a new UIDVALIDITY with zero messages; returning before
+          // the epoch transition would strand old-epoch rows forever. Reconcile under the
+          // same folder-row lock used by backfill so an old writer cannot reinsert after us.
+          const emptied = await withTransaction(async (tx) => {
+            const lockedRow = await assertFolderObservation(tx, account.id, observationToken);
+            const locked = { rows: [lockedRow] };
+            const lockedValidity = locked.rows[0]?.uid_validity != null
+              ? Number(locked.rows[0].uid_validity)
+              : null;
+            if (currentValidity != null && lockedValidity != null && lockedValidity !== currentValidity) {
+              throw new Error(`UIDVALIDITY changed while reconciling empty ${folder}`);
+            }
+            const purged = await tx.query(
+              `DELETE FROM messages
+                WHERE account_id = $1 AND folder = $2
+                  AND (synced_at IS NULL OR synced_at < $3)`,
+              [account.id, folder, observationStartedAt]
+            );
+            await tx.query(
+              `UPDATE folders f
+                  SET total_count = stats.complete_count,
+                      unread_count = stats.unread_count,
+                      backfill_incomplete = CASE
+                        WHEN stats.row_count = 0 THEN false
+                        ELSE f.backfill_incomplete OR stats.incomplete_count > 0
+                      END,
+                      uid_validity = COALESCE($1, f.uid_validity), updated_at = NOW()
+                 FROM (
+                   SELECT COUNT(*) FILTER (WHERE metadata_complete = true) AS complete_count,
+                          COUNT(*) FILTER (WHERE metadata_complete = true AND is_read = false) AS unread_count,
+                          COUNT(*) AS row_count,
+                          COUNT(*) FILTER (WHERE metadata_complete = false) AS incomplete_count
+                     FROM messages
+                    WHERE account_id = $2 AND folder = $3 AND is_deleted = false
+                 ) stats
+                WHERE f.account_id = $2 AND f.path = $3`,
+              [currentValidity, account.id, folder]
+            );
+            return purged.rowCount;
+          });
+          await emitSectionsChanged(this.pluginFacade, account, emptied);
+          return { insertedCount: 0, broadcastedNewMessages: false };
         }
 
         // mailbox.unseen from IMAP SELECT is the sequence number of the first unseen
         // message, NOT the count of unread messages.  Compute the real count from the
         // messages table instead — accurate post-backfill and never inflated.
         const { rows: [ucRow] } = await query(
-          `SELECT COUNT(*) FILTER (WHERE is_read = false) AS n FROM messages WHERE account_id = $1 AND folder = $2`,
+          `SELECT COUNT(*) FILTER (WHERE is_read = false) AS n FROM messages
+           WHERE account_id = $1 AND folder = $2 AND is_deleted = false AND metadata_complete = true`,
           [account.id, folder]
         );
         const dbUnreadCount = parseInt(ucRow.n || 0);
-        await query(`
-          INSERT INTO folders (account_id, path, name, total_count, unread_count, uid_validity)
-          VALUES ($1, $2, $2, $3, $4, $5)
-          ON CONFLICT (account_id, path) DO UPDATE
-          SET total_count = $3, unread_count = $4, uid_validity = COALESCE($5, folders.uid_validity), updated_at = NOW()
-        `, [account.id, folder, mailbox.exists, dbUnreadCount, currentValidity]);
+        await withTransaction(async (tx) => {
+          await assertCurrentSyncEpoch(tx);
+          await tx.query(
+            `UPDATE folders
+                SET total_count = $3,
+                    unread_count = $4,
+                    uid_validity = COALESCE($5, uid_validity),
+                    updated_at = NOW()
+              WHERE account_id = $1 AND path = $2`,
+            [account.id, folder, mailbox.exists, dbUnreadCount, currentValidity],
+          );
+        });
 
         // Omit body parts for providers that throttle BODY[] fetches, and when
         // noBodyParts is set. Envelope/flags/uid/bodyStructure always fetched.
         const fetchQuery = {
-          uid: true, flags: true, envelope: true,
+          uid: true, flags: true, modseq: true, envelope: true,
           bodyStructure: true,
           size: true,
           internalDate: true,
@@ -2641,6 +3643,14 @@ export class ImapManager {
         let newMessages = [];
         let insertedCount = 0;
         let broadcastedNewMessages = false;
+        let metadataRetryDeferred = false;
+        let pullSnapshot = null;
+        let warnedIncompleteFetch = false;
+        const warnIncompleteFetch = () => {
+          if (warnedIncompleteFetch) return;
+          warnedIncompleteFetch = true;
+          console.warn(`Message sync deferred incomplete metadata for ${logAccount(account)}/${folder}; retrying on a later sync`);
+        };
 
         // Inbox-ingest facts core hands to plugins after this batch (via the `inboxIngest` hook):
         //   • newInboxIds — the id of every row this sync newly inserts into INBOX, read or unread.
@@ -2658,12 +3668,6 @@ export class ImapManager {
         const newInboxIds = [];
         const ingestDeletedIds = new Set();
 
-        // Relocate-exempt label folders for this account (empty when no label plugin is
-        // active). Loaded once per sync — the plugins' folder sets are cheap/cached — so the
-        // relocate guard keeps a labeled message's sibling rows instead of collapsing them
-        // onto whichever folder synced last. See relocateMessageQuery / collectRelocateExemptFolders.
-        const exemptFolders = await collectRelocateExemptFolders(account);
-
         // Insert/update a single fetched message and track it as new if appropriate.
         // Called from both Phase 1 and Phase 2; ON CONFLICT handles deduplication so
         // a message processed in both phases is never double-counted.
@@ -2679,7 +3683,7 @@ export class ImapManager {
             });
             if (!parsed.uid) {
               console.warn(`Message sync skipped: IMAP FETCH returned no UID for ${account.email}/${folder}`);
-              return;
+              return false;
             }
             let safeHtml = null, text = null, atts = [];
             if (prefetchBody && provider.fetchBody) {
@@ -2693,18 +3697,6 @@ export class ImapManager {
             const refs = sanitizeStr(parsed.references);
             const threadId = await computeThreadId(account.id, msgId, inReplyTo, refs, sanitizeStr(parsed.subject));
 
-            // If a row with this message_id already exists for this account at a
-            // different (folder, uid), it was moved. Relocate it in-place rather
-            // than inserting a duplicate. The COUNT=1 guard prevents incorrectly
-            // merging Gmail's virtual-folder copies (same message_id in INBOX and
-            // [Gmail]/All Mail simultaneously).
-            if (msgId) {
-              const { sql: relocateSql, params: relocateParams } =
-                relocateMessageQuery(folder, parsed, account.id, msgId, exemptFolders);
-              const relocated = await query(relocateSql, relocateParams);
-              if (relocated.rows.length > 0) return;
-            }
-
             let msgCategory = null;
             if (account.categorization_enabled || await getGlobalCategorizationEnabled(account.user_id)) {
               try {
@@ -2714,8 +3706,10 @@ export class ImapManager {
               } catch { /* non-fatal — leave category NULL */ }
             }
 
-            const result = await query(`
-              INSERT INTO messages (
+            const result = await withTransaction(async (tx) => {
+              await assertCurrentSyncEpoch(tx);
+              const insertResult = await tx.query(`
+                INSERT INTO messages (
                 account_id, uid, folder, message_id, subject,
                 from_name, from_email, to_addresses, cc_addresses,
                 reply_to, in_reply_to,
@@ -2726,80 +3720,38 @@ export class ImapManager {
                 sender_name, sender_email
               ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29)
               ON CONFLICT (account_id, uid, folder) DO UPDATE
-              SET subject = CASE
-                    WHEN EXCLUDED.subject IS NOT NULL
-                         AND EXCLUDED.subject != ''
-                         AND EXCLUDED.subject != '(no subject)'
-                    THEN EXCLUDED.subject
-                    ELSE messages.subject
-                  END,
-                  from_name = COALESCE(NULLIF(EXCLUDED.from_name, ''), messages.from_name),
-                  from_email = COALESCE(NULLIF(EXCLUDED.from_email, ''), messages.from_email),
-                  to_addresses = CASE
-                    WHEN EXCLUDED.to_addresses::text IS NOT NULL AND EXCLUDED.to_addresses::text <> '[]'
-                    THEN EXCLUDED.to_addresses
-                    ELSE messages.to_addresses
-                  END,
-                  cc_addresses = CASE
-                    WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
-                    THEN EXCLUDED.cc_addresses
-                    ELSE messages.cc_addresses
-                  END,
-                  reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), EXCLUDED.reply_to::text)::jsonb,
-                  in_reply_to = COALESCE(messages.in_reply_to, EXCLUDED.in_reply_to),
-                  snippet = CASE WHEN EXCLUDED.snippet != '' THEN EXCLUDED.snippet
-                                 ELSE messages.snippet END,
-                  is_read = CASE
-                    WHEN messages.read_changed_at IS NOT NULL
-                         AND NOW() - messages.read_changed_at < interval '30 seconds'
-                    THEN messages.is_read
-                    ELSE EXCLUDED.is_read
-                  END,
-                  is_starred = CASE
-                    WHEN messages.star_changed_at IS NOT NULL
-                         AND NOW() - messages.star_changed_at < interval '30 seconds'
-                    THEN messages.is_starred
-                    ELSE EXCLUDED.is_starred
-                  END,
-                  flags = $17,
-                  body_html = COALESCE(messages.body_html, EXCLUDED.body_html),
-                  body_text = COALESCE(messages.body_text, EXCLUDED.body_text),
-                  attachments = COALESCE(messages.attachments::text, EXCLUDED.attachments::text)::jsonb,
-                  thread_references = COALESCE(messages.thread_references, EXCLUDED.thread_references),
-                  -- #378: heal a row that was self-rooted (thread_id = its own Message-ID, e.g. a
-                  -- sent copy orphaned by an older upsert) by adopting the real conversation root
-                  -- the sync just computed. Genuine thread roots keep their value (EXCLUDED equals it).
-                  thread_id = CASE
-                    WHEN messages.thread_id = messages.message_id
-                         AND EXCLUDED.thread_id IS NOT NULL
-                         AND EXCLUDED.thread_id <> messages.message_id
-                    THEN EXCLUDED.thread_id
-                    ELSE COALESCE(messages.thread_id, EXCLUDED.thread_id)
-                  END,
-                  is_bulk = COALESCE(messages.is_bulk, EXCLUDED.is_bulk),
-                  category = COALESCE(messages.category, EXCLUDED.category),
-                  list_unsubscribe = COALESCE(messages.list_unsubscribe, EXCLUDED.list_unsubscribe),
-                  list_unsubscribe_post = COALESCE(messages.list_unsubscribe_post, EXCLUDED.list_unsubscribe_post),
-                  delivery_addresses = COALESCE(messages.delivery_addresses, EXCLUDED.delivery_addresses),
-                  sender_name = COALESCE(EXCLUDED.sender_name, messages.sender_name),
-                  sender_email = COALESCE(EXCLUDED.sender_email, messages.sender_email)
-              RETURNING id, (xmax = 0) as is_new
-            `, [
-              account.id, parsed.uid, folder,
-              msgId, sanitizeStr(parsed.subject),
-              sanitizeStr(parsed.fromName), sanitizeStr(parsed.fromEmail),
-              JSON.stringify(parsed.to), JSON.stringify(parsed.cc),
-              JSON.stringify(parsed.replyTo || []), inReplyTo,
-              safeDate(parsed.date), sanitizeStr(parsed.snippet),
-              parsed.isRead, parsed.isStarred,
-              parsed.hasAttachments, JSON.stringify(parsed.flags),
-              sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(atts || []),
-              refs, threadId, parsed.isBulk ?? null, msgCategory,
-              sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe'] ?? null)),
-              sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe-post'] ?? null)),
-              JSON.stringify(parsed.deliveryAddresses || []),
-              sanitizeStr(parsed.senderName), sanitizeStr(parsed.senderEmail),
-            ]);
+              SET ${COMPLETE_METADATA_CONFLICT_UPDATE_SQL}
+                RETURNING id, (xmax = 0) as is_new
+              `, [
+                account.id, parsed.uid, folder,
+                msgId, sanitizeStr(parsed.subject),
+                sanitizeStr(parsed.fromName), sanitizeStr(parsed.fromEmail),
+                JSON.stringify(parsed.to), JSON.stringify(parsed.cc),
+                JSON.stringify(parsed.replyTo || []), inReplyTo,
+                safeDate(parsed.date), sanitizeStr(parsed.snippet),
+                parsed.isRead, parsed.isStarred,
+                parsed.hasAttachments, JSON.stringify(parsed.flags),
+                sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(atts || []),
+                refs, threadId, parsed.isBulk ?? null, msgCategory,
+                sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe'] ?? null)),
+                sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe-post'] ?? null)),
+                JSON.stringify(parsed.deliveryAddresses || []),
+                sanitizeStr(parsed.senderName), sanitizeStr(parsed.senderEmail),
+              ]);
+
+              // Keep the inserted row and conversation repair atomic. If the
+              // propagation fails, rolling back the insert leaves this UID
+              // eligible for the next exact-diff retry.
+              if (threadId && threadId !== msgId) {
+                await tx.query(
+                  `UPDATE messages SET thread_id = $1
+                   WHERE account_id = $2 AND thread_id = $3 AND message_id != $3`,
+                  [threadId, account.id, msgId]
+                );
+              }
+
+              return insertResult;
+            });
             if (result.rows[0]?.is_new) {
               insertedCount++;
               // Inbox-ingest candidate: any newly-inserted INBOX row, read OR unread (read state
@@ -2813,18 +3765,55 @@ export class ImapManager {
                 newMessages.push({ ...parsed, id: result.rows[0].id, accountId: account.id, folder });
               }
             }
-            // Propagate resolved thread_id to any earlier messages that used this
-            // message as a provisional thread root (out-of-order delivery / sync).
-            if (threadId && threadId !== msgId) {
-              await query(
-                `UPDATE messages SET thread_id = $1
-                 WHERE account_id = $2 AND thread_id = $3 AND message_id != $3`,
-                [threadId, account.id, msgId]
-              );
-            }
+            return true;
           } catch (parseErr) {
+            if (parseErr?.code === 'SYNC_UIDVALIDITY_CHANGED' || isFolderObservationError(parseErr)) throw parseErr;
             console.error('Message sync parse error:', parseErr.message);
+            return false;
           }
+        };
+
+        // Preserve the UID watermark as a retry floor. If one candidate is incomplete, a
+        // later valid UID must not be inserted first or MAX(uid) would leap past the gap and
+        // periodic sync would never request the incomplete message again.
+        const processMetadataBatch = async (messages, expectedCount = null) => {
+          const ordered = [...messages].sort((a, b) => Number(a.uid) - Number(b.uid));
+          const returnedUids = new Set(ordered
+            .map(msg => Number(msg?.uid))
+            .filter(Number.isFinite));
+          if ((expectedCount != null && returnedUids.size !== expectedCount)
+              || ordered.some(msg => !hasFetchedEnvelope(msg))) {
+            metadataRetryDeferred = true;
+            warnIncompleteFetch();
+            return false;
+          }
+          for (const msg of ordered) {
+            if (!await processMsg(msg)) {
+              metadataRetryDeferred = true;
+              warnIncompleteFetch();
+              return false;
+            }
+          }
+          if (pullSnapshot) {
+            const changed = await ImapManager.prototype._applyFlagUpdates.call(
+              this,
+              account,
+              folder,
+              ordered.map(msg => ({
+                uid: msg.uid,
+                isRead: msg.flags?.has?.('\\Seen') === true,
+                isStarred: msg.flags?.has?.('\\Flagged') === true,
+                modseq: msg.modseq ?? null,
+              })),
+              currentValidity,
+              observationContext,
+              pullSnapshot,
+            );
+            if (changed > 0) {
+              this.broadcast({ type: 'flags_synced', accountId: account.id }, account.user_id);
+            }
+          }
+          return true;
         };
 
         // Fetch strategy. The UID-watermark phase below catches new mail only when the local
@@ -2838,20 +3827,51 @@ export class ImapManager {
           maxKnownUid,
           serverExists: mailbox.exists,
         });
+        if (observationToken.uidValidity != null && observationToken.generation != null) {
+          pullSnapshot = await ImapManager.prototype._captureFlagPullSnapshot.call(
+            this,
+            account, folder, currentValidity, observationToken,
+          );
+        }
 
         // ── New-mail phase — UID-watermark safety net for a populated local cache. Fetches only
         // UIDs above the highest we already have — usually just the newest message, then a no-op
         // upsert. When no local UID exists, the full plan above owns metadata ingestion instead.
         if (maxKnownUid > 0) {
           try {
-            for await (const msg of client.fetch(`${maxKnownUid + 1}:*`, fetchQuery, { uid: true })) {
-              await processMsg(msg);
+            // Search first so work scales with actual messages rather than numeric UID distance.
+            // `n:*` has reversed-range semantics when n is above the server's current maximum,
+            // so filter the SEARCH result strictly above our local watermark before fetching.
+            const candidateResult = await client.search(
+              { uid: `${maxKnownUid + 1}:*` },
+              { uid: true }
+            );
+            if (!Array.isArray(candidateResult)) {
+              metadataRetryDeferred = true;
+              warnIncompleteFetch();
+            } else {
+              const candidateUids = [...new Set(candidateResult
+                .map(Number)
+                .filter(uid => Number.isFinite(uid) && uid > maxKnownUid))]
+                .sort((a, b) => a - b);
+
+              for (let offset = 0; offset < candidateUids.length; offset += METADATA_SYNC_BATCH_SIZE) {
+                const batchUids = candidateUids.slice(offset, offset + METADATA_SYNC_BATCH_SIZE);
+                const newMailCandidates = await fetchCompleteMetadataBatch(client, batchUids, fetchQuery);
+                if (newMailCandidates === null) {
+                  metadataRetryDeferred = true;
+                  warnIncompleteFetch();
+                  break;
+                }
+                if (!await processMetadataBatch(newMailCandidates)) break;
+              }
             }
           } catch (err) {
             if (!extractImapError(err).toLowerCase().includes('invalid messageset')) throw err;
-            // UID range became stale due to concurrent expunge between SELECT and FETCH.
-            // Non-fatal — next sync will catch up.
-            console.warn(`New-mail sync skipped for ${logAccount(account)}/${folder}: stale UID range after concurrent expunge`);
+            // SEARCH or an exact candidate FETCH became stale after a concurrent EXPUNGE.
+            // Preserve the retry floor and keep later phases from advancing past the gap.
+            metadataRetryDeferred = true;
+            warnIncompleteFetch();
           }
         }
 
@@ -2860,8 +3880,8 @@ export class ImapManager {
         // Bounded by FLAG_SCAN_TIMEOUT_MS: if a throttled connection makes it crawl, we DEFER it
         // (flagScanComplete=false) and skip advancing the watermark, so it retries next tick with
         // nothing lost — rather than burning the whole-sync budget and forcing a reconnect.
-        let flagScanComplete = true;
-        if (plan === 'delta') {
+        let flagScanComplete = !metadataRetryDeferred;
+        if (!metadataRetryDeferred && plan === 'delta') {
           // Flag-only scan. The only thing that changes on an EXISTING message is its flags
           // (read/star) — new mail is the UID phase's job — so fetch just uid+flags over a recent
           // UID window and bulk-apply. Deliberately lightweight: iCloud advertises CONDSTORE (so
@@ -2874,8 +3894,13 @@ export class ImapManager {
           const flagsToUpdate = [];
           try {
             const scan = (async () => {
-              for await (const msg of client.fetch(`${deltaLow}:*`, { uid: true, flags: true }, { uid: true, changedSince: BigInt(storedModseq) })) {
-                flagsToUpdate.push({ uid: msg.uid, isRead: msg.flags.has('\\Seen'), isStarred: msg.flags.has('\\Flagged') });
+              for await (const msg of client.fetch(`${deltaLow}:*`, { uid: true, flags: true, modseq: true }, { uid: true, changedSince: BigInt(storedModseq) })) {
+                flagsToUpdate.push({
+                  uid: msg.uid,
+                  isRead: msg.flags.has('\\Seen'),
+                  isStarred: msg.flags.has('\\Flagged'),
+                  modseq: msg.modseq ?? null,
+                });
               }
             })();
             // If the timeout wins the race, the fetch keeps running until ImapFlow's commandTimeout
@@ -2900,7 +3925,9 @@ export class ImapManager {
           // so the next tick redoes it. A flag change has no new_messages event of its own, so a
           // flags_synced nudge lets a read-elsewhere reflect live instead of staying stale.
           if (flagScanComplete) {
-            const changed = await this._applyFlagUpdates(account, folder, flagsToUpdate);
+            const changed = await this._applyFlagUpdates(
+              account, folder, flagsToUpdate, currentValidity, observationContext, pullSnapshot
+            );
             logger.debug(`Delta flag scan OK for ${logAccount(account)}/${folder}: ${flagsToUpdate.length} fetched, ${changed} changed in ${Date.now() - deltaStartedAt}ms (uid>=${deltaLow}), modseq ${storedModseq}->${serverModseq}`);
             if (changed > 0) {
               this.broadcast({ type: 'flags_synced', accountId: account.id }, account.user_id);
@@ -2911,7 +3938,7 @@ export class ImapManager {
               await emitSectionsChanged(this.pluginFacade, account, changed);
             }
           }
-        } else if (plan === 'full') {
+        } else if (!metadataRetryDeferred && plan === 'full') {
           // A missing/invalid modseq baseline or an incomplete local cache requires a recent
           // sequence scan with full metadata. Re-read exists from the live connection — ImapFlow
           // may have decremented it if an EXPUNGE arrived during the UID phase, making a range
@@ -2920,12 +3947,18 @@ export class ImapManager {
           // older un-cached messages in a large folder are backfill's job, not this scan's; backfill
           // runs on connect/reconnect/reindex and its dbCount-vs-serverTotal check re-detects the gap.
           const liveExists = client.mailbox?.exists ?? 0;
-          const phase2Range = liveExists > limit
-            ? `${liveExists - limit + 1}:${liveExists}` : '1:*';
+          const expectedMetadataCount = Math.min(liveExists, limit);
+          const phase2Range = expectedMetadataCount === 0
+            ? null
+            : liveExists > limit
+              ? `${liveExists - limit + 1}:${liveExists}`
+              : `1:${liveExists}`;
           try {
+            const fullMetadataBatch = [];
             const scan = (async () => {
+              if (!phase2Range) return;
               for await (const msg of client.fetch(phase2Range, fetchQuery)) {
-                await processMsg(msg);
+                fullMetadataBatch.push(msg);
               }
             })();
             scan.catch(() => {}); // see the delta branch — swallow a post-timeout late rejection
@@ -2936,6 +3969,8 @@ export class ImapManager {
             if (outcome === FLAG_SCAN_TIMED_OUT) {
               flagScanComplete = false;
               console.warn(`Sequence flag scan deferred for ${logAccount(account)}/${folder}: over ${FLAG_SCAN_TIMEOUT_MS}ms (provider throttling) — retrying next tick`);
+            } else if (!await processMetadataBatch(fullMetadataBatch, expectedMetadataCount)) {
+              flagScanComplete = false;
             }
           } catch (err) {
             if (!extractImapError(err).toLowerCase().includes('invalid messageset')) throw err;
@@ -2953,10 +3988,15 @@ export class ImapManager {
         // advancing past an incomplete scan would drop those flag changes. Skipped when nothing
         // changed (already equal) and on a UIDVALIDITY reset (reseed from the new epoch instead).
         if (serverModseq != null && !uidValidityChanged && plan !== 'unchanged' && flagScanComplete) {
-          await query(
-            'UPDATE folders SET highest_modseq = $1 WHERE account_id = $2 AND path = $3',
-            [serverModseq.toString(), account.id, folder]
-          );
+          await withTransaction(async (tx) => {
+            await assertCurrentSyncEpoch(tx);
+            await tx.query(
+              `UPDATE folders SET highest_modseq = $1
+                WHERE account_id = $2 AND path = $3
+                  AND ($4::bigint IS NULL OR uid_validity = $4)`,
+              [serverModseq.toString(), account.id, folder, currentValidity]
+            );
+          });
         }
 
         if (newMessages.length > 0) {
@@ -2969,12 +4009,12 @@ export class ImapManager {
             // re-eval below can exclude any they move out of INBOX. Only needed with an ingest plugin.
             const unreadBeforeRules = wantsInboxIngest ? newMessages.map(m => m.id) : null;
             try {
-              newMessages = await applyBlockList(newMessages, account, this);
+              newMessages = await applyBlockList(newMessages, account, this, observationContext);
             } catch (err) {
               console.error('blockList error:', err.message);
             }
             try {
-              const rulesResult = await applyInboxRules(newMessages, account, this);
+              const rulesResult = await applyInboxRules(newMessages, account, this, observationContext);
               newMessages = rulesResult.remaining;
               mutedIds = rulesResult.mutedIds;
             } catch (err) {
@@ -3033,7 +4073,8 @@ export class ImapManager {
             query(
               `SELECT COUNT(*)::int AS total FROM messages m
                JOIN email_accounts a ON a.id = m.account_id
-               WHERE a.user_id = $1 AND a.enabled = true AND m.folder = 'INBOX' AND m.is_read = false AND m.is_deleted = false`,
+               WHERE a.user_id = $1 AND a.enabled = true AND m.folder = 'INBOX'
+                 AND m.is_read = false AND m.is_deleted = false AND m.metadata_complete = true`,
               [account.user_id]
             ).then(r => {
               sendPushToUser(account.user_id, { ...basePayload, unreadCount: r.rows[0]?.total ?? 0 })
@@ -3093,20 +4134,43 @@ export class ImapManager {
         // without this an on-demand folder (e.g. Junk/Spam, which has no follow-up tick) keeps
         // showing the pre-sync count until it is opened again. Mirrors the recompute that backfill
         // and reconcileDeletes already run; total_count keeps the server EXISTS value set above.
-        await query(
-          `UPDATE folders
-           SET unread_count = (SELECT COUNT(*) FILTER (WHERE m.is_read = false)
-                               FROM messages m WHERE m.account_id = $1 AND m.folder = $2)
-           WHERE account_id = $1 AND path = $2`,
-          [account.id, folder]
-        );
-        await query('UPDATE email_accounts SET last_sync = NOW() WHERE id = $1', [account.id]);
+        const reconciledServerTotal = Number(client.mailbox?.exists ?? mailbox.exists ?? 0);
+        await withTransaction(async (tx) => {
+          if (observationContext.tokens.length > 0) await assertObservationContext(tx, account.id, observationContext);
+          else await lockFolderRows(tx, account.id, [folder]);
+          await tx.query(
+            `UPDATE folders
+             SET total_count = $3,
+                 unread_count = (SELECT COUNT(*) FILTER (WHERE m.is_read = false)
+                                 FROM messages m WHERE m.account_id = $1 AND m.folder = $2
+                                   AND m.is_deleted = false AND m.metadata_complete = true)
+             WHERE account_id = $1 AND path = $2`,
+            [account.id, folder, reconciledServerTotal]
+          );
+          await tx.query(
+            'UPDATE email_accounts SET last_sync = NOW() WHERE id = $1',
+            [account.id]
+          );
+        });
         return { insertedCount, broadcastedNewMessages };
       } finally {
         lock.release();
       }
     } catch (err) {
       console.error(`Message sync error for ${logAccount(account)}/${folder}:`, extractImapError(err));
+      const superseded = err?.code === 'SYNC_UIDVALIDITY_CHANGED' || isFolderObservationError(err);
+      if (superseded) {
+        try { client.close(); } catch { /* already closed */ }
+      }
+      if (superseded && supersessionRestartsRemaining > 0) {
+        // One fresh-login retry gives this operation a new SELECT/UID set without
+        // allowing competing observers to create an unbounded recursive retry loop.
+        return this._withFreshSyncSession(account, (freshClient) =>
+          ImapManager.prototype.syncMessages.call(
+            this, account, freshClient, folder, limit, prefetchBody, noBodyParts,
+            supersessionRestartsRemaining - 1
+          ));
+      }
       throw err;
     }
   }
@@ -3121,25 +4185,111 @@ export class ImapManager {
   //      quickly even on a fresh account with tens of thousands of messages.
   //   4. For non-Gmail providers also store body_html/body_text during backfill so
   //      clicking an old email never needs a live IMAP round-trip.
-  async backfillMessages(account, folder = 'INBOX') {
+  async backfillMessages(account, folder = 'INBOX', restartOnSupersession = true) {
     const backfillKey = `${account.id}:${folder}`;
-    if (this.backfillRunning.has(backfillKey)) return;
+    if (this.backfillRunning.has(backfillKey)) return false;
     this.backfillRunning.add(backfillKey);
 
     // Spread into a local copy so per-run mutations (e.g. batchSize reduction on rate-limit)
     // don't permanently modify the shared PROVIDERS singleton for other accounts.
     const cfg = { ...providerProfile(account) };
 
-    // Relocate-exempt label folders for this account (empty when no label plugin is active).
-    // Loaded once per backfill — the plugins' folder sets are cheap/cached — so the relocate
-    // guard keeps labeled messages' sibling rows. See relocateMessageQuery /
-    // collectRelocateExemptFolders.
-    const exemptFolders = await collectRelocateExemptFolders(account);
-
     // Dedicated connection managed here — completely independent of the shared pool
     // so backfilling never blocks the user from opening emails.
     let bfClient = null;
     let batchesOnConn = 0;
+    let backfillUidValidity = null;
+    let backfillObservationToken = null;
+    let observationStartedAt = null;
+
+    const backfillEpochError = (observed, source) => {
+      const err = new Error(`Backfill UIDVALIDITY changed from ${backfillUidValidity} to ${observed} (${source})`);
+      err.code = 'BACKFILL_UIDVALIDITY_CHANGED';
+      return err;
+    };
+
+    const assertBackfillEpoch = () => {
+      const selectedValidity = bfClient?.mailbox?.uidValidity != null
+        ? Number(bfClient.mailbox.uidValidity)
+        : null;
+      if (backfillUidValidity == null) {
+        backfillUidValidity = selectedValidity;
+      } else if (selectedValidity != null && selectedValidity !== backfillUidValidity) {
+        throw backfillEpochError(selectedValidity, 'selected mailbox');
+      }
+      return selectedValidity;
+    };
+
+    const assertStoredBackfillEpoch = async (runQuery = query, { lock = false } = {}) => {
+      if (backfillUidValidity == null) return;
+      const stored = await runQuery(
+        `SELECT uid_validity FROM folders WHERE account_id = $1 AND path = $2${lock ? ' FOR UPDATE' : ''}`,
+        [account.id, folder]
+      );
+      const storedValidity = stored.rows[0]?.uid_validity != null
+        ? Number(stored.rows[0].uid_validity)
+        : null;
+      if (storedValidity !== backfillUidValidity) {
+        throw backfillEpochError(storedValidity, 'folder state');
+      }
+    };
+
+    const withBackfillEpochFence = (callback) => withTransaction(async (tx) => {
+      if (backfillObservationToken) {
+        await assertFolderObservation(tx, account.id, backfillObservationToken);
+      }
+      await assertStoredBackfillEpoch((sql, params) => tx.query(sql, params), { lock: true });
+      return callback(tx);
+    });
+
+    const completeBackfill = async ({ empty = false } = {}) => {
+      return withBackfillEpochFence(async (tx) => {
+        if (empty) {
+          const newer = await tx.query(
+            `SELECT 1 FROM messages
+              WHERE account_id = $1 AND folder = $2 AND synced_at >= $3
+              LIMIT 1`,
+            [account.id, folder, observationStartedAt]
+          );
+          if (newer.rows.length > 0) return false;
+        }
+        const completed = empty
+          ? await tx.query(
+              `UPDATE folders
+                  SET total_count = 0, unread_count = 0, backfill_incomplete = false
+                WHERE account_id = $1 AND path = $2
+                RETURNING path`,
+              [account.id, folder]
+            )
+          : await tx.query(
+              `UPDATE folders
+                  SET total_count  = (SELECT COUNT(*) FROM messages m
+                                       WHERE m.account_id = $1 AND m.folder = $2
+                                         AND m.is_deleted = false AND m.metadata_complete = true),
+                      unread_count = (SELECT COUNT(*) FILTER (WHERE is_read = false) FROM messages m
+                                       WHERE m.account_id = $1 AND m.folder = $2
+                                         AND m.is_deleted = false AND m.metadata_complete = true),
+                      backfill_incomplete = false
+                WHERE account_id = $1 AND path = $2
+                RETURNING path`,
+              [account.id, folder]
+            );
+        if (completed.rowCount === 0 && completed.rows.length === 0) {
+          throw new Error(`Backfill folder disappeared for ${logAccount(account)}/${folder}`);
+        }
+        return true;
+      });
+    };
+
+    const verifyBackfillEpoch = async () => {
+      const lock = await bfClient.getMailboxLock(folder);
+      try {
+        assertBackfillEpoch();
+        await assertStoredBackfillEpoch();
+      } finally {
+        lock.release();
+      }
+    };
 
     const openBfClient = async () => {
       // Always clean up any existing client before creating a new one
@@ -3166,20 +4316,33 @@ export class ImapManager {
       // A false skip is self-correcting: the next reconnect or explicit sync will
       // re-evaluate, and syncMessages independently checks UIDVALIDITY changes.
       const folderMeta = await query(
-        'SELECT uid_validity, total_count FROM folders WHERE account_id = $1 AND path = $2',
+        'SELECT uid_validity, total_count, backfill_incomplete FROM folders WHERE account_id = $1 AND path = $2',
         [account.id, folder]
       );
       const meta = folderMeta.rows[0];
-      if (meta?.uid_validity && meta.total_count > 0) {
+      if (meta?.uid_validity && meta.total_count > 0 && !meta.backfill_incomplete) {
         const countRow = await query(
           'SELECT COUNT(*) AS n FROM messages WHERE account_id = $1 AND folder = $2 AND is_deleted = false',
           [account.id, folder]
         );
         if (Number(countRow.rows[0].n) >= Number(meta.total_count)) {
           logger.debug(`Backfill skipped for ${logAccount(account)}/${folder} — DB pre-check: ${countRow.rows[0].n} msgs ≥ cached total ${meta.total_count}`);
-          return;
+          return true;
         }
       }
+
+      // One advancing token owns the server observation and every marker/data/count write.
+      // Claim it before publishing that an exact diff is owed and before SELECT/SEARCH.
+      backfillObservationToken = await claimFolderObservation(account.id, folder);
+      observationStartedAt = new Date();
+
+      // Once a run passes the cheap completed-folder gate, persist that an exact UID diff is now
+      // owed. Any interruption or incomplete FETCH keeps future runs from trusting count/max
+      // shortcuts until a full server-vs-DB UID comparison clears this marker.
+      await withBackfillEpochFence((tx) => tx.query(
+        'UPDATE folders SET backfill_incomplete = true WHERE account_id = $1 AND path = $2',
+        [account.id, folder]
+      ));
 
       console.log(`Starting backfill for ${logAccount(account)}/${folder} (batch=${cfg.batchSize}, delay=${cfg.batchDelay}ms, fetchBody=${cfg.fetchBody})`);
       await openBfClient();
@@ -3191,38 +4354,40 @@ export class ImapManager {
       {
         const lock = await bfClient.getMailboxLock(folder);
         try {
+          const currentValidity = assertBackfillEpoch();
+
+          // Backfill may seed an as-yet-unknown epoch, but it never changes a known one.
+          // Only syncMessages performs epoch transitions because it can atomically publish
+          // the new epoch and purge the old rows under the shared folder-row lock. Treat a
+          // mismatch here as a stale backfill connection and leave the durable marker set.
+          if (currentValidity) {
+            await withTransaction(async (tx) => {
+              const foldRow = await tx.query(
+                `SELECT uid_validity FROM folders
+                  WHERE account_id = $1 AND path = $2
+                  FOR UPDATE`,
+                [account.id, folder]
+              );
+              const storedValidity = foldRow.rows[0]?.uid_validity != null
+                ? Number(foldRow.rows[0].uid_validity)
+                : null;
+              if (storedValidity !== null && storedValidity !== currentValidity) {
+                throw backfillEpochError(storedValidity, 'folder state');
+              }
+              if (storedValidity === null) {
+                backfillObservationToken = await seedFolderUidValidity(
+                  tx, account.id, backfillObservationToken, currentValidity,
+                );
+              }
+            });
+          }
+
           const totalExists = bfClient.mailbox?.exists || 0;
           if (totalExists === 0) {
             logger.debug(`Backfill ${logAccount(account)}: mailbox empty`);
-            await query(
-              'UPDATE folders SET total_count = 0, unread_count = 0 WHERE account_id = $1 AND path = $2',
-              [account.id, folder]
-            ).catch(() => {});
-            return;
+            return await completeBackfill({ empty: true });
           }
           serverUids = await bfClient.search({ all: true }, { uid: true });
-
-          // UIDVALIDITY check — if this backfill connection sees a different epoch than
-          // what is stored, purge stale rows so the diff below re-fetches everything.
-          const currentValidity = bfClient.mailbox?.uidValidity ? Number(bfClient.mailbox.uidValidity) : null;
-          if (currentValidity) {
-            const foldRow = await query(
-              'SELECT uid_validity FROM folders WHERE account_id = $1 AND path = $2',
-              [account.id, folder]
-            );
-            const storedValidity = foldRow.rows[0]?.uid_validity ? Number(foldRow.rows[0].uid_validity) : null;
-            if (storedValidity !== null && storedValidity !== currentValidity) {
-              console.warn(`Backfill: UIDVALIDITY changed for ${logAccount(account)}/${folder}: ${storedValidity} → ${currentValidity}. Purging stale messages.`);
-              const purged = await query('DELETE FROM messages WHERE account_id = $1 AND folder = $2', [account.id, folder]);
-              // Same GTD section-data staleness gap as the syncMessages purge path.
-              await emitSectionsChanged(this.pluginFacade, account, purged.rowCount);
-            }
-            // Always keep stored validity current
-            await query(
-              'UPDATE folders SET uid_validity = $1 WHERE account_id = $2 AND path = $3',
-              [currentValidity, account.id, folder]
-            );
-          }
         } finally {
           lock.release();
         }
@@ -3241,18 +4406,10 @@ export class ImapManager {
         [account.id, folder]
       );
       const dbCount = parseInt(dbSummaryResult.rows[0].count);
-      const maxDbUid = Number(dbSummaryResult.rows[0].max_uid);
-      // serverUids from UID SEARCH ALL are in ascending order per IMAP RFC 3501
-      const maxServerUid = serverUids.length > 0 ? serverUids[serverUids.length - 1] : 0;
 
-      // Both conditions must hold: we have the newest message (max UID matches) AND
-      // we have at least as many messages as the server.  Checking only max UID is
-      // insufficient — syncMessages always fetches the most-recent N messages, so
-      // maxDbUid == maxServerUid even when thousands of older messages are missing.
-      if (maxServerUid > 0 && maxDbUid >= maxServerUid && dbCount >= serverTotal) {
-        console.log(`Backfill already complete for ${logAccount(account)}: maxDbUid=${maxDbUid}, maxServerUid=${maxServerUid}, dbCount=${dbCount}`);
-        return;
-      }
+      // Once the cheap completed-folder gate above decides a backfill is needed, always compute
+      // the exact UID diff. Count+max alone cannot prove completeness: one stale DB UID can mask
+      // one genuine historical gap while preserving both values.
 
       // Step 2 — load UIDs we already have so we can diff precisely.
       // Even for 47 000 messages this query is fast (uid is indexed) and the
@@ -3262,7 +4419,7 @@ export class ImapManager {
       // comparison works correctly. IMAP UIDs are 32-bit unsigned integers so
       // they are always within JavaScript's safe integer range (< 2^53).
       const existingRows = await query(
-        'SELECT uid FROM messages WHERE account_id = $1 AND folder = $2',
+        'SELECT uid FROM messages WHERE account_id = $1 AND folder = $2 AND metadata_complete = true',
         [account.id, folder]
       );
       const existingUids = new Set(existingRows.rows.map(r => Number(r.uid)));
@@ -3273,16 +4430,11 @@ export class ImapManager {
         .sort((a, b) => b - a);
 
       if (missingUids.length === 0) {
+        await verifyBackfillEpoch();
         console.log(`Backfill ${logAccount(account)}: no missing UIDs (${dbCount} in DB vs ${serverTotal} on server — within tolerance)`);
         // Still reconcile folder counts — they may be stale if a previous backfill was interrupted.
-        await query(
-          `UPDATE folders
-           SET total_count  = (SELECT COUNT(*)                                FROM messages m WHERE m.account_id = $1 AND m.folder = $2),
-               unread_count = (SELECT COUNT(*) FILTER (WHERE is_read = false)  FROM messages m WHERE m.account_id = $1 AND m.folder = $2)
-           WHERE account_id = $1 AND path = $2`,
-          [account.id, folder]
-        ).catch(() => {});
-        return;
+        await completeBackfill();
+        return true;
       }
 
       console.log(`Backfill ${logAccount(account)}: ${missingUids.length} missing of ${serverTotal} (${dbCount} already in DB)`);
@@ -3303,13 +4455,21 @@ export class ImapManager {
       // refreshed once at completion when the account is gtd_enabled — the tick's fingerprint
       // can't see rows backfill already wrote (before==after). See emitSectionsChanged.
       let backfilledRows = 0;
+      let backfillIncomplete = false;
+      let warnedIncompleteBackfill = false;
+      const deferIncompleteBackfill = () => {
+        backfillIncomplete = true;
+        if (warnedIncompleteBackfill) return;
+        warnedIncompleteBackfill = true;
+        console.warn(`Backfill deferred incomplete metadata for ${logAccount(account)}/${folder}; retrying on a later backfill`);
+      };
 
       while (i < missingUids.length) {
         // Stop immediately if the account was deleted while backfilling
         const accountCheck = await query('SELECT id FROM email_accounts WHERE id = $1', [account.id]);
         if (!accountCheck.rows.length) {
           console.log(`Backfill stopping — account ${logAccount(account)} was deleted`);
-          return;
+          return false;
         }
 
         // Periodically reconnect to keep connections fresh and pick up refreshed OAuth tokens
@@ -3323,12 +4483,12 @@ export class ImapManager {
         }
 
         const batch = missingUids.slice(i, i + cfg.batchSize);
-        // Comma-separated UID list — e.g. "1234,5678,9012"
-        const uidSet = batch.join(',');
 
         try {
           const lock = await bfClient.getMailboxLock(folder);
           try {
+            assertBackfillEpoch();
+            await assertStoredBackfillEpoch();
             // Third arg { uid: true } issues UID FETCH instead of sequence FETCH.
             // bodyParts omitted for Gmail (empty array) — metadata only, no throttling.
             const bfQuery = {
@@ -3339,8 +4499,12 @@ export class ImapManager {
             };
             if (bodyParts.length > 0) bfQuery.bodyParts = bodyParts;
 
-            for await (const msg of bfClient.fetch(uidSet, bfQuery, { uid: true })) {
-              try {
+            const metadataMessages = await fetchCompleteMetadataBatch(bfClient, batch, bfQuery);
+            if (metadataMessages === null) {
+              deferIncompleteBackfill();
+            } else {
+              for (const msg of metadataMessages) {
+                try {
                 const parsed = await parseMessage(msg);
                 enrichParsedMetadata(parsed, {
                   accountEmail: account.email_address,
@@ -3351,6 +4515,7 @@ export class ImapManager {
                 });
                 if (!parsed.uid) {
                   console.warn(`Backfill skipped: IMAP FETCH returned no UID for ${account.email}/${folder}`);
+                  deferIncompleteBackfill();
                   continue;
                 }
                 let safeHtml = null, bodyText = null, atts = [];
@@ -3366,14 +4531,6 @@ export class ImapManager {
                 const bfReplyTo  = sanitizeStr(parsed.inReplyTo);
                 const bfRefs     = sanitizeStr(parsed.references);
                 const bfThreadId = await computeThreadId(account.id, bfMsgId, bfReplyTo, bfRefs, sanitizeStr(parsed.subject));
-
-                if (bfMsgId) {
-                  const { sql: relocateSql, params: relocateParams } =
-                    relocateMessageQuery(folder, parsed, account.id, bfMsgId, exemptFolders);
-                  const relocated = await query(relocateSql, relocateParams);
-                  if (relocated.rows.length > 0) { backfilledRows += relocated.rows.length; continue; }
-                }
-
                 let bfCategory = null;
                 if (account.categorization_enabled || await getGlobalCategorizationEnabled(account.user_id)) {
                   try {
@@ -3383,8 +4540,9 @@ export class ImapManager {
                   } catch { /* non-fatal */ }
                 }
 
-                await query(`
-                  INSERT INTO messages (
+                const writeResult = await withBackfillEpochFence(async (tx) => {
+                  await tx.query(`
+                    INSERT INTO messages (
                     account_id, uid, folder, message_id, subject,
                     from_name, from_email, to_addresses, cc_addresses,
                     reply_to, in_reply_to,
@@ -3395,87 +4553,41 @@ export class ImapManager {
                     sender_name, sender_email
                   ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29)
                   ON CONFLICT (account_id, uid, folder) DO UPDATE
-                  SET subject = CASE
-                        WHEN EXCLUDED.subject IS NOT NULL
-                             AND EXCLUDED.subject != ''
-                             AND EXCLUDED.subject != '(no subject)'
-                        THEN EXCLUDED.subject
-                        ELSE messages.subject
-                      END,
-                      from_name = COALESCE(NULLIF(EXCLUDED.from_name, ''), messages.from_name),
-                      from_email = COALESCE(NULLIF(EXCLUDED.from_email, ''), messages.from_email),
-                      to_addresses = CASE
-                        WHEN EXCLUDED.to_addresses::text IS NOT NULL AND EXCLUDED.to_addresses::text <> '[]'
-                        THEN EXCLUDED.to_addresses
-                        ELSE messages.to_addresses
-                      END,
-                      cc_addresses = CASE
-                        WHEN EXCLUDED.cc_addresses::text IS NOT NULL AND EXCLUDED.cc_addresses::text <> '[]'
-                        THEN EXCLUDED.cc_addresses
-                        ELSE messages.cc_addresses
-                      END,
-                      reply_to = COALESCE(NULLIF(messages.reply_to::text, '[]'), EXCLUDED.reply_to::text)::jsonb,
-                      in_reply_to = COALESCE(messages.in_reply_to, EXCLUDED.in_reply_to),
-                      snippet = CASE WHEN EXCLUDED.snippet != '' THEN EXCLUDED.snippet
-                                     ELSE messages.snippet END,
-                      is_read = CASE
-                        WHEN messages.read_changed_at IS NOT NULL
-                             AND NOW() - messages.read_changed_at < interval '30 seconds'
-                        THEN messages.is_read
-                        ELSE EXCLUDED.is_read
-                      END,
-                      is_starred = CASE
-                        WHEN messages.star_changed_at IS NOT NULL
-                             AND NOW() - messages.star_changed_at < interval '30 seconds'
-                        THEN messages.is_starred
-                        ELSE EXCLUDED.is_starred
-                      END,
-                      flags = EXCLUDED.flags,
-                      body_html = COALESCE(messages.body_html, EXCLUDED.body_html),
-                      body_text = COALESCE(messages.body_text, EXCLUDED.body_text),
-                      attachments = COALESCE(messages.attachments::text, EXCLUDED.attachments::text)::jsonb,
-                      thread_references = COALESCE(messages.thread_references, EXCLUDED.thread_references),
-                      -- #378: heal a self-rooted (orphaned) row by adopting the real conversation root.
-                      thread_id = CASE
-                        WHEN messages.thread_id = messages.message_id
-                             AND EXCLUDED.thread_id IS NOT NULL
-                             AND EXCLUDED.thread_id <> messages.message_id
-                        THEN EXCLUDED.thread_id
-                        ELSE COALESCE(messages.thread_id, EXCLUDED.thread_id)
-                      END,
-                      is_bulk = COALESCE(messages.is_bulk, EXCLUDED.is_bulk),
-                      category = COALESCE(messages.category, EXCLUDED.category),
-                      list_unsubscribe = COALESCE(messages.list_unsubscribe, EXCLUDED.list_unsubscribe),
-                      list_unsubscribe_post = COALESCE(messages.list_unsubscribe_post, EXCLUDED.list_unsubscribe_post),
-                      delivery_addresses = COALESCE(messages.delivery_addresses, EXCLUDED.delivery_addresses),
-                      sender_name = COALESCE(EXCLUDED.sender_name, messages.sender_name),
-                      sender_email = COALESCE(EXCLUDED.sender_email, messages.sender_email)
-                `, [
-                  account.id, parsed.uid, folder,
-                  bfMsgId, sanitizeStr(parsed.subject),
-                  sanitizeStr(parsed.fromName), sanitizeStr(parsed.fromEmail),
-                  JSON.stringify(parsed.to), JSON.stringify(parsed.cc),
-                  JSON.stringify(parsed.replyTo || []), bfReplyTo,
-                  safeDate(parsed.date), sanitizeStr(parsed.snippet),
-                  parsed.isRead, parsed.isStarred,
-                  parsed.hasAttachments, JSON.stringify(parsed.flags),
-                  sanitizeStr(safeHtml), sanitizeStr(bodyText), JSON.stringify(atts || []),
-                  bfRefs, bfThreadId, parsed.isBulk ?? null, bfCategory,
-                  sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe'] ?? null)),
-                  sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe-post'] ?? null)),
-                  JSON.stringify(parsed.deliveryAddresses || []),
-                  sanitizeStr(parsed.senderName), sanitizeStr(parsed.senderEmail),
-                ]);
-                backfilledRows++;
-                if (bfThreadId && bfThreadId !== bfMsgId) {
-                  await query(
-                    `UPDATE messages SET thread_id = $1
-                     WHERE account_id = $2 AND thread_id = $3 AND message_id != $3`,
-                    [bfThreadId, account.id, bfMsgId]
-                  );
+                  SET ${COMPLETE_METADATA_CONFLICT_UPDATE_SQL}
+                  `, [
+                    account.id, parsed.uid, folder,
+                    bfMsgId, sanitizeStr(parsed.subject),
+                    sanitizeStr(parsed.fromName), sanitizeStr(parsed.fromEmail),
+                    JSON.stringify(parsed.to), JSON.stringify(parsed.cc),
+                    JSON.stringify(parsed.replyTo || []), bfReplyTo,
+                    safeDate(parsed.date), sanitizeStr(parsed.snippet),
+                    parsed.isRead, parsed.isStarred,
+                    parsed.hasAttachments, JSON.stringify(parsed.flags),
+                    sanitizeStr(safeHtml), sanitizeStr(bodyText), JSON.stringify(atts || []),
+                    bfRefs, bfThreadId, parsed.isBulk ?? null, bfCategory,
+                    sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe'] ?? null)),
+                    sanitizeStr(decodeMimeWords(parsed.parsedHeaders?.['list-unsubscribe-post'] ?? null)),
+                    JSON.stringify(parsed.deliveryAddresses || []),
+                    sanitizeStr(parsed.senderName), sanitizeStr(parsed.senderEmail),
+                  ]);
+
+                  if (bfThreadId && bfThreadId !== bfMsgId) {
+                    await tx.query(
+                      `UPDATE messages SET thread_id = $1
+                       WHERE account_id = $2 AND thread_id = $3 AND message_id != $3`,
+                      [bfThreadId, account.id, bfMsgId]
+                    );
+                  }
+                  return { rowsChanged: 1 };
+                });
+                backfilledRows += writeResult.rowsChanged;
+                } catch (parseErr) {
+                  if (parseErr?.code === 'BACKFILL_UIDVALIDITY_CHANGED' ||
+                      parseErr?.code === 'FOLDER_OBSERVATION_SUPERSEDED' ||
+                      parseErr?.code === 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED') throw parseErr;
+                  console.error('Backfill parse error:', parseErr.message);
+                  deferIncompleteBackfill();
                 }
-              } catch (parseErr) {
-                console.error('Backfill parse error:', parseErr.message);
               }
             }
           } finally {
@@ -3498,6 +4610,9 @@ export class ImapManager {
           await new Promise(r => setTimeout(r, cfg.batchDelay));
 
         } catch (err) {
+          if (err?.code === 'BACKFILL_UIDVALIDITY_CHANGED' ||
+              err?.code === 'FOLDER_OBSERVATION_SUPERSEDED' ||
+              err?.code === 'FOLDER_OBSERVATION_UIDVALIDITY_CHANGED') throw err;
           consecutiveErrors++;
           const detail = extractImapError(err);
           // Discard the broken connection — openBfClient will reconnect next iteration
@@ -3521,24 +4636,50 @@ export class ImapManager {
         }
       }
 
+      if (backfillIncomplete) {
+        // Keep the authoritative server count instead of shrinking it to the incomplete DB
+        // count. The next backfill then fails its count pre-check and recomputes the exact
+        // missing UID set, while clients never receive a false completion event.
+        await withBackfillEpochFence((tx) => tx.query(
+          `UPDATE folders
+              SET total_count = $3,
+                  unread_count = (SELECT COUNT(*) FILTER (WHERE is_read = false)
+                                    FROM messages m
+                                   WHERE m.account_id = $1 AND m.folder = $2
+                                     AND m.is_deleted = false AND m.metadata_complete = true),
+                  backfill_incomplete = true
+            WHERE account_id = $1 AND path = $2`,
+          [account.id, folder, serverTotal]
+        ));
+        await emitSectionsChanged(this.pluginFacade, account, backfilledRows);
+        return false;
+      }
+
       console.log(`Backfill complete for ${logAccount(account)}/${folder}`);
+      await verifyBackfillEpoch();
       // Backfill inserts rows directly without going through adjustFolderCounts,
       // so folder counters would stay at 0 without this reconciliation step.
-      await query(
-        `UPDATE folders
-         SET total_count  = (SELECT COUNT(*)                                FROM messages m WHERE m.account_id = $1 AND m.folder = $2),
-             unread_count = (SELECT COUNT(*) FILTER (WHERE is_read = false)  FROM messages m WHERE m.account_id = $1 AND m.folder = $2)
-         WHERE account_id = $1 AND path = $2`,
-        [account.id, folder]
-      ).catch(err => console.error(`Folder count update after backfill failed for ${logAccount(account)}/${folder}:`, err.message));
+      await completeBackfill();
       this.broadcast({ type: 'backfill_complete', accountId: account.id }, account.user_id);
       // Backfill wrote rows the GTD tick's fingerprint can't detect (before==after); if this
       // folder is a designated GTD folder and any row changed, nudge GTD section clients. One emit per
       // affected folder (backfillAllFolders loops here); the client debounces. Gated cheaply
       // on gtd_enabled + changedCount>0 only.
       await emitSectionsChanged(this.pluginFacade, account, backfilledRows);
+      return true;
     } catch (err) {
       console.error(`Backfill failed for ${logAccount(account)}/${folder}:`, err.message);
+      if (restartOnSupersession && typeof this.backfillMessages === 'function' && (
+        isFolderObservationError(err) || err?.code === 'BACKFILL_UIDVALIDITY_CHANGED'
+      )) {
+        if (bfClient) {
+          try { bfClient.close(); } catch { /* already closed */ }
+          bfClient = null;
+        }
+        this.backfillRunning.delete(backfillKey);
+        return this.backfillMessages(account, folder, false);
+      }
+      return false;
     } finally {
       if (bfClient) { try { await bfClient.logout(); } catch { /* already disconnected */ } }
       this.backfillRunning.delete(backfillKey);
@@ -3661,14 +4802,15 @@ export class ImapManager {
   // Skips provider-specific duplicate-view folders (e.g. Gmail's All Mail, Starred, Important)
   // to avoid storing tens of thousands of duplicate message rows.
   async backfillAllFolders(account) {
-    if (this.backfillAllRunning.has(account.id)) return;
+    if (this.backfillAllRunning.has(account.id)) return false;
     this.backfillAllRunning.add(account.id);
     const host = (account.imap_host || '').toLowerCase();
     // Broadcast start BEFORE waiting on the per-host semaphore so a queued reindex shows as
-    // "in progress" in the admin UI instead of looking idle while it waits for a slot. The
-    // matching backfill_all_complete always fires from the finally, so the pair stays balanced.
+    // "in progress" in the admin UI instead of looking idle while it waits for a slot.
+    // A completion event is emitted only when every folder reports a complete metadata pass.
     this.broadcast({ type: 'backfill_all_start', accountId: account.id }, account.user_id);
     let slotHeld = false;
+    let allComplete = false;
     try {
       // Draw from the per-host background-connection budget (shared with the snippet indexer):
       // a user with many accounts on one provider would otherwise open a background connection
@@ -3679,7 +4821,7 @@ export class ImapManager {
       const { skipFolderPatterns, skipFolderNames } = providerProfile(account);
 
       // INBOX first — highest priority, existing behaviour
-      await this.backfillMessages(account, 'INBOX');
+      let metadataDeferred = await this.backfillMessages(account, 'INBOX') === false;
 
       // Then all other known folders (discovered at connect time by syncFolders)
       const folderResult = await query(
@@ -3689,25 +4831,44 @@ export class ImapManager {
 
       for (const { path } of folderResult.rows) {
         const pathLower = path.toLowerCase();
-        if (skipFolderPatterns.some(pat => pathLower.includes(pat))) continue;
-        if (skipFolderNames.includes(pathLower)) continue;
-        await this.backfillMessages(account, path).catch(err =>
-          console.warn(`Backfill skipped ${logAccount(account)}/${path}: ${err.message}`)
-        );
+        const deliberatelySkipped = skipFolderPatterns.some(pat => pathLower.includes(pat))
+          || skipFolderNames.includes(pathLower);
+        if (deliberatelySkipped) {
+          try {
+            await query(
+              'UPDATE folders SET backfill_incomplete = false WHERE account_id = $1 AND path = $2',
+              [account.id, path]
+            );
+          } catch (err) {
+            metadataDeferred = true;
+            console.warn(`Backfill marker clear failed for skipped ${logAccount(account)}/${path}: ${err.message}`);
+          }
+          continue;
+        }
+        const folderComplete = await this.backfillMessages(account, path).catch(err => {
+          console.warn(`Backfill skipped ${logAccount(account)}/${path}: ${err.message}`);
+          return false;
+        });
+        if (folderComplete === false) metadataDeferred = true;
       }
-
+      allComplete = !metadataDeferred;
     } finally {
       if (slotHeld) this._bgConnSem.release(host); // free the per-host slot for the next background job
       this.backfillAllRunning.delete(account.id);
-      this.broadcast({ type: 'backfill_all_complete', accountId: account.id }, account.user_id);
-      // Both run as background jobs after the complete signal — neither should block the UI.
-      this.refreshBulkFlags(account).catch(err =>
-        console.warn(`Bulk flag refresh failed for ${logAccount(account)}:`, err.message)
-      );
-      this.startSnippetIndexer(account).catch(err =>
-        console.error(`Snippet indexer failed for ${logAccount(account)}:`, err.message)
-      );
+      if (allComplete) {
+        this.broadcast({ type: 'backfill_all_complete', accountId: account.id }, account.user_id);
+        // Both run as background jobs after the complete signal — neither should block the UI.
+        this.refreshBulkFlags(account).catch(err =>
+          console.warn(`Bulk flag refresh failed for ${logAccount(account)}:`, err.message)
+        );
+        this.startSnippetIndexer(account).catch(err =>
+          console.error(`Snippet indexer failed for ${logAccount(account)}:`, err.message)
+        );
+      } else {
+        this.broadcast({ type: 'backfill_all_deferred', accountId: account.id }, account.user_id);
+      }
     }
+    return allComplete;
   }
 
   // Called by the body-fetch route whenever a user opens a message that required a live
@@ -3810,46 +4971,58 @@ export class ImapManager {
           }
 
           const batchResult = await query(
-            `SELECT uid FROM messages
-             WHERE account_id = $1 AND folder = $2 AND (snippet IS NULL OR snippet = '') AND snippet_attempted_at IS NULL
-             ORDER BY date DESC LIMIT $3`,
+            `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+                    f.uid_validity AS folder_uid_validity,
+                    f.observation_generation AS folder_observation_generation
+             FROM messages m
+             JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                           AND f.is_present = true AND f.uid_validity IS NOT NULL
+             WHERE m.account_id = $1 AND m.folder = $2
+               AND m.is_deleted = false AND m.metadata_complete = true
+               AND (m.snippet IS NULL OR m.snippet = '') AND m.snippet_attempted_at IS NULL
+             ORDER BY m.date DESC LIMIT $3`,
             [account.id, folder, batchSize]
           );
           if (!batchResult.rows.length) { done = true; break; }
 
           const uids = batchResult.rows.map(r => r.uid);
+          const snapshotByUid = new Map(batchResult.rows.map(row => [Number(row.uid), row]));
+          const batchSnapshots = batchResult.rows.map(snapshotFromMessageRow);
           try {
             const lock = await siClient.getMailboxLock(folder);
             try {
-              for await (const msg of siClient.fetch(uids.join(','), {
-                uid: true, envelope: true, bodyStructure: true,
-                bodyParts: BODY_PREFETCH_PARTS,
-              }, { uid: true })) {
-                try {
-                  const parsed = await parseMessage(msg);
-                  if (parsed.snippet) {
-                    await query(
-                      `UPDATE messages SET snippet = $1
-                       WHERE account_id = $2 AND uid = $3 AND folder = $4
-                         AND (snippet IS NULL OR snippet = '')`,
-                      [sanitizeStr(parsed.snippet), account.id, msg.uid, folder]
-                    );
-                  }
-                } catch { /* skip snippet on parse/update failure */ }
-              }
+              await withUidEpochFence(account.id, folder, siClient, async tx => {
+                for await (const msg of siClient.fetch(uids.join(','), {
+                  uid: true, envelope: true, bodyStructure: true,
+                  bodyParts: BODY_PREFETCH_PARTS,
+                }, { uid: true })) {
+                  try {
+                    const snapshot = snapshotByUid.get(Number(msg.uid));
+                    if (!snapshot) continue;
+                    const parsed = await parseMessage(msg);
+                    if (parsed.snippet) {
+                      await tx.query(
+                        `UPDATE messages SET snippet = $1
+                         WHERE id = $2 AND account_id = $3 AND uid = $4 AND folder = $5
+                           AND (snippet IS NULL OR snippet = '')`,
+                        [sanitizeStr(parsed.snippet), snapshot.id, account.id, msg.uid, folder]
+                      );
+                    }
+                  } catch { /* skip snippet on parse/update failure */ }
+                }
+                // Mark every exact snapshot row in this batch that still has no snippet as
+                // attempted while the folder epoch is fenced. A UID reused after an epoch
+                // transition can never inherit old-epoch body content or retry state.
+                await tx.query(
+                  `UPDATE messages SET snippet_attempted_at = NOW()
+                   WHERE account_id = $1 AND folder = $2 AND id = ANY($3::uuid[])
+                     AND (snippet IS NULL OR snippet = '') AND snippet_attempted_at IS NULL`,
+                  [account.id, folder, batchResult.rows.map(row => row.id)]
+                );
+              }, undefined, null, batchSnapshots);
             } finally {
               lock.release();
             }
-            // Mark every message in this batch that still has no snippet as attempted, so a
-            // fetched-but-empty (or server-missing) message is never re-selected — this is what
-            // guarantees the backlog drains by one batch per iteration instead of looping on the
-            // same un-snippetable rows forever (#379).
-            await query(
-              `UPDATE messages SET snippet_attempted_at = NOW()
-               WHERE account_id = $1 AND folder = $2 AND uid = ANY($3::bigint[])
-                 AND (snippet IS NULL OR snippet = '') AND snippet_attempted_at IS NULL`,
-              [account.id, folder, uids]
-            );
             batchCount++;
             consecutiveErrors = 0;
           } catch (err) {
@@ -3911,19 +5084,61 @@ export class ImapManager {
     }
   }
 
-  async appendToFolder(account, folder, rawMessage, flags = ['\\Seen']) {
-    let uid = null;
-    await withFreshClient(account, async (client) => {
-      const result = await client.append(folder, rawMessage, flags);
-      if (result === false) throw new Error('IMAP append returned false — server did not confirm message was stored');
-      if (result && typeof result.uid === 'number') uid = result.uid;
+  async appendToFolder(account, folder, rawMessage, flags = ['\\Seen'], {
+    operationKey,
+    materialize = null,
+  } = {}) {
+    const destination = await readFolderObservation(account.id, folder);
+    const intent = buildProviderOperationIdentity({
+      kind: 'append', accountId: account.id, destination, requestKey: operationKey,
     });
-    console.log(`Appended to IMAP ${logAccount(account)}/${folder} uid=${uid}`);
-    return { uid, folder };
+    const receipt = await this.providerOperationExecutor.execute({
+      intent,
+      acquireProvider: (callback) => withSwitchableMailboxClient(
+        account, folder, callback,
+      ),
+      validate: async (resource, tx, operation) => {
+        await assertProviderOperationObservations(tx, operation);
+        if (!recoveryKeywordAllowed(resource.client.mailbox, operation.marker)) {
+          throw new Error(`Destination mailbox does not support provider operation marker ${operation.marker}`);
+        }
+        assertLiveProviderEpoch(resource, operation.destination);
+      },
+      validateRecovery: async (resource, tx, operation) => {
+        await assertProviderOperationDestination(tx, operation);
+        assertLiveProviderEpoch(resource, operation.destination);
+      },
+      validateCompletion: (tx, operation) => assertProviderOperationDestination(tx, operation),
+      prepare: ({ client }, marker) => {
+        if (!recoveryKeywordAllowed(client.mailbox, marker)) {
+          throw new Error(`Destination mailbox does not support provider operation marker ${marker}`);
+        }
+      },
+      command: async ({ client }, marker) => ({
+        ...(await appendMessageOnClient(client, folder, rawMessage, flags, marker)),
+        folder,
+      }),
+      recover: async ({ client }, marker) => ({
+        ...(await recoverProviderMarkerOnClient(client, marker)), folder,
+      }),
+      complete: async (providerReceipt, _operation, tx) => {
+        const typedReceipt = { ...providerReceipt, folder };
+        if (tx) await materialize?.(typedReceipt, tx);
+        else await materialize?.(typedReceipt);
+        return typedReceipt;
+      },
+      cleanup: async ({ client }, marker, providerReceipt, operation) => {
+        await cleanupCompletedProviderOperationMarkers({
+          client, switchTo: async () => {},
+        }, marker, providerReceipt, operation);
+      },
+    });
+    console.log(`Appended to IMAP ${logAccount(account)}/${folder} uid=${receipt.uid}`);
+    return receipt;
   }
 
-  async appendToSent(account, folder, rawMessage) {
-    return this.appendToFolder(account, folder, rawMessage, ['\\Seen']);
+  async appendToSent(account, folder, rawMessage, options = {}) {
+    return this.appendToFolder(account, folder, rawMessage, ['\\Seen'], options);
   }
 
   // Persist authoritative Sent metadata right after SMTP/APPEND so a later IMAP sync
@@ -3940,7 +5155,7 @@ export class ImapManager {
     date = new Date(),
     inReplyTo = null,
     references = null,
-  }) {
+  }, { tx = null } = {}) {
     if (!uid || !folder) return;
     const msgId = sanitizeStr(messageId);
     // Thread the Sent copy into its conversation the same way a real sync does — via the
@@ -3950,7 +5165,8 @@ export class ImapManager {
     const threadId = msgId
       ? await computeThreadId(account.id, msgId, sanitizeStr(inReplyTo), sanitizeStr(references), sanitizeStr(subject))
       : null;
-    await query(`
+    const runQuery = tx ? tx.query.bind(tx) : query;
+    await runQuery(`
       INSERT INTO messages (
         account_id, uid, folder, message_id, subject,
         from_name, from_email, to_addresses, cc_addresses,
@@ -3979,7 +5195,8 @@ export class ImapManager {
                AND EXCLUDED.thread_id <> messages.message_id
           THEN EXCLUDED.thread_id
           ELSE COALESCE(messages.thread_id, EXCLUDED.thread_id)
-        END
+        END,
+        metadata_complete = true
     `, [
       account.id, uid, folder, msgId,
       sanitizeStr(subject || '(no subject)'),
@@ -4008,10 +5225,11 @@ export class ImapManager {
     bodyHtml = null,
     bodyText = null,
     date = new Date(),
-  }) {
+  }, { tx = null } = {}) {
     if (!uid || !folder) return;
     const msgId = sanitizeStr(messageId);
-    await query(`
+    const runQuery = tx ? tx.query.bind(tx) : query;
+    await runQuery(`
       INSERT INTO messages (
         account_id, uid, folder, message_id, subject,
         from_name, from_email, to_addresses, cc_addresses,
@@ -4036,7 +5254,8 @@ export class ImapManager {
         snippet = CASE WHEN EXCLUDED.snippet <> '' THEN EXCLUDED.snippet ELSE messages.snippet END,
         flags = EXCLUDED.flags,
         body_html = COALESCE(EXCLUDED.body_html, messages.body_html),
-        body_text = COALESCE(EXCLUDED.body_text, messages.body_text)
+        body_text = COALESCE(EXCLUDED.body_text, messages.body_text),
+        metadata_complete = true
     `, [
       account.id, uid, folder, msgId,
       sanitizeStr(subject || '(no subject)'),
@@ -4052,18 +5271,9 @@ export class ImapManager {
 
   async findUidByMessageId(account, folder, messageId) {
     if (!messageId || !folder) return null;
-    const mid = String(messageId).replace(/[<>]/g, '').trim();
+    const mid = String(messageId).trim();
     if (!mid) return null;
-    return withFreshClient(account, async (client) => {
-      const lock = await client.getMailboxLock(folder);
-      try {
-        const uids = await client.search({ header: ['Message-ID', mid] }, { uid: true });
-        if (!uids?.length) return null;
-        return uids[uids.length - 1];
-      } finally {
-        lock.release();
-      }
-    });
+    return withFencedUidClient(account, folder, (client) => findSingleMessageIdUid(client, mid));
   }
 
   // Syncs the most recent messages in a specific folder on demand.
@@ -4138,13 +5348,22 @@ export class ImapManager {
       try {
         // Skip if body already cached (concurrent click may have triggered this too)
         const existing = await query(
-          'SELECT id FROM messages WHERE id = $1 AND (body_html IS NOT NULL OR body_text IS NOT NULL)',
+          `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+                  f.uid_validity AS folder_uid_validity,
+                  f.observation_generation AS folder_observation_generation,
+                  (m.body_html IS NOT NULL OR m.body_text IS NOT NULL) AS cached
+             FROM messages m
+             JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                           AND f.is_present = true AND f.uid_validity IS NOT NULL
+            WHERE m.id = $1 AND m.is_deleted = false AND m.metadata_complete = true`,
           [msg.id]
         );
-        if (existing.rows.length) continue;
+        if (!existing.rows.length || existing.rows[0].cached) continue;
+        const live = existing.rows[0];
+        const snapshot = snapshotFromMessageRow(live);
 
         const { html, text, attachments } = await this.fetchMessageBody(
-          account, msg.uid, msg.folder || 'INBOX'
+          account, live.uid, live.folder, { snapshot },
         );
         const safeHtml = html ? sanitizeEmail(html) : null;
         if (safeHtml || text) {
@@ -4153,8 +5372,19 @@ export class ImapManager {
             `UPDATE messages
              SET body_html = $1, body_text = $2, attachments = $3,
                  snippet = CASE WHEN $5 != '' THEN $5 ELSE snippet END
-             WHERE id = $4`,
-            [sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(attachments || []), msg.id, sanitizeStr(snip)]
+             WHERE id = $4 AND account_id = $6 AND uid = $7 AND folder = $8
+               AND is_deleted = false AND metadata_complete = true
+               AND EXISTS (
+                 SELECT 1 FROM folders f
+                  WHERE f.account_id = messages.account_id AND f.path = messages.folder
+                    AND f.is_present = true AND f.uid_validity = $9
+                    AND f.observation_generation = $10
+               )`,
+            [
+              sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(attachments || []),
+              msg.id, sanitizeStr(snip), snapshot.accountId, snapshot.uid, snapshot.folder,
+              snapshot.uidValidity, snapshot.folderGeneration,
+            ]
           );
         }
       } catch (err) {
@@ -4177,8 +5407,14 @@ export class ImapManager {
     if (!providerProfile(account).snippetIndex) return;
 
     const uncachedResult = await query(
-      `SELECT id, uid, folder FROM messages
-       WHERE id = ANY($1::uuid[]) AND body_html IS NULL AND body_text IS NULL`,
+      `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+              f.uid_validity AS folder_uid_validity,
+              f.observation_generation AS folder_observation_generation
+         FROM messages m
+         JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                       AND f.is_present = true AND f.uid_validity IS NOT NULL
+        WHERE m.id = ANY($1::uuid[]) AND m.body_html IS NULL AND m.body_text IS NULL
+          AND m.is_deleted = false AND m.metadata_complete = true`,
       [messageIds]
     );
     if (!uncachedResult.rows.length) return;
@@ -4190,13 +5426,16 @@ export class ImapManager {
       }
 
       try {
+        const snapshot = snapshotFromMessageRow(msg);
         const existing = await query(
           'SELECT id FROM messages WHERE id = $1 AND (body_html IS NOT NULL OR body_text IS NOT NULL)',
           [msg.id]
         );
         if (existing.rows.length) continue;
 
-        const { html, text, attachments } = await this.fetchMessageBody(account, msg.uid, msg.folder);
+        const { html, text, attachments } = await this.fetchMessageBody(
+          account, msg.uid, msg.folder, { snapshot },
+        );
         const safeHtml = html ? sanitizeEmail(html) : null;
         if (safeHtml || text) {
           const snip = snippetFromBody(text, safeHtml || html);
@@ -4204,8 +5443,19 @@ export class ImapManager {
             `UPDATE messages
              SET body_html = $1, body_text = $2, attachments = $3,
                  snippet = CASE WHEN $5 != '' THEN $5 ELSE snippet END
-             WHERE id = $4`,
-            [sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(attachments || []), msg.id, sanitizeStr(snip)]
+             WHERE id = $4 AND account_id = $6 AND uid = $7 AND folder = $8
+               AND is_deleted = false AND metadata_complete = true
+               AND EXISTS (
+                 SELECT 1 FROM folders f
+                  WHERE f.account_id = messages.account_id AND f.path = messages.folder
+                    AND f.is_present = true AND f.uid_validity = $9
+                    AND f.observation_generation = $10
+               )`,
+            [
+              sanitizeStr(safeHtml), sanitizeStr(text), JSON.stringify(attachments || []),
+              msg.id, sanitizeStr(snip), snapshot.accountId, snapshot.uid, snapshot.folder,
+              snapshot.uidValidity, snapshot.folderGeneration,
+            ]
           );
         }
       } catch (err) {
@@ -4217,12 +5467,12 @@ export class ImapManager {
   // Uses a fresh connection to avoid lock contention with sync connection.
   // Auto-retries once on transient connection errors (stale pool connection, NAT
   // timeout, half-open TCP, etc.) so a single click is enough in all common cases.
-  async fetchMessageBody(account, uid, folder) {
+  async fetchMessageBody(account, uid, folder, { snapshot = null } = {}) {
     // Inner fetch — called up to twice. `acquire` selects how the connection is obtained:
     // the first attempt uses the pool (withFreshClient); the retry uses a genuinely fresh
     // login (withFreshLogin) so a frozen/half-open pooled connection can't hang or return
     // a blank body for recently-arrived mail.
-    const doFetch = (acquire) => acquire(account, async (client) => {
+    const doFetch = (acquire) => withFencedUidClient(account, folder, async (client) => {
       let html = null;
       let text = null;
       let attachments;
@@ -4232,8 +5482,6 @@ export class ImapManager {
       // quota is hit.
       const uidStr = String(uid);
 
-      const lock = await client.getMailboxLock(folder);
-      try {
         let structure = null;
         const prefetched = new Map(); // part number -> Buffer
 
@@ -4370,13 +5618,13 @@ export class ImapManager {
             html = html.replace(new RegExp(`cid:<?${escapedCid}>?`, 'gi'), dataUri);
           }
         }
-      } finally {
-        lock.release();
-      }
-
       // Some malformed emails include NUL bytes that PostgreSQL rejects in text
       // columns. Strip them once here so all callers are safe.
       return { html: sanitizeStr(html), text: sanitizeStr(text), attachments };
+    }, {
+      acquire,
+      expectedUidValidity: snapshot?.uidValidity,
+      messageSnapshots: snapshot ? [snapshot] : [],
     });
 
     // Providers flagged preferFreshBodyFetch (e.g. PurelyMail) skip the shared pool on the
@@ -4426,10 +5674,8 @@ export class ImapManager {
     }
   }
 
-  async fetchHeaders(account, uid, folder) {
-    return withFreshClient(account, async (client) => {
-      const lock = await client.getMailboxLock(folder);
-      try {
+  async fetchHeaders(account, uid, folder, { snapshot = null } = {}) {
+    return withFencedUidClient(account, folder, async (client) => {
         const uidStr = String(uid);
         let headers = '';
 
@@ -4449,18 +5695,15 @@ export class ImapManager {
             }
           }
         }
-
         return headers;
-      } finally {
-        lock.release();
-      }
+    }, {
+      expectedUidValidity: snapshot?.uidValidity,
+      messageSnapshots: snapshot ? [snapshot] : [],
     });
   }
 
-  async fetchAttachment(account, uid, folder, partNum) {
-    return withFreshClient(account, async (client) => {
-      const lock = await client.getMailboxLock(folder);
-      try {
+  async fetchAttachment(account, uid, folder, partNum, { snapshot = null } = {}) {
+    return withFencedUidClient(account, folder, async (client) => {
         let buffer = null;
         const uidStr = String(uid);
 
@@ -4478,19 +5721,17 @@ export class ImapManager {
           }
         }
         return buffer;
-      } finally {
-        lock.release();
-      }
+    }, {
+      expectedUidValidity: snapshot?.uidValidity,
+      messageSnapshots: snapshot ? [snapshot] : [],
     });
   }
 
   // Fetch multiple attachment parts in a single IMAP round trip.
   // parts: array of { part, encoding } (metadata from messages.attachments).
   // Returns Map<partNum, Buffer> — missing or empty parts are omitted.
-  async fetchMultipleAttachments(account, uid, folder, parts) {
-    return withFreshClient(account, async (client) => {
-      const lock = await client.getMailboxLock(folder);
-      try {
+  async fetchMultipleAttachments(account, uid, folder, parts, { snapshot = null } = {}) {
+    return withFencedUidClient(account, folder, async (client) => {
         const uidStr = String(uid);
         const partNums = parts.map(p => p.part);
         const buffers = new Map();
@@ -4519,53 +5760,58 @@ export class ImapManager {
         }
 
         return buffers;
-      } finally {
-        lock.release();
-      }
+    }, {
+      expectedUidValidity: snapshot?.uidValidity,
+      messageSnapshots: snapshot ? [snapshot] : [],
     });
   }
 
-  async setFlag(account, uid, folder, flag, value) {
-    console.log(`setFlag: uid=${uid} folder=${folder} flag=${flag} value=${value}`);
-    // Up to 2 attempts. ImapFlow returns false when the server did NOT apply the flag —
-    // typically a stale/half-open pooled connection whose SELECT view is missing the UID.
-    // Throwing on false makes withFreshClient evict that client from the pool, so the
-    // retry acquires a fresh connection (this is exactly why marking a message
-    // individually a moment later succeeds). Re-applying a flag is idempotent, so the
-    // retry is safe. Surfacing the final failure keeps callers such as bulk-read from
-    // reporting success while the DB read/flag state silently drifts from the server —
-    // which a later flag-sync would then revert, leaving the message unexpectedly unread.
-    let lastErr = null;
-    for (let attempt = 1; attempt <= 2; attempt++) {
-      try {
-        await withFreshClient(account, async (client) => {
-          const lock = await client.getMailboxLock(folder);
-          try {
-            const flagResult = value
-              ? await client.messageFlagsAdd(String(uid), [flag], { uid: true })
-              : await client.messageFlagsRemove(String(uid), [flag], { uid: true });
-            if (flagResult === false) {
-              throw new Error(`server did not apply ${flag}=${value} for uid=${uid} (no matching message)`);
-            }
-            logger.debug(`setFlag success: uid=${uid} ${flag}=${value}`);
-          } finally {
-            lock.release();
-          }
-        });
-        return; // applied
-      } catch (err) {
-        lastErr = err;
-        if (attempt < 2) await new Promise(r => setTimeout(r, 400));
-      }
+  async setDesiredFlag(account, messageId, flag, value, { snapshot = null } = {}) {
+    const accepted = await desiredFlagExecutor.accept({
+      messageId,
+      flag,
+      value,
+      ...(snapshot ? {
+        accountId: snapshot.accountId,
+        uid: snapshot.uid,
+        folder: snapshot.folder,
+        uidValidity: snapshot.uidValidity,
+        folderGeneration: snapshot.folderGeneration,
+      } : {}),
+    });
+    try {
+      const delivered = await desiredFlagExecutor.deliver(
+        messageId, flag, this._desiredFlagProvider(account),
+      );
+      return { ...accepted, acceptance: accepted, delivery: delivered };
+    } catch (err) {
+      // Acceptance committed the local row/count and durable pending intent before
+      // provider delivery began. Preserve that fact explicitly so callers can
+      // reflect local truth without guessing from a provider error.
+      err.desiredFlagAcceptance = accepted;
+      throw err;
     }
-    console.error(`setFlag failed after retry: uid=${uid} ${flag}=${value}:`, lastErr?.message);
-    throw lastErr;
+  }
+
+  _desiredFlagProvider(account) {
+    return {
+      withSession: (delivery, callback) => {
+        const deliverySnapshot = desiredFlagDeliverySnapshot(delivery);
+        return withFencedUidClient(
+          account,
+          delivery.folder,
+          client => callback(createImapDesiredFlagSession(client, delivery)),
+          {
+            expectedUidValidity: delivery.uidValidity,
+            messageSnapshots: [deliverySnapshot],
+          },
+        );
+      },
+    };
   }
 
   async createFolder(account, path) {
-    return withFreshClient(account, async (client) => {
-      await client.mailboxCreate(path);
-    });
+    return withFreshClient(account, client => createMailboxTopology(account, client, path));
   }
 
   // Ensure a mailbox exists, returning { path, created }: `path` is the real server path
@@ -4574,29 +5820,7 @@ export class ImapManager {
   // folders" action reports both so the settings UI can show the real path and whether it
   // pre-existed. Namespace/delimiter/already-exists handling lives in ensureMailbox.
   async ensureFolder(account, path, opts = {}) {
-    return withFreshClient(account, (client) => ensureMailbox(client, path, opts));
-  }
-
-  async moveMessageGetNewUid(account, uid, fromFolder, toFolder) {
-    let newUid = null;
-    try {
-      await withFreshClient(account, async (client) => {
-        const lock = await client.getMailboxLock(fromFolder);
-        try {
-          const result = await client.messageMove(String(uid), toFolder, { uid: true });
-          if (result === false) throw new Error('messageMove returned false — server did not confirm move');
-          if (result?.uidMap) {
-            newUid = result.uidMap.get(Number(uid)) || null;
-          }
-        } finally {
-          lock.release();
-        }
-      });
-    } catch (err) {
-      console.error(`moveMessageGetNewUid failed: uid=${uid}:`, err.message);
-      throw err;
-    }
-    return newUid;
+    return withFreshClient(account, client => ensureMailboxTopology(account, client, path, opts));
   }
 
   async deleteFolder(account, path) {
@@ -4606,135 +5830,487 @@ export class ImapManager {
         const lock = await client.getMailboxLock('INBOX');
         lock.release();
       }
-      await client.mailboxDelete(path);
+      return deleteMailboxTopology(account, client, path);
     });
   }
 
   async renameFolder(account, oldPath, newPath) {
-    return withFreshClient(account, async (client) => {
-      await client.mailboxRename(oldPath, newPath);
-    });
+    return withFreshClient(
+      account,
+      client => renameMailboxTopology(account, client, oldPath, newPath),
+    );
   }
 
-  async emptyFolder(account, folder) {
+  async assertRecoveryKeywordSupported(account, folder, keyword) {
     return withFreshClient(account, async (client) => {
       const lock = await client.getMailboxLock(folder);
       try {
-        if (!client.mailbox || client.mailbox.exists === 0) return;
-        await this._deleteAllInFolder(client, folder);
-      } catch (err) {
-        const msg = (err.message || '').toLowerCase();
-        // Non-fatal if folder is already empty or server reports no messages
-        if (!msg.includes('no messages') && !msg.includes('empty') && !msg.includes('nothing')) throw err;
-      } finally {
-        lock.release();
-      }
-    });
-  }
-
-  // Apply a whole-folder IMAP write to every matching message in the currently-locked
-  // folder, in UID-addressed chunks with a one-shot retry per chunk. A single command over
-  // the whole folder (messageDelete('1:*') / messageFlagsAdd('1:*', ...)) gets throttled or
-  // times out on some providers on a large folder (observed failing on a 4k+ message Trash,
-  // then succeeding on a manual retry), so batch it and confirm each chunk. UID addressing
-  // keeps a concurrent EXPUNGE from shifting a sequence range under us. `searchQuery` selects
-  // the messages; `apply(client, range)` runs the IMAP command for a UID range and returns
-  // imapflow's truthy/false result. Returns the count processed; throws (with progress) if a
-  // chunk cannot be confirmed.
-  async _chunkedFolderOp(client, folder, searchQuery, apply, { label = 'operation', chunkSize = 500, retryBackoffMs = 500 } = {}) {
-    const uids = await client.search(searchQuery, { uid: true });
-    if (!uids || uids.length === 0) return 0;
-    let done = 0;
-    for (let i = 0; i < uids.length; i += chunkSize) {
-      const chunk = uids.slice(i, i + chunkSize);
-      const range = chunk.join(',');
-      let ok = false;
-      for (let attempt = 0; attempt < 2; attempt++) {
-        try {
-          ok = await apply(client, range);
-        } catch (err) {
-          if (attempt === 1) throw err; // exhausted the retry — surface the real error
-          ok = false;
+        if (!recoveryKeywordAllowed(client.mailbox, keyword)) {
+          throw new Error(`Destination mailbox does not support recovery keyword ${keyword}`);
         }
-        if (ok) break;
-        if (attempt === 0 && retryBackoffMs > 0) await new Promise(r => setTimeout(r, retryBackoffMs));
-      }
-      if (!ok) {
-        throw new Error(`${label} could not be confirmed for ${folder} after ${done}/${uids.length} messages`);
-      }
-      done += chunk.length;
-    }
-    return done;
-  }
-
-  // Delete every message in the locked folder, chunked (see _chunkedFolderOp). The caller
-  // leaves the DB rows in place on throw so the next sync reconciles.
-  async _deleteAllInFolder(client, folder, opts = {}) {
-    return this._chunkedFolderOp(
-      client, folder, { all: true },
-      (c, range) => c.messageDelete(range, { uid: true }),
-      { label: 'messageDelete', ...opts },
-    );
-  }
-
-  // Add \Seen to every unread message in the locked folder, chunked (see _chunkedFolderOp).
-  // Searching UNSEEN only touches what needs changing (idempotent, and a no-op on an
-  // already-read folder).
-  async _markSeenInFolder(client, folder, opts = {}) {
-    return this._chunkedFolderOp(
-      client, folder, { seen: false },
-      (c, range) => c.messageFlagsAdd(range, ['\\Seen'], { uid: true }),
-      { label: 'messageFlagsAdd', ...opts },
-    );
-  }
-
-  async markAllReadImap(account, folder) {
-    return withFreshClient(account, async (client) => {
-      const lock = await client.getMailboxLock(folder);
-      try {
-        if (!client.mailbox || client.mailbox.exists === 0) return;
-        // Chunked so a single STORE +FLAGS \Seen over a large folder can't get throttled
-        // into a whole-operation failure (which would leave the DB read but the server
-        // unread, and the next flag-sync would flip those rows back to unread).
-        await this._markSeenInFolder(client, folder);
-      } catch (err) {
-        console.warn(`markAllRead IMAP warning for ${folder}:`, err.message);
-        // Non-fatal — DB is already updated; the next sync reconciles any residual unread.
+        return true;
       } finally {
         lock.release();
       }
     });
   }
 
-  async moveMessage(account, uid, fromFolder, toFolder) {
-    let newUid = null;
+  async findUidByRecoveryKeyword(account, folder, keyword) {
+    return withFencedUidClient(account, folder, (client) =>
+      findSingleRecoveryKeywordUid(client, keyword));
+  }
+
+  async findUidByRecoveryKeywordReceipt(account, folder, keyword) {
+    return withFencedUidClient(account, folder, async (client) => {
+      const uid = await findSingleRecoveryKeywordUid(client, keyword);
+      const uidValidity = client.mailbox?.uidValidity != null
+        ? String(client.mailbox.uidValidity)
+        : null;
+      if (uid == null || uidValidity == null) {
+        throw new Error(`Could not establish destination UID epoch for ${folder}`);
+      }
+      return { folder, uid: Number(uid), uidValidity };
+    });
+  }
+
+  async findUidByMessageIdReceipt(account, folder, messageId) {
+    const [token] = await readProviderOperationObservations(account.id, [folder]);
+    return withFencedUidClient(account, folder, async (client) => {
+      const uid = await findSingleMessageIdUid(client, messageId);
+      const uidValidity = client.mailbox?.uidValidity != null
+        ? String(client.mailbox.uidValidity)
+        : null;
+      if (uid == null || uidValidity == null) {
+        throw new Error(`Could not establish destination UID epoch for ${folder}`);
+      }
+      return { folder, uid: Number(uid), uidValidity, destinationToken: token };
+    }, {
+      expectedUidValidity: token.uidValidity,
+      observationContext: { accountId: account.id, tokens: [token] },
+    });
+  }
+
+  async upsertSentMessageRecordFromReceipt(account, receipt, meta) {
+    if (!receipt?.destinationToken || Number(receipt.uid) <= 0) {
+      throw new Error('Exact Sent destination receipt is required');
+    }
+    return this.withFolderObservationContext(
+      account.id,
+      { accountId: account.id, tokens: [receipt.destinationToken] },
+      tx => this.upsertSentMessageRecord(
+        account, receipt.folder, receipt.uid, meta, { tx },
+      ),
+    );
+  }
+
+  async moveMessage(account, uid, fromFolder, toFolder, {
+    expectedUidValidity = undefined,
+    returnReceipt = false,
+    observationContext = null,
+    operationTokens = null,
+    operationKey,
+    materialize = null,
+    snapshot = null,
+  } = {}) {
+    requireExactMutationSnapshot(snapshot, account.id, uid, fromFolder, 'MOVE');
     try {
-      await withFreshClient(account, async (client) => {
-        const lock = await client.getMailboxLock(fromFolder);
-        try {
+      let tokens = observationContext && !operationTokens
+        ? await claimFolderObservations(account.id, [fromFolder, toFolder], {
+          context: observationContext.tokens,
+        })
+        : await readProviderOperationObservations(
+          account.id,
+          [fromFolder, toFolder],
+          operationTokens,
+        );
+      let recoveryOperation = null;
+      if (operationTokens && this.providerOperationExecutor.getExisting) {
+        const supplied = new Map(operationTokens.map(token => [token.folder, token]));
+        const frozenIntent = buildProviderOperationIdentity({
+          kind: 'move', accountId: account.id,
+          source: { ...supplied.get(fromFolder), uid: Number(uid) },
+          destination: supplied.get(toFolder), requestKey: operationKey,
+          sourceMessageId: snapshot.id,
+        });
+        recoveryOperation = await this.providerOperationExecutor.getExisting(frozenIntent.id);
+        if (recoveryOperation) {
+          tokens = await readProviderOperationObservations(account.id, [fromFolder, toFolder]);
+        } else {
+          await preflightFrozenProviderOperation(frozenIntent);
+        }
+      }
+      if (observationContext) observationContext.tokens = tokens;
+      const tokenByFolder = new Map(tokens.map(token => [token.folder, token]));
+      const sourceToken = tokenByFolder.get(fromFolder);
+      const destinationToken = tokenByFolder.get(toFolder);
+      if (expectedUidValidity !== undefined && (
+        expectedUidValidity == null || sourceToken?.uidValidity == null ||
+        Number(sourceToken.uidValidity) !== Number(expectedUidValidity)
+      )) {
+        const err = new Error(`Snapshot UIDVALIDITY changed before ${fromFolder} move`);
+        err.code = 'SNAPSHOT_UIDVALIDITY_CHANGED';
+        throw err;
+      }
+      const intent = buildProviderOperationIdentity({
+        kind: 'move', accountId: account.id,
+        source: { ...sourceToken, uid: Number(uid) }, destination: destinationToken,
+        requestKey: operationKey, sourceMessageId: snapshot.id,
+      });
+      if (operationTokens && !this.providerOperationExecutor.getExisting) {
+        await preflightFrozenProviderOperation(intent);
+      }
+      const receipt = await this.providerOperationExecutor.execute({
+        intent,
+        completeWithProvider: Boolean(materialize),
+        acquireProvider: async (callback, operation) => {
+          try {
+            return await withSwitchableMailboxClient(
+              account,
+              toFolder,
+              async resource => {
+                if (operation.state === 'ready') {
+                  validateFrozenMoveCapabilities(resource, intent.marker, {
+                    role: 'Destination', requireMove: false,
+                  });
+                  await resource.switchTo(fromFolder);
+                }
+                return callback(resource);
+              },
+            );
+          } catch (error) {
+            throw operationTokens
+              ? normalizeFrozenMailboxAcquisitionError(error, [fromFolder, toFolder])
+              : error;
+          }
+        },
+        validate: async (resource, tx, operation) => {
+          await assertProviderOperationObservations(tx, operation);
+          await assertLiveMessageSnapshots(tx, account.id, [snapshot]);
+          validateFrozenMoveCapabilities(resource, operation.marker, {
+            role: 'Source', requireMove: true,
+          });
+          assertLiveProviderEpoch(resource, operation.source, 'Source');
+          assertLiveProviderEpoch(resource, operation.destination);
+        },
+        validateRecovery: async (resource, tx, operation) => {
+          await assertProviderOperationDestination(tx, operation);
+          assertLiveProviderEpoch(resource, operation.destination);
+        },
+        validateCompletion: async (tx, operation) => {
+          await assertProviderOperationDestination(tx, operation);
+          await assertLiveMessageSnapshots(tx, account.id, [snapshot], {
+            includeRevisions: false,
+            includeFolderGeneration: !recoveryOperation,
+          });
+        },
+        prepare: ({ client }, marker) => storeAndVerifyProviderMarker(client, uid, marker),
+        command: async ({ client, switchTo }, marker, operation) => {
           const result = await client.messageMove(String(uid), toFolder, { uid: true });
           if (result === false) throw new Error('messageMove returned false — server did not confirm move');
-          if (result?.uidMap) newUid = result.uidMap.get(Number(uid)) || null;
-        } finally {
-          lock.release();
-        }
+          const mappedUid = result?.uidMap?.get(Number(uid)) ?? null;
+          await switchTo(toFolder);
+          const recovered = await recoverProviderMarkerOnClient(client, marker);
+          if (recovered.status !== 'unique') {
+            throw new Error(`MOVE provider marker is ${recovered.status}`);
+          }
+          if (mappedUid != null && Number(mappedUid) !== recovered.uid) {
+            throw new ProviderOperationError(
+              `UIDPLUS destination ${mappedUid} disagrees with provider marker UID ${recovered.uid}`,
+              {
+                code: 'PROVIDER_RECEIPT_MISMATCH', retryable: false, uncertain: true, manual: true,
+                details: { uidplus: Number(mappedUid), markerUid: recovered.uid },
+              },
+            );
+          }
+          return {
+            uid: recovered.uid, uidValidity: recovered.uidValidity, folder: toFolder,
+            sourceToken: operation.source, destinationToken: operation.destination, marker,
+          };
+        },
+        recover: async ({ client, switchTo }, marker, operation) => {
+          await switchTo(toFolder);
+          return withUidEpochFence(
+            account.id,
+            toFolder,
+            client,
+            async () => ({
+              ...(await recoverProviderMarkerOnClient(client, marker)), folder: toFolder,
+              sourceToken: operation.source, destinationToken: operation.destination, marker,
+            }),
+            operation.destination.uidValidity,
+          );
+        },
+        complete: async (providerReceipt, operation, tx, providerResource) => {
+          await materialize?.(providerReceipt, operation, tx, providerResource);
+          return providerReceipt;
+        },
+        cleanup: async ({ client, switchTo }, marker, providerReceipt, operation) => {
+          await cleanupCompletedProviderOperationMarkers(
+            { client, switchTo }, marker, providerReceipt, operation,
+          );
+        },
       });
+      return returnReceipt ? receipt : receipt.uid;
     } catch (err) {
       console.error(`moveMessage failed: uid=${uid}:`, err.message);
       throw err;
     }
-    return newUid;
   }
 
-  async permanentDeleteMessage(account, uid, folder) {
-    await withFreshClient(account, async (client) => {
-      const lock = await client.getMailboxLock(folder);
-      try {
-        const result = await client.messageDelete(String(uid), { uid: true });
-        if (result === false) throw new Error('messageDelete returned false — server did not confirm deletion');
-      } finally {
-        lock.release();
+  async moveMessageWithReceipt(account, uid, fromFolder, toFolder, {
+    expectedUidValidity = undefined,
+    observationContext = null,
+    operationTokens = null,
+    operationKey,
+    materialize = null,
+    snapshot = null,
+  } = {}) {
+    return this.moveMessage(account, uid, fromFolder, toFolder, {
+      expectedUidValidity, observationContext,
+      ...(operationTokens ? { operationTokens } : {}),
+      operationKey, materialize, snapshot,
+      returnReceipt: true,
+    });
+  }
+
+  // Verify one exact UID without fetching message content. Used only to reconcile an
+  // interrupted two-system mutation: if IMAP already removed/moved the source but the DB
+  // transaction failed, the next idempotent request can safely discard the stale local row.
+  async messageExists(account, uid, folder, { expectedUidValidity = undefined } = {}) {
+    return withFencedUidClient(
+      account,
+      folder,
+      (client) => searchContainsExactUid(client, uid),
+      { expectedUidValidity },
+    );
+  }
+
+  async reconcileMissingMessageCopy(account, row, { deleteIfUncaused = false } = {}) {
+    const durableMove = await this.providerOperationExecutor?.findMoveBySource?.({
+      accountId: account.id, sourceMessageId: row.id, folder: row.folder, uid: row.uid,
+    });
+    if (durableMove) {
+      // An associated durable MOVE is causal evidence: resume it under executor ownership and
+      // preserve the source UUID/local metadata. Never reinterpret its absent UID as deletion.
+      if (!durableMove.requestKey) return { reconciled: false, changed: 0 };
+      const destinationFolder = durableMove.destination.folder;
+      const allMail = await isAllMailFolder(account.id, destinationFolder);
+      let materialized = null;
+      const receipt = await this.moveMessageWithReceipt(
+        account, row.uid, row.folder, destinationFolder, {
+          operationKey: durableMove.requestKey,
+          operationTokens: [durableMove.source, durableMove.destination],
+          expectedUidValidity: row.folder_uid_validity,
+          snapshot: snapshotFromMessageRow(row),
+          materialize: async (providerReceipt, operation, tx, providerResource) => {
+            materialized = await materializeArchiveReceipt(tx, {
+              accountId: account.id, sourceSnapshot: row, destinationFolder,
+              receipt: providerReceipt, operation, allMail, providerResource,
+            });
+          },
+        },
+      );
+      if (materialized) {
+        return { reconciled: true, changed: materialized.concurrentWinner ? 0 : 1 };
       }
+      const confirmed = await query(
+        `SELECT 1 FROM messages
+          WHERE id = $1 AND account_id = $2
+            AND (($3::boolean = true AND folder <> $4)
+              OR ($3::boolean = false AND folder = $4 AND uid = $5))
+          LIMIT 1`,
+        [row.id, account.id, allMail, receipt.folder, Number(receipt.uid)],
+      );
+      return { reconciled: confirmed.rows.length === 1, changed: 0 };
+    }
+    if (row.folder === 'INBOX') {
+      const archiveFolder = await resolveArchiveFolder(account.id, account.folder_mappings);
+      if (archiveFolder) {
+        const allMail = await isAllMailFolder(account.id, archiveFolder);
+        if (row.folder_uid_validity == null) return { reconciled: false, changed: 0 };
+        const operationId = buildProviderOperationId({
+          kind: 'move', accountId: account.id, requestKey: `archive:${row.id}`,
+          source: {
+            folder: row.folder, uid: Number(row.uid),
+            uidValidity: String(row.folder_uid_validity),
+          },
+          destinationFolder: archiveFolder,
+        });
+        let materialized = null;
+        let recoveryIntent;
+        if (row.folder_observation_generation != null) {
+          const fresh = await readProviderOperationObservations(
+            account.id, [row.folder, archiveFolder],
+          );
+          const byFolder = new Map(fresh.map(token => [token.folder, token]));
+          recoveryIntent = buildProviderOperationIdentity({
+            kind: 'move', accountId: account.id, requestKey: `archive:${row.id}`,
+            source: { ...byFolder.get(row.folder), uid: Number(row.uid) },
+            destination: byFolder.get(archiveFolder), sourceMessageId: row.id,
+          });
+        }
+        const replay = await this.providerOperationExecutor.completeExisting(operationId, {
+          ...(recoveryIntent ? { intent: recoveryIntent } : {}),
+          completeWithProvider: allMail,
+          acquireProvider: (callback, operation) => withSwitchableMailboxClient(
+            account, archiveFolder, callback, operation,
+          ),
+          validateExisting: operation => assertExactArchiveRecoveryOperation(operation, {
+            operationId, accountId: account.id, row, archiveFolder,
+          }),
+          validateCompletion: (tx, operation) => (
+            assertProviderOperationDestination(tx, operation)
+          ),
+          complete: async (providerReceipt, operation, tx, providerResource) => {
+            materialized = await materializeArchiveReceipt(tx, {
+              accountId: account.id,
+              sourceSnapshot: row,
+              destinationFolder: archiveFolder,
+              receipt: providerReceipt,
+              operation,
+              allMail,
+              providerResource,
+            });
+            return providerReceipt;
+          },
+          cleanup: async ({ client, switchTo }, marker, providerReceipt, operation) => {
+            await cleanupCompletedProviderOperationMarkers(
+              { client, switchTo }, marker, providerReceipt, operation,
+            );
+          },
+        });
+        if (replay.status !== 'completed') return { reconciled: false, changed: 0 };
+        const destinationReceipt = replay.receipt;
+        if (materialized) {
+          return { reconciled: true, changed: materialized.concurrentWinner ? 0 : 1 };
+        }
+        if (allMail) {
+          const remaining = await query(
+            'SELECT 1 FROM messages WHERE id = $1 AND account_id = $2 LIMIT 1',
+            [row.id, account.id],
+          );
+          return { reconciled: remaining.rows.length === 0, changed: 0 };
+        }
+        const confirmed = await query(
+          `SELECT m.id
+             FROM messages m
+             JOIN folders live_folder ON live_folder.account_id = m.account_id
+                                     AND live_folder.path = m.folder
+                                     AND live_folder.is_present = true
+                                     AND live_folder.uid_validity IS NOT NULL
+            WHERE m.id = $1 AND m.account_id = $2 AND m.folder = $3 AND m.uid = $4
+              AND m.is_deleted = false AND m.metadata_complete = true`,
+          [row.id, account.id, archiveFolder, Number(destinationReceipt.uid)],
+        );
+        return { reconciled: confirmed.rows.length === 1, changed: 0 };
+      }
+      if (!deleteIfUncaused) return { reconciled: false, changed: 0 };
+    }
+    const changed = await deleteMessageCopyRow(row.account_id, row.uid, row.folder, row.id);
+    if (changed > 0) return { reconciled: true, changed };
+    // A zero-row exact delete is only an idempotent concurrent completion when the
+    // message row itself is gone. If the same id was relocated, its live server copy
+    // still needs Seen and Done must remain blocked/retryable.
+    return { reconciled: await confirmLocalMessageCopyGone(row), changed: 0 };
+  }
+
+  async permanentDeleteMessage(account, uid, folder, {
+    expectedUidValidity = undefined,
+    snapshot = null,
+    materialize = null,
+    operationKey = null,
+  } = {}) {
+    requireExactMutationSnapshot(snapshot, account.id, uid, folder, 'Permanent delete');
+    const [sourceToken] = await readProviderOperationObservations(account.id, [folder]);
+    if (expectedUidValidity !== undefined && (
+      expectedUidValidity == null || sourceToken?.uidValidity == null ||
+      Number(sourceToken.uidValidity) !== Number(expectedUidValidity)
+    )) {
+      const err = new Error(`Snapshot UIDVALIDITY changed before ${folder} delete`);
+      err.code = 'SNAPSHOT_UIDVALIDITY_CHANGED';
+      throw err;
+    }
+    const intent = buildProviderOperationIdentity({
+      kind: 'delete', accountId: account.id,
+      source: { ...sourceToken, uid: Number(uid) },
+      destination: sourceToken,
+      requestKey: operationKey || `delete:${snapshot.id}`,
+      sourceMessageId: snapshot.id,
+    });
+    const deleteExactUid = async client => {
+      if (!client.capabilities?.has('UIDPLUS')) {
+        throw new ProviderOperationError('Causal permanent delete requires UIDPLUS', {
+          code: 'PROVIDER_UIDPLUS_REQUIRED', retryable: false, uncertain: false,
+        });
+      }
+      const result = await client.messageDelete(String(uid), { uid: true });
+      if (result === false) throw new Error('messageDelete returned false — server did not confirm deletion');
+    };
+    return this.providerOperationExecutor.execute({
+      intent,
+      acquireProvider: callback => withFreshClient(account, async client => {
+        const lock = await client.getMailboxLock(folder);
+        try {
+          return await callback({ client });
+        } finally {
+          lock.release();
+        }
+      }),
+      validate: async ({ client }, tx, operation) => {
+        await assertProviderOperationObservations(tx, operation);
+        await assertLiveMessageSnapshots(tx, account.id, [snapshot]);
+        assertLiveProviderEpoch({ client }, operation.source, 'Source');
+        if (!client.capabilities?.has('UIDPLUS')) {
+          throw new ProviderOperationError('Causal permanent delete requires UIDPLUS', {
+            code: 'PROVIDER_UIDPLUS_REQUIRED', retryable: false, uncertain: false,
+          });
+        }
+      },
+      validateRecovery: async ({ client }, tx, operation) => {
+        await assertProviderOperationObservations(tx, operation);
+        assertLiveProviderEpoch({ client }, operation.source, 'Source');
+      },
+      validateCompletion: async (tx) => {
+        const remaining = await tx.query(
+          'SELECT 1 FROM messages WHERE id = $1 AND account_id = $2 LIMIT 1',
+          [snapshot.id, account.id],
+        );
+        if (remaining.rows.length) {
+          await assertLiveMessageSnapshots(tx, account.id, [snapshot], { includeRevisions: false });
+        }
+      },
+      prepare: ({ client }, marker) => storeAndVerifyProviderMarker(client, uid, marker),
+      command: async ({ client }, marker, operation) => {
+        await deleteExactUid(client);
+        return {
+          status: 'unique', folder, uid: Number(uid),
+          uidValidity: String(operation.source.uidValidity),
+          sourceToken: operation.source, destinationToken: operation.destination, marker,
+        };
+      },
+      recover: async ({ client }, marker, operation) => {
+        if (!(await searchContainsExactUid(client, uid, { keyword: marker }))) {
+          return { status: 'absent' };
+        }
+        await deleteExactUid(client);
+        if (await searchContainsExactUid(client, uid)) {
+          return { status: 'ambiguous', folder, uid: Number(uid), marker };
+        }
+        return {
+          status: 'unique', folder, uid: Number(uid),
+          uidValidity: String(operation.source.uidValidity),
+          sourceToken: operation.source, destinationToken: operation.destination, marker,
+        };
+      },
+      complete: async (receipt, operation, tx) => {
+        await materialize?.(tx, receipt, operation);
+        return receipt;
+      },
+      cleanup: async ({ client }, marker, providerReceipt, operation) => {
+        await cleanupCompletedProviderOperationMarkers({
+          client, switchTo: async () => {},
+        }, marker, providerReceipt, operation);
+      },
     });
   }
 
@@ -4750,40 +6326,113 @@ export class ImapManager {
   // Post-copy notification/re-evaluation is a plugin concern: the generic `afterLabelCopy`
   // hook lets the owning plugin (GTD) broadcast its refresh event and, on the deferred path,
   // reconcile once the sibling lands. copyMessage itself stays label-feature-agnostic.
-  async copyMessage(accountId, uid, fromFolder, toFolder) {
+  async copyMessage(accountId, uid, fromFolder, toFolder, { operationKey, snapshot = null } = {}) {
+    requireExactMutationSnapshot(snapshot, accountId, uid, fromFolder, 'COPY');
     const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [accountId]);
     const account = accountResult.rows[0];
     if (!account) throw new Error(`copyMessage: account ${accountId} not found`);
 
-    let newUid = null;
+    const tokens = await readProviderOperationObservations(account.id, [fromFolder, toFolder]);
+    const tokenByFolder = new Map(tokens.map(token => [token.folder, token]));
+    const sourceToken = tokenByFolder.get(fromFolder);
+    const destinationToken = tokenByFolder.get(toFolder);
+    const intent = buildProviderOperationIdentity({
+      kind: 'copy', accountId: account.id,
+      source: { ...sourceToken, uid: Number(uid) }, destination: destinationToken,
+      requestKey: operationKey, sourceMessageId: snapshot.id,
+    });
+    let receipt;
     try {
-      await withFreshClient(account, async (client) => {
-        const lock = await client.getMailboxLock(fromFolder);
-        try {
-          const result = await client.messageCopy(String(uid), toFolder, { uid: true });
-          if (result === false) throw new Error('messageCopy returned false — server did not confirm copy');
-          if (result?.uidMap) newUid = result.uidMap.get(Number(uid)) || null;
-        } finally {
-          lock.release();
-        }
+      receipt = await this.providerOperationExecutor.execute({
+        intent,
+        acquireProvider: (callback, operation) => withSwitchableMailboxClient(
+          account,
+          toFolder,
+          async resource => {
+            if (operation.state === 'ready') {
+              if (!recoveryKeywordAllowed(resource.client.mailbox, intent.marker)) {
+                throw new Error(`Destination mailbox does not support provider operation marker ${intent.marker}`);
+              }
+              await resource.switchTo(fromFolder);
+            }
+            return callback(resource);
+          },
+        ),
+        validate: async (resource, tx, operation) => {
+          await assertProviderOperationObservations(tx, operation);
+          await assertLiveMessageSnapshots(tx, account.id, [snapshot]);
+          if (!recoveryKeywordAllowed(resource.client.mailbox, operation.marker)) {
+            throw new Error(`Source mailbox does not support provider operation marker ${operation.marker}`);
+          }
+          assertLiveProviderEpoch(resource, operation.source, 'Source');
+          assertLiveProviderEpoch(resource, operation.destination);
+        },
+        validateRecovery: async (resource, tx, operation) => {
+          await assertProviderOperationDestination(tx, operation);
+          assertLiveProviderEpoch(resource, operation.destination);
+        },
+        validateCompletion: async (tx, operation) => {
+          await assertProviderOperationDestination(tx, operation);
+          await assertLiveMessageSnapshots(tx, account.id, [snapshot], { includeRevisions: false });
+        },
+        prepare: ({ client }, marker) => storeAndVerifyProviderMarker(client, uid, marker),
+        command: async ({ client, switchTo }, marker, operation) => {
+          const copyResult = await client.messageCopy(String(uid), toFolder, { uid: true });
+          if (copyResult === false) throw new Error('messageCopy returned false — server did not confirm copy');
+          const mappedUid = copyResult?.uidMap?.get(Number(uid)) || null;
+          await switchTo(toFolder);
+          const recovered = await recoverProviderMarkerOnClient(client, marker);
+          if (recovered.status !== 'unique') throw new Error(`COPY provider marker is ${recovered.status}`);
+          if (mappedUid != null && mappedUid !== recovered.uid) {
+            throw new ProviderOperationError(
+              `UIDPLUS destination ${mappedUid} disagrees with provider marker UID ${recovered.uid}`,
+              {
+                code: 'PROVIDER_RECEIPT_MISMATCH', retryable: false, uncertain: true, manual: true,
+                details: { uidplus: Number(mappedUid), markerUid: recovered.uid },
+              },
+            );
+          }
+          return {
+            uid: recovered.uid, uidValidity: recovered.uidValidity, folder: toFolder,
+            sourceToken: operation.source, destinationToken: operation.destination, marker,
+          };
+        },
+        recover: async ({ client, switchTo }, marker, operation) => {
+          await switchTo(toFolder);
+          return withUidEpochFence(
+            account.id,
+            toFolder,
+            client,
+            async () => ({
+              ...(await recoverProviderMarkerOnClient(client, marker)), folder: toFolder,
+              sourceToken: operation.source, destinationToken: operation.destination, marker,
+            }),
+            operation.destination.uidValidity,
+          );
+        },
+        complete: async (providerReceipt, _operation, tx) => {
+          await insertCopiedSibling(accountId, uid, fromFolder, toFolder, providerReceipt.uid, {
+            tx, receipt: providerReceipt,
+          });
+          return providerReceipt;
+        },
+        afterCommit: async providerReceipt => {
+          await pluginRegistry.runHook('afterLabelCopy', {
+            mgr: this.pluginFacade, account, toFolder, fromFolder,
+            srcUid: uid, newUid: providerReceipt.uid ?? null,
+          });
+        },
+        cleanup: async ({ client, switchTo }, marker, providerReceipt, operation) => {
+          await cleanupCompletedProviderOperationMarkers(
+            { client, switchTo }, marker, providerReceipt, operation,
+          );
+        },
       });
     } catch (err) {
       console.error(`copyMessage failed: uid=${uid}:`, err.message);
       throw err;
     }
-
-    // Hand off to label plugins (GTD broadcasts its section-refresh and, on the deferred path,
-    // reconciles once the sibling lands — see plugins/gtd/hooks.js afterLabelCopy). Fired before
-    // the sibling INSERT to preserve the historical emit-then-insert order; `newUid` tells the
-    // plugin whether the sibling is available now (UIDPLUS) or deferred to a destination sync
-    // (null). The hook swallows per-plugin errors and the plugin's deferred work is fire-and-
-    // forget, so this never blocks or breaks the copy.
-    await pluginRegistry.runHook('afterLabelCopy', { mgr: this.pluginFacade, account, toFolder, fromFolder, srcUid: uid, newUid });
-
-    if (newUid == null) return null;
-
-    await insertCopiedSibling(accountId, uid, fromFolder, toFolder, newUid);
-    return newUid;
+    return receipt.uid;
   }
 
   // Remove a single label = delete ONE folder's copy of the message, leaving the other
@@ -4792,15 +6441,40 @@ export class ImapManager {
   // If the IMAP delete throws, the DB row is left in place so the two never silently diverge.
   // Post-remove notification is a plugin concern (generic `afterLabelRemove` hook), so this
   // stays label-feature-agnostic.
-  async removeMessageCopy(accountId, uid, folder) {
+  async removeMessageCopy(accountId, uid, folder, {
+    expectedId = null,
+    notify = true,
+    expectedUidValidity = undefined,
+    snapshot = null,
+    operationKey = null,
+  } = {}) {
     const accountResult = await query('SELECT * FROM email_accounts WHERE id = $1', [accountId]);
     const account = accountResult.rows[0];
     if (!account) throw new Error(`removeMessageCopy: account ${accountId} not found`);
+    requireExactMutationSnapshot(snapshot, accountId, uid, folder, 'Remove message copy');
+    if (expectedId && expectedId !== snapshot.id) {
+      throw new Error('Remove message copy row identity disagrees with its exact snapshot');
+    }
 
-    await this.permanentDeleteMessage(account, uid, folder);
-    const result = await deleteMessageCopyRow(accountId, uid, folder);
+    let result = 0;
+    try {
+      await this.permanentDeleteMessage(account, uid, folder, {
+        expectedUidValidity: expectedUidValidity ?? snapshot.uidValidity,
+        snapshot,
+        operationKey: operationKey || `delete:${expectedId || snapshot?.id}`,
+        materialize: async tx => {
+          result = await deleteMessageCopyRow(accountId, uid, folder, expectedId, { tx });
+          return result;
+        },
+      });
+    } catch (err) {
+      if (err.code === 'SNAPSHOT_UIDVALIDITY_CHANGED') throw err;
+      throw err;
+    }
     // Removing a label copy changes label-feed data — let plugins broadcast their refresh.
-    await pluginRegistry.runHook('afterLabelRemove', { mgr: this.pluginFacade, account, folder, uid });
+    if (notify && result > 0) {
+      await pluginRegistry.runHook('afterLabelRemove', { mgr: this.pluginFacade, account, folder, uid });
+    }
     return result;
   }
 
@@ -4813,202 +6487,72 @@ export class ImapManager {
   // destination UIDNEXT so the DB can store the correct new UIDs.
   // On command failure, verifies via UID SEARCH and confirms destination arrival
   // before trusting the source-absence result.
-  async bulkMoveMessages(account, uids, fromFolder, toFolder) {
+  async bulkMoveMessages(account, uids, fromFolder, toFolder, {
+    observationContext = null,
+    operationKey,
+    operationKeys = null,
+    sourceSnapshots = null,
+    sourceRows = null,
+    materialize = null,
+  } = {}) {
     if (!uids.length) return { uidMap: new Map(), succeeded: [], failed: [] };
-    let destUidNextBefore = null;
-
-    // Capture UIDNEXT on a dedicated connection so a STATUS failure (e.g. toFolder
-    // is the currently selected mailbox on a pooled connection) cannot corrupt the
-    // connection used for the actual move.
-    try {
-      const status = await withFreshClient(account, async (client) => {
-        return await client.status(toFolder, { uidNext: true });
-      });
-      destUidNextBefore = status?.uidNext ?? null;
-    } catch (statusErr) {
-      console.warn(`bulkMoveMessages STATUS ${toFolder} failed (${statusErr.message}) — reconciliation skipped`);
-    }
-
-    try {
-      const serverUidMap = await withFreshClient(account, async (client) => {
-        const lock = await client.getMailboxLock(fromFolder);
-        try {
-          const result = await client.messageMove(uids.map(String), toFolder, { uid: true });
-          if (result === false) throw new Error('bulk messageMove returned false — server did not confirm move');
-          return result?.uidMap?.size ? result.uidMap : null;
-        } finally {
-          lock.release();
-        }
-      });
-
-      if (serverUidMap) {
-        return { uidMap: serverUidMap, succeeded: uids, failed: [] };
-      }
-
-      // Move succeeded but server returned no uidMap (no UIDPLUS).
-      // Try to recover new UIDs via UIDNEXT scan so the DB stays accurate.
-      const uidMap = await this._reconcileMovedUids(account, uids, toFolder, destUidNextBefore);
-      return { uidMap, succeeded: uids, failed: [] };
-
-    } catch (err) {
-      console.warn(`bulkMoveMessages ${fromFolder} → ${toFolder}: batch failed (${err.message}), verifying via UID SEARCH`);
+    if (!operationKey) throw new Error('bulk MOVE operation key is required');
+    for (const uid of uids) {
+      const snapshot = sourceSnapshots?.get?.(uid) || sourceSnapshots?.get?.(String(uid));
       try {
-        const remaining = await withFreshClient(account, async (client) => {
-          const lock = await client.getMailboxLock(fromFolder);
-          try {
-            return await client.search({ uid: uids.join(',') }, { uid: true });
-          } finally {
-            lock.release();
-          }
-        });
-        const remainingSet = new Set(remaining.map(Number));
-        const succeeded = uids.filter(uid => !remainingSet.has(Number(uid)));
-        const failed    = uids.filter(uid =>  remainingSet.has(Number(uid)));
-
-        if (!succeeded.length) {
-          return { uidMap: new Map(), succeeded: [], failed: uids };
-        }
-
-        // Confirm that messages gone from source actually landed in destination
-        // before treating source-absence as proof of success.
-        if (destUidNextBefore !== null) {
-          try {
-            const destNewUids = await withFreshClient(account, async (client) => {
-              const lock = await client.getMailboxLock(toFolder);
-              try {
-                return await client.search({ uid: `${destUidNextBefore}:*` }, { uid: true });
-              } finally {
-                lock.release();
-              }
-            });
-            if (destNewUids.length < succeeded.length) {
-              console.warn(`bulkMoveMessages fallback: ${succeeded.length} UIDs gone from source but only ${destNewUids.length} new UIDs in destination — treating all as failed`);
-              return { uidMap: new Map(), succeeded: [], failed: uids };
-            }
-            // Destination count confirms the move; build uidMap if counts match exactly.
-            const uidMap = new Map();
-            if (destNewUids.length === succeeded.length) {
-              // IMAP MOVE assigns destination UIDs in ascending source-UID order, so BOTH
-              // sides must be sorted before zipping. `succeeded` is in arbitrary input
-              // order (not UID order), so zipping it against the sorted destination UIDs
-              // as-is would map each message to the wrong new UID.
-              const sortedSrc = succeeded.map(Number).sort((a, b) => a - b);
-              const sortedNew = [...destNewUids].sort((a, b) => a - b);
-              sortedSrc.forEach((uid, i) => uidMap.set(uid, sortedNew[i]));
-            }
-            console.log(`bulkMoveMessages: ${succeeded.length}/${uids.length} confirmed moved via UID SEARCH + dest verification`);
-            return { uidMap, succeeded, failed };
-          } catch (destErr) {
-            console.warn(`bulkMoveMessages: destination verification failed (${destErr.message}) — trusting source-absence`);
-          }
-        }
-
-        if (succeeded.length) {
-          console.log(`bulkMoveMessages: ${succeeded.length}/${uids.length} messages confirmed moved via UID SEARCH`);
-        }
-        return { uidMap: new Map(), succeeded, failed };
-      } catch (searchErr) {
-        console.error(`bulkMoveMessages: UID SEARCH verification failed: ${searchErr.message}`);
-        return { uidMap: new Map(), succeeded: [], failed: uids };
+        requireExactMutationSnapshot(snapshot, account.id, uid, fromFolder, 'Bulk MOVE');
+      } catch {
+        throw new Error(`Exact source snapshot missing or invalid for bulk MOVE uid ${uid}`);
       }
     }
-  }
-
-  // After a successful move that returned no uidMap, scan the destination folder
-  // for UIDs >= destUidNextBefore and assign them to source UIDs in sorted order.
-  // Only commits the mapping when the count matches exactly (conservative).
-  async _reconcileMovedUids(account, sourceUids, toFolder, destUidNextBefore) {
-    if (destUidNextBefore === null) return new Map();
-    try {
-      const newUids = await withFreshClient(account, async (client) => {
-        const lock = await client.getMailboxLock(toFolder);
-        try {
-          return await client.search({ uid: `${destUidNextBefore}:*` }, { uid: true });
-        } finally {
-          lock.release();
-        }
-      });
-      if (newUids.length !== sourceUids.length) {
-        console.warn(`bulkMoveMessages reconcile: expected ${sourceUids.length} new UIDs in ${toFolder}, found ${newUids.length} — skipping UID update (will reconcile on next sync)`);
-        return new Map();
-      }
-      // IMAP MOVE assigns destination UIDs in ascending source-UID order, so sort BOTH
-      // sides before zipping — sourceUids is in arbitrary input order.
-      const sortedSrc = sourceUids.map(Number).sort((a, b) => a - b);
-      const sortedNew = [...newUids].sort((a, b) => a - b);
-      const uidMap = new Map();
-      sortedSrc.forEach((uid, i) => uidMap.set(uid, sortedNew[i]));
-      console.log(`bulkMoveMessages: reconciled ${uidMap.size} UIDs via destination UIDNEXT scan`);
-      return uidMap;
-    } catch (err) {
-      console.warn(`bulkMoveMessages: UID reconciliation failed (${err.message}) — UIDs will be updated on next sync`);
-      return new Map();
-    }
-  }
-
-  // Permanently delete a batch of UIDs already in the given folder (two-step:
-  // flag \Deleted + expunge) in a single IMAP command sequence.
-  // Returns { succeeded, failed } — subsets of the input uids array.
-  //
-  // With UIDPLUS: UID EXPUNGE targets only the specified UIDs — safe.
-  // Without UIDPLUS: plain EXPUNGE removes ALL \Deleted messages in the mailbox.
-  // To prevent collateral damage, we temporarily unflag any other \Deleted messages
-  // before expunging, then restore them in a finally block.
-  async bulkPermanentDelete(account, uids, folder) {
-    if (!uids.length) return { succeeded: [], failed: [] };
-    try {
-      await withFreshClient(account, async (client) => {
-        const lock = await client.getMailboxLock(folder);
-        try {
-          const hasUidPlus = client.capabilities?.has('UIDPLUS');
-          if (hasUidPlus) {
-            const result = await client.messageDelete(uids.map(String).join(','), { uid: true });
-            if (result === false) throw new Error('bulk messageDelete returned false — server did not confirm deletion');
-          } else {
-            // No UIDPLUS: protect other \Deleted messages from the broad EXPUNGE.
-            const ourSet = new Set(uids.map(Number));
-            const allDeleted = await client.search({ deleted: true }, { uid: true });
-            const othersDeleted = allDeleted.filter(uid => !ourSet.has(uid));
-            if (othersDeleted.length > 0) {
-              await client.messageFlagsRemove(othersDeleted.join(','), ['\\Deleted'], { uid: true });
-            }
-            try {
-              const result = await client.messageDelete(uids.map(String).join(','), { uid: true });
-              if (result === false) throw new Error('bulk messageDelete returned false — server did not confirm deletion');
-            } finally {
-              if (othersDeleted.length > 0) {
-                await client.messageFlagsAdd(othersDeleted.join(','), ['\\Deleted'], { uid: true });
-              }
-            }
-          }
-        } finally {
-          lock.release();
-        }
-      });
-      return { succeeded: uids, failed: [] };
-    } catch (err) {
-      console.warn(`bulkPermanentDelete ${folder}: batch failed (${err.message}), verifying via UID SEARCH`);
+    const tokens = observationContext
+      ? await claimFolderObservations(account.id, [fromFolder, toFolder], {
+        context: observationContext.tokens,
+      })
+      : await readProviderOperationObservations(account.id, [fromFolder, toFolder]);
+    if (observationContext) observationContext.tokens = tokens;
+    const outcomes = await Promise.all(uids.map(async uid => {
       try {
-        const remaining = await withFreshClient(account, async (client) => {
-          const lock = await client.getMailboxLock(folder);
-          try {
-            return await client.search({ uid: uids.join(',') }, { uid: true });
-          } finally {
-            lock.release();
+        let rowOperationKey;
+        if (operationKeys != null) {
+          rowOperationKey = operationKeys.get?.(uid) ?? operationKeys.get?.(String(uid));
+          if (!rowOperationKey) {
+            throw new Error(`exact bulk MOVE operation key missing for uid ${uid}`);
           }
-        });
-        const remainingSet = new Set(remaining.map(Number));
-        const succeeded = uids.filter(uid => !remainingSet.has(Number(uid)));
-        const failed    = uids.filter(uid =>  remainingSet.has(Number(uid)));
-        if (succeeded.length) {
-          console.log(`bulkPermanentDelete: ${succeeded.length}/${uids.length} messages confirmed deleted via UID SEARCH`);
+        } else {
+          rowOperationKey = `${operationKey}:${uid}`;
         }
-        return { succeeded, failed };
-      } catch (searchErr) {
-        console.error(`bulkPermanentDelete: UID SEARCH verification failed: ${searchErr.message}`);
-        return { succeeded: [], failed: uids };
+        const sourceSnapshot = sourceSnapshots?.get?.(uid) || sourceSnapshots?.get?.(String(uid));
+        const sourceRow = sourceRows?.get?.(uid) || sourceRows?.get?.(String(uid));
+        const receipt = await this.moveMessage(account, uid, fromFolder, toFolder, {
+          returnReceipt: true,
+          operationTokens: tokens,
+          operationKey: rowOperationKey,
+          snapshot: sourceSnapshot,
+          expectedUidValidity: sourceSnapshot.uidValidity,
+          ...(materialize ? {
+            materialize: (providerReceipt, operation, tx, providerResource) => (
+              materialize(sourceRow, providerReceipt, operation, tx, providerResource)
+            ),
+          } : {}),
+        });
+        return { uid, receipt };
+      } catch (error) {
+        console.warn(`bulkMoveMessages ${fromFolder} → ${toFolder} uid=${uid} failed: ${error.message}`);
+        return { uid, error };
       }
-    }
+    }));
+    const succeeded = outcomes.filter(item => item.receipt).map(item => item.uid);
+    const failed = outcomes.filter(item => item.error).map(item => item.uid);
+    const uidMap = new Map(outcomes
+      .filter(item => item.receipt?.uid != null)
+      .map(item => [Number(item.uid), Number(item.receipt.uid)]));
+    const receiptMap = new Map(outcomes
+      .filter(item => item.receipt)
+      .map(item => [Number(item.uid), item.receipt]));
+    const result = { uidMap, succeeded, failed };
+    Object.defineProperty(result, 'receiptMap', { value: receiptMap, enumerable: false });
+    return result;
   }
 
   async syncNow(userId, accountId = null) {
@@ -5114,17 +6658,26 @@ export class ImapManager {
   }
 
   async _runSnoozeWakeup() {
-    // Find snoozed messages whose snooze_until has passed and which are still in
-    // the snoozed folder (joined via stable Message-ID header).
+    // Find due snoozes through the exact local row captured when the provider MOVE
+    // completed. Message-ID is descriptive metadata, never wakeup causality.
     const due = await query(`
       SELECT sm.id AS snooze_id, sm.user_id, sm.account_id,
-             sm.message_id_header, sm.original_folder, sm.snoozed_folder, m.uid, m.is_read
+             sm.message_row_id, sm.message_id_header, sm.original_folder,
+             sm.snoozed_folder, m.uid, m.is_read, m.read_revision, m.star_revision,
+             live_folder.uid_validity AS folder_uid_validity,
+             live_folder.observation_generation AS folder_observation_generation
       FROM snoozed_messages sm
-      JOIN messages m ON m.account_id = sm.account_id
-                     AND m.message_id = sm.message_id_header
+      JOIN messages m ON m.id = sm.message_row_id
+                     AND m.account_id = sm.account_id
                      AND m.folder = sm.snoozed_folder
                      AND m.is_deleted = false
+                     AND m.metadata_complete = true
+      JOIN folders live_folder ON live_folder.account_id = m.account_id
+                              AND live_folder.path = m.folder
+                              AND live_folder.is_present = true
+                              AND live_folder.uid_validity IS NOT NULL
       WHERE sm.snooze_until <= NOW()
+        AND sm.resolution_state = 'active'
     `);
 
     for (const row of due.rows) {
@@ -5137,89 +6690,78 @@ export class ImapManager {
         // the DB row if an EXPUNGE arrives from the Snoozed folder while the move
         // is in flight.
         this._guardMoveUid(row.account_id, row.snoozed_folder, row.uid);
-        let newUid;
         try {
-          // Move back to original folder
-          newUid = await this.moveMessageGetNewUid(
-            account, row.uid, row.snoozed_folder, row.original_folder
+          // The durable receipt is the only destination identity. Marker recovery always
+          // supplies an exact UID even when UIDPLUS is unavailable.
+          const moveReceipt = await this.moveMessage(
+            account, row.uid, row.snoozed_folder, row.original_folder,
+            {
+              operationKey: `snooze-wakeup:${row.snooze_id}`,
+              returnReceipt: true,
+              expectedUidValidity: row.folder_uid_validity,
+              snapshot: snapshotFromMessageRow({
+                ...row, id: row.message_row_id, account_id: row.account_id,
+                folder: row.snoozed_folder,
+              }),
+              materialize: (receipt, operation, tx) => materializeArchiveReceipt(tx, {
+                accountId: row.account_id,
+                sourceSnapshot: {
+                  ...row, id: row.message_row_id, account_id: row.account_id,
+                  folder: row.snoozed_folder,
+                },
+                destinationFolder: row.original_folder,
+                receipt,
+                operation,
+              }),
+            },
           );
 
-          // Mark as unread so the user notices it
-          if (newUid) {
-            await this.setFlag(account, newUid, row.original_folder, '\\Seen', false);
-          } else if (row.message_id_header) {
-            // No UIDPLUS — server moved the message but returned no UID map.
-            // Search the destination folder by Message-ID to locate and unflag \Seen.
-            try {
-              await withFreshClient(account, async (client) => {
-                const lock = await client.getMailboxLock(row.original_folder);
-                try {
-                  const uids = await client.search({ header: ['Message-ID', row.message_id_header] }, { uid: true });
-                  if (uids.length > 0) {
-                    const r = await client.messageFlagsRemove(String(uids[0]), ['\\Seen'], { uid: true });
-                    if (r === false) console.warn(`Snooze wakeup: messageFlagsRemove returned false for ${row.original_folder}`);
-                  } else {
-                    console.warn(`Snooze wakeup: could not find message in ${row.original_folder} to mark unread (Message-ID: ${row.message_id_header})`);
-                  }
-                } finally {
-                  lock.release();
-                }
-              });
-            } catch (err) {
-              console.warn(`Snooze wakeup: could not mark message unread on server (no UIDPLUS): ${err.message}`);
-            }
+          const unread = await this.setDesiredFlag(
+            account, row.message_row_id, 'read', false, {
+              snapshot: {
+                id: row.message_row_id, accountId: row.account_id,
+                uid: Number(moveReceipt.uid), folder: row.original_folder,
+                uidValidity: String(moveReceipt.uidValidity),
+                folderGeneration: String(moveReceipt.destinationToken.generation),
+                readRevision: Number(row.read_revision || 0),
+                starRevision: Number(row.star_revision || 0),
+              },
+            },
+          );
+          if (unread?.delivery?.state !== 'confirmed') {
+            throw new Error('Snooze wakeup unread delivery was not confirmed');
           }
 
-          // Update DB: change folder, mark unread, and update UID if the move returned one.
-          if (newUid != null) {
-            await query(
-              'UPDATE messages SET folder = $1, is_read = false, read_changed_at = NOW(), uid = $4 WHERE account_id = $2 AND message_id = $3 AND folder = $5',
-              [row.original_folder, row.account_id, row.message_id_header, newUid, row.snoozed_folder]
-            );
-          } else {
-            // Non-UIDPLUS: DB holds the stale source UID at the destination. Guard it so
-            // reconcileDeletes does not treat it as an orphan before the next sync corrects it.
-            this._guardMoveUid(row.account_id, row.original_folder, row.uid);
-            await query(
-              'UPDATE messages SET folder = $1, is_read = false, read_changed_at = NOW() WHERE account_id = $2 AND message_id = $3 AND folder = $4',
-              [row.original_folder, row.account_id, row.message_id_header, row.snoozed_folder]
-            );
-            setTimeout(() => this._unguardMoveUid(row.account_id, row.original_folder, row.uid), 10_000);
+          const resolved = await query(
+            `DELETE FROM snoozed_messages
+              WHERE id = $1 AND message_row_id = $2 AND resolution_state = 'active'`,
+            [row.snooze_id, row.message_row_id],
+          );
+          if (resolved.rowCount !== 1) {
+            const error = new Error('Exact snooze resolution record was superseded');
+            error.code = 'SNOOZE_RESOLUTION_PERSISTENCE_FAILED';
+            error.retryable = false;
+            throw error;
           }
         } finally {
           this._unguardMoveUid(row.account_id, row.snoozed_folder, row.uid);
         }
-
-        // Remove snooze record
-        await query('DELETE FROM snoozed_messages WHERE id = $1', [row.snooze_id]);
-
-        // Update folder counts: message leaves Snoozed and re-enters original_folder as unread.
-        // row.is_read reflects the read state in the Snoozed folder before the move.
-        adjustFolderCounts(row.account_id, row.snoozed_folder, -1, row.is_read ? 0 : -1);
-        adjustFolderCounts(row.account_id, row.original_folder, 1, 1); // always +1 unread on wakeup
 
         // Notify the user's open clients so the message reappears
         this.broadcast({ type: 'snooze_wakeup', accountId: row.account_id }, row.user_id);
 
         console.log(`Snooze wakeup: message ${row.message_id_header} restored to ${row.original_folder}`);
       } catch (err) {
-        console.error(`Snooze wakeup failed for snooze_id ${row.snooze_id}:`, err.message);
+        console.error(
+          `Snooze wakeup failed for snooze_id ${row.snooze_id}${err.code ? ` [${err.code}]` : ''}:`,
+          err.message,
+        );
       }
     }
 
-    // Clean up orphaned snooze records whose message has left the snoozed folder
-    // (e.g. user manually moved it out) and are at least 5 minutes past due.
-    await query(`
-      DELETE FROM snoozed_messages sm
-      WHERE sm.snooze_until <= NOW() - INTERVAL '5 minutes'
-        AND NOT EXISTS (
-          SELECT 1 FROM messages m
-          WHERE m.account_id = sm.account_id
-            AND m.message_id = sm.message_id_header
-            AND m.folder = sm.snoozed_folder
-            AND m.is_deleted = false
-        )
-    `);
+    // Non-actionable and orphaned legacy rows remain durable for reconciliation.
+    // Deleting by absence would turn an observation into causal success and could also
+    // erase a zero-CAS/manual result after the provider MOVE already happened.
   }
 
   broadcast(data, userId = null) {
@@ -5255,12 +6797,104 @@ export class ImapManager {
     return this._pendingMoveUids.has(`${accountId}:${folder}:${uid}`);
   }
 
+  async _reconcileFolderDeletes(
+    account, folder, serverUidSet, selectedValidity, reconcileStartedAt,
+    observationContext = null
+  ) {
+    // UIDVALIDITY is mandatory for a destructive UID diff. A pooled client can retain an
+    // old selected mailbox across a provider rebuild; without this fence, old-epoch SEARCH
+    // results could delete unrelated new-epoch rows after UID reuse.
+    if (selectedValidity == null) return 0;
+
+    const orphanRows = await withTransaction(async (tx) => {
+      // Capture exact row and folder identities under the authoritative snapshot epoch. Provider
+      // recovery runs after releasing this lock so its own observation fences cannot deadlock.
+      const states = observationContext
+        ? await assertObservationContext(tx, account.id, observationContext)
+        : null;
+      const state = states?.get(folder) || await tx.query(
+        `SELECT uid_validity FROM folders
+          WHERE account_id = $1 AND path = $2
+          FOR UPDATE`,
+        [account.id, folder]
+      ).then(result => result.rows[0]);
+      const durableValidity = state?.uid_validity != null
+        ? Number(state.uid_validity)
+        : null;
+      if (durableValidity !== selectedValidity) return null;
+
+      const dbResult = await tx.query(
+        `SELECT m.*,
+                f.uid_validity AS folder_uid_validity,
+                f.observation_generation AS folder_observation_generation,
+                f.topology_identity AS folder_topology_identity
+           FROM messages m
+           JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+          WHERE m.account_id = $1 AND m.folder = $2
+            AND (m.synced_at IS NULL OR m.synced_at < $3)`,
+        [account.id, folder, reconcileStartedAt]
+      );
+      return dbResult.rows.filter(row => (
+        !serverUidSet.has(Number(row.uid)) &&
+        !this._isMoveUidGuarded(account.id, folder, row.uid)
+      ));
+    });
+    if (orphanRows == null) return 0;
+
+    let removedCount = 0;
+    if (orphanRows.length > 0) {
+      console.log(`Reconcile: resolving ${orphanRows.length} missing message(s) from ${logAccount(account)}/${folder}`);
+    }
+    for (const row of orphanRows) {
+      try {
+        const result = await this.reconcileMissingMessageCopy(
+          account, row, { deleteIfUncaused: true },
+        );
+        removedCount += Number(result.changed || 0);
+      } catch (error) {
+        console.warn(
+          `Reconcile: retaining recoverable source ${row.id} (${folder}/${row.uid}): ${error.message}`,
+        );
+      }
+    }
+
+    await withTransaction(async tx => {
+      const states = observationContext
+        ? await assertObservationContext(tx, account.id, observationContext)
+        : null;
+      const state = states?.get(folder) || await tx.query(
+        `SELECT uid_validity FROM folders
+          WHERE account_id = $1 AND path = $2
+          FOR UPDATE`,
+        [account.id, folder],
+      ).then(result => result.rows[0]);
+      if (Number(state?.uid_validity) !== selectedValidity) return;
+      // SEARCH is authoritative for total UIDs. A local-count mismatch means at least one
+      // historical server UID is absent or incomplete locally; retain the server total and
+      // force exact-UID backfill instead of hiding the gap behind a smaller local count.
+      await tx.query(
+        `UPDATE folders f
+         SET total_count  = $3,
+             unread_count = (SELECT COUNT(*) FILTER (WHERE m.is_read = false)
+                                             FROM messages m WHERE m.account_id = $1 AND m.folder = $2
+                                               AND m.is_deleted = false AND m.metadata_complete = true),
+             backfill_incomplete = f.backfill_incomplete OR
+               (SELECT COUNT(*) FROM messages m
+                 WHERE m.account_id = $1 AND m.folder = $2
+                   AND m.is_deleted = false AND m.metadata_complete = true) <> $3
+         WHERE f.account_id = $1 AND f.path = $2`,
+        [account.id, folder, serverUidSet.size]
+      );
+    });
+    return removedCount;
+  }
+
   // Compare the server's UID set for every folder that has local messages against our DB
   // and hard-delete rows whose UIDs no longer exist on the server (deleted by another
   // client). Phase 1: collect all server UID sets via one pool connection (IMAP-only, no
   // DB writes). Phase 2: diff and delete outside the IMAP connection so a DB error never
   // evicts a healthy pool client.
-  async reconcileDeletes(account) {
+  async reconcileDeletes(account, restartOnSupersession = true) {
     // Captured before the Phase 1 snapshot. Any row inserted or re-synced after this
     // instant (new IDLE mail, a bulk-move reinsert) is NOT in the snapshot yet, so it
     // would look like an orphan. Excluding rows synced at/after the cutoff closes that
@@ -5274,9 +6908,13 @@ export class ImapManager {
     if (!folderResult.rows.length) return;
 
     const folders = folderResult.rows.map(r => r.folder);
+    const observationContext = {
+      accountId: account.id,
+      tokens: await claimFolderObservations(account.id, folders),
+    };
 
     // Phase 1 — fetch server UID sets for each folder (IMAP only, inside withFreshClient).
-    const serverUidsByFolder = new Map(); // folder -> Set<number>
+    const serverUidsByFolder = new Map(); // folder -> { uids: Set<number>, uidValidity: number }
     try {
       await withFreshClient(account, async (client) => {
         for (const folder of folders) {
@@ -5285,6 +6923,13 @@ export class ImapManager {
             const lock = await client.getMailboxLock(folder);
             try {
               serverUids = await client.search({ all: true }, { uid: true });
+              const selectedValidity = client.mailbox?.uidValidity != null
+                ? Number(client.mailbox.uidValidity)
+                : null;
+              serverUidsByFolder.set(folder, {
+                uids: new Set(serverUids),
+                uidValidity: selectedValidity,
+              });
             } finally {
               lock.release();
             }
@@ -5293,7 +6938,6 @@ export class ImapManager {
             console.warn(`Reconcile: could not open ${logAccount(account)}/${folder}: ${extractImapError(err)}`);
             continue;
           }
-          serverUidsByFolder.set(folder, new Set(serverUids));
         }
       });
     } catch (err) {
@@ -5304,35 +6948,19 @@ export class ImapManager {
     // Phase 2 — diff each folder's server UIDs against the DB and delete orphans.
     // Runs outside withFreshClient so DB errors never cause unnecessary pool eviction.
     let deletedCount = 0;
-    for (const [folder, serverUidSet] of serverUidsByFolder) {
-      const dbResult = await query(
-        'SELECT uid FROM messages WHERE account_id = $1 AND folder = $2 AND (synced_at IS NULL OR synced_at < $3)',
-        [account.id, folder, reconcileStartedAt]
-      );
-      const orphanUids = dbResult.rows
-        .map(r => Number(r.uid))
-        .filter(uid => !serverUidSet.has(uid) && !this._isMoveUidGuarded(account.id, folder, uid));
-
-      if (orphanUids.length === 0) continue;
-
-      console.log(`Reconcile: removing ${orphanUids.length} server-deleted message(s) from ${logAccount(account)}/${folder}`);
-      // Re-assert the cutoff in the DELETE: a row updated to a fresh synced_at between
-      // the SELECT above and here (e.g. a concurrent bulk-move reinsert) is spared.
-      await query(
-        'DELETE FROM messages WHERE account_id = $1 AND folder = $2 AND uid = ANY($3::bigint[]) AND (synced_at IS NULL OR synced_at < $4)',
-        [account.id, folder, orphanUids, reconcileStartedAt]
-      );
-      // Resync cached folder counts from actual row data — reconcile deletes rows
-      // without going through adjustFolderCounts, so counts would otherwise drift.
-      await query(
-        `UPDATE folders f
-         SET total_count  = (SELECT COUNT(*)              FROM messages m WHERE m.account_id = $1 AND m.folder = $2),
-             unread_count = (SELECT COUNT(*) FILTER (WHERE m.is_read = false)
-                                             FROM messages m WHERE m.account_id = $1 AND m.folder = $2)
-         WHERE f.account_id = $1 AND f.path = $2`,
-        [account.id, folder]
-      );
-      deletedCount += orphanUids.length;
+    try {
+      for (const [folder, snapshot] of serverUidsByFolder) {
+        deletedCount += await this._reconcileFolderDeletes(
+          account, folder, snapshot.uids, snapshot.uidValidity, reconcileStartedAt,
+          observationContext
+        );
+      }
+    } catch (err) {
+      if (restartOnSupersession && isFolderObservationError(err)) {
+        this._evictPool?.(account.id);
+        return this.reconcileDeletes(account, false);
+      }
+      throw err;
     }
 
     if (deletedCount > 0) {

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -1,8 +1,58 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('imapflow', () => ({ ImapFlow: vi.fn() }));
-vi.mock('./db.js', () => ({ query: vi.fn() }));
-vi.mock('./messageParser.js', () => ({ parseMessage: vi.fn(), buildSnippetFromHtml: vi.fn(), snippetFromBody: vi.fn(), decodeMimeWords: vi.fn(), detectBulkFromParsedHeaders: vi.fn(), parseRawHeaders: vi.fn(), enrichParsedMetadata: vi.fn((parsed) => parsed) }));
+vi.mock('./db.js', () => {
+  const query = vi.fn();
+  return {
+    query,
+    withTransaction: vi.fn(callback => callback({ query })),
+    withSession: vi.fn(callback => callback({ query: vi.fn().mockResolvedValue({ rows: [] }) })),
+  };
+});
+vi.mock('./folderObservation.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    claimFolderObservation: vi.fn(async (_accountId, folder) => ({
+      folder, uidValidity: null, generation: null,
+    })),
+    claimFolderObservations: vi.fn(async (_accountId, paths) => paths.map(folder => ({
+      folder, uidValidity: null, generation: null,
+    }))),
+    readFolderObservation: vi.fn(async (_accountId, folder) => ({
+      folder, uidValidity: null, generation: null,
+    })),
+    claimMailboxTopology: vi.fn(async accountId => ({ accountId, generation: '1' })),
+    commitMailboxTopology: vi.fn(async () => ({ tombstoned: [] })),
+    seedFolderUidValidity: vi.fn(async (_tx, _accountId, token, uidValidity) => ({
+      ...token, uidValidity: String(uidValidity), isPresent: true,
+    })),
+    assertFolderObservation: vi.fn(async (tx, accountId, token) => {
+      const result = await tx.query(
+        `SELECT uid_validity, highest_modseq FROM folders
+          WHERE account_id = $1 AND path = $2
+          FOR UPDATE`,
+        [accountId, token.folder],
+      );
+      return result?.rows?.[0] || {
+        uid_validity: token.uidValidity, highest_modseq: null, is_present: true,
+      };
+    }),
+  };
+});
+vi.mock('./messageParser.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    parseMessage: vi.fn(),
+    buildSnippetFromHtml: vi.fn(),
+    snippetFromBody: vi.fn(),
+    decodeMimeWords: vi.fn(),
+    detectBulkFromParsedHeaders: vi.fn(),
+    parseRawHeaders: vi.fn(),
+    enrichParsedMetadata: vi.fn((parsed) => parsed),
+  };
+});
 vi.mock('../routes/oauth.js', () => ({ refreshMicrosoftToken: vi.fn() }));
 vi.mock('./emailSanitizer.js', () => ({ sanitizeEmail: vi.fn() }));
 vi.mock('./encryption.js', () => ({ decrypt: vi.fn() }));
@@ -12,20 +62,1091 @@ vi.mock('../utils/redact.js', () => ({ redactEmail: vi.fn() }));
 vi.mock('./hostValidation.js', () => ({ resolveForConnection: vi.fn() }));
 vi.mock('./connectionPolicy.js', () => ({ getConnectionPolicy: vi.fn() }));
 
-import { ImapManager, providerProfile, makeClientCfg, relocateExemptGuard, insertCopiedSibling, deleteMessageCopyRow, emitSectionsChanged, ensureMailbox, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, folderSyncDue, planModseqSync, connectStaggerFor, walkStructure, parsePersistentCap, resolvePersistentCap, persistentEligible, shouldRetryIPv4 } from './imapManager.js';
+import { ImapManager, COMPLETE_METADATA_CONFLICT_UPDATE_SQL, providerProfile, makeClientCfg, relocateExemptGuard, insertCopiedSibling, deleteMessageCopyRow, emitSectionsChanged, ensureMailbox, createKeyedSemaphore, isConnectionRefusal, connectCooldownMs, effectiveSyncIntervalMs, folderSyncDue, planModseqSync, connectStaggerFor, walkStructure, parsePersistentCap, resolvePersistentCap, persistentEligible, shouldRetryIPv4, recoveryKeywordAllowed, findSingleRecoveryKeywordUid, findSingleMessageIdUid, recoverProviderMarkerOnClient, searchContainsExactUid, validateRecoveryDestinationUid, desiredFlagDeliverySnapshot, abortPoolClients, registerTemporaryPoolClient, abortConnectionPool, withUidEpochFence, validateFrozenMoveCapabilities, normalizeFrozenMailboxAcquisitionError } from './imapManager.js';
 import { pluginRegistry } from '../plugins/registry.js';
 import { EventEmitter } from 'node:events';
 import { ImapFlow } from 'imapflow';
-import { query } from './db.js';
+import { query, withTransaction } from './db.js';
 import { resolveForConnection } from './hostValidation.js';
 import { getConnectionPolicy } from './connectionPolicy.js';
 import { invalidateGtdConfigCache } from '../plugins/gtd/gtdConfig.js';
 import { parseMessage } from './messageParser.js';
+import {
+  assertFolderObservation,
+  claimFolderObservation,
+  claimFolderObservations,
+  claimMailboxTopology,
+  commitMailboxTopology,
+  readFolderObservation,
+  seedFolderUidValidity,
+} from './folderObservation.js';
+import * as imapModule from './imapManager.js';
+import { desiredFlagExecutor } from './desiredFlags.js';
+import { buildProviderOperationId, providerOperationMarker } from './providerOperations.js';
 
 const account = (imap_host, oauth_provider = null) => ({ imap_host, oauth_provider });
 
 const resolved = { host: '127.0.0.1', servername: null };
 const baseAccount = { imap_host: '127.0.0.1', imap_port: 1143, imap_tls: true, imap_skip_tls_verify: false, auth_user: 'user', auth_pass: 'enc' };
+const sourceSnapshot = (uid = 7, {
+  accountId = 'acct-1', folder = 'INBOX', uidValidity = '101', generation = '4',
+} = {}) => ({
+  id: `11111111-1111-4111-8111-${String(uid).padStart(12, '0')}`,
+  accountId, uid, folder, uidValidity, folderGeneration: generation,
+  readRevision: 1, starRevision: 2,
+});
+const exactSourceSnapshot = Object.freeze(sourceSnapshot());
+const sourceSnapshotMap = (...uids) => new Map(uids.map(uid => [uid, sourceSnapshot(uid)]));
+
+beforeEach(() => {
+  withTransaction.mockReset();
+  withTransaction.mockImplementation(callback => callback({ query }));
+});
+
+describe('metadata conflict flag safety', () => {
+  it('never publishes provider flags through a metadata UPSERT without a captured revision CAS', () => {
+    expect(COMPLETE_METADATA_CONFLICT_UPDATE_SQL).toMatch(
+      /is_read = CASE WHEN NOT messages\.metadata_complete THEN EXCLUDED\.is_read ELSE messages\.is_read END/,
+    );
+    expect(COMPLETE_METADATA_CONFLICT_UPDATE_SQL).toMatch(
+      /is_starred = CASE WHEN NOT messages\.metadata_complete THEN EXCLUDED\.is_starred ELSE messages\.is_starred END/,
+    );
+    expect(COMPLETE_METADATA_CONFLICT_UPDATE_SQL).not.toMatch(/read_changed_at|star_changed_at|30 seconds/);
+  });
+});
+
+describe('headerless move recovery protocol', () => {
+  const keyword = '$MailFlowMove-row-1';
+
+  it('rejects a mailbox that explicitly disallows new keywords', () => {
+    expect(recoveryKeywordAllowed({ permanentFlags: new Set(['\\Seen']) }, keyword)).toBe(false);
+    expect(recoveryKeywordAllowed({ permanentFlags: new Set(['\\*']) }, keyword)).toBe(true);
+    expect(recoveryKeywordAllowed({}, keyword)).toBe(true);
+  });
+
+  it('treats SEARCH false as an error and rejects ambiguous destination markers', async () => {
+    await expect(findSingleRecoveryKeywordUid({ search: vi.fn().mockResolvedValue(false) }, keyword))
+      .rejects.toThrow(/search/i);
+    await expect(findSingleRecoveryKeywordUid({ search: vi.fn().mockResolvedValue([81, 82]) }, keyword))
+      .rejects.toThrow(/ambiguous/i);
+    await expect(findSingleRecoveryKeywordUid({ search: vi.fn().mockResolvedValue([]) }, keyword))
+      .resolves.toBeNull();
+  });
+
+  it('requires a unique Message-ID destination and treats SEARCH false as failure', async () => {
+    await expect(findSingleMessageIdUid({ search: vi.fn().mockResolvedValue(false) }, 'm@x'))
+      .rejects.toThrow(/search/i);
+    await expect(findSingleMessageIdUid({
+      search: vi.fn().mockResolvedValue([81, 82]),
+      fetchOne: vi.fn().mockImplementation(async uid => ({
+        uid: Number(uid),
+        headers: Buffer.from('Message-ID: <m@x>\r\n'),
+      })),
+    }, 'm@x'))
+      .rejects.toThrow(/ambiguous/i);
+    await expect(findSingleMessageIdUid({
+      search: vi.fn().mockResolvedValue([82, 82]),
+      fetchOne: vi.fn().mockResolvedValue({
+        uid: 82,
+        headers: Buffer.from('Message-ID: <m@x>\r\n'),
+      }),
+    }, 'm@x'))
+      .resolves.toBe(82);
+  });
+
+  it('rejects a sole substring Message-ID search result', async () => {
+    const client = {
+      search: vi.fn().mockResolvedValue([82]),
+      fetchOne: vi.fn().mockResolvedValue({
+        uid: 82,
+        headers: Buffer.from('Message-ID: <prefix-m@x>\r\n'),
+      }),
+    };
+
+    await expect(findSingleMessageIdUid(client, '<m@x>'))
+      .rejects.toThrow(/does not exactly match/i);
+  });
+
+  it('selects the one exact Message-ID when SEARCH also returns substring matches', async () => {
+    const client = {
+      search: vi.fn().mockResolvedValue([81, 82]),
+      fetchOne: vi.fn().mockImplementation(async uid => ({
+        uid: Number(uid),
+        headers: Buffer.from(Number(uid) === 82
+          ? 'Message-ID: <m@x>\r\n'
+          : 'Message-ID: <prefix-m@x>\r\n'),
+      })),
+    };
+
+    await expect(findSingleMessageIdUid(client, '<m@x>')).resolves.toBe(82);
+  });
+
+  it('never converts an exact-UID SEARCH command failure into message absence', async () => {
+    await expect(searchContainsExactUid({ search: vi.fn().mockResolvedValue(false) }, 7))
+      .rejects.toThrow(/search/i);
+    await expect(searchContainsExactUid({ search: vi.fn().mockResolvedValue([]) }, 7))
+      .resolves.toBe(false);
+  });
+
+  it('rejects disagreement between UIDPLUS and the verified keyword destination', () => {
+    expect(() => validateRecoveryDestinationUid(81, 82)).toThrow(/uidplus/i);
+    expect(validateRecoveryDestinationUid(82, 82)).toBe(82);
+    expect(validateRecoveryDestinationUid(null, 82)).toBe(82);
+  });
+
+});
+
+describe('causal COPY and APPEND marker protocol', () => {
+  const marker = '$MailFlowOp-abcdefghijklmnopqrstuvwxyzABCDEFGH123456789';
+
+  it.each([
+    [[], { status: 'absent' }],
+    [[88], { status: 'unique', uid: 88, uidValidity: '202' }],
+    [[88, 89], { status: 'ambiguous', uids: [88, 89] }],
+  ])('recovers only a unique marker match (%j)', async (uids, expected) => {
+    const client = { mailbox: { uidValidity: 202 }, search: vi.fn().mockResolvedValue(uids) };
+    await expect(recoverProviderMarkerOnClient(client, marker)).resolves.toEqual(expected);
+  });
+});
+
+describe('durable provider operation wiring', () => {
+  afterEach(() => {
+    query.mockReset();
+    claimFolderObservation.mockClear();
+    claimFolderObservations.mockClear();
+    readFolderObservation.mockClear();
+  });
+
+  it('rejects MOVE, COPY, and bulk MOVE without exact source snapshots', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder, uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8', isPresent: true,
+    }));
+    const execute = vi.fn();
+
+    await expect(ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', { operationKey: 'move-without-row' },
+    )).rejects.toThrow(/exact live message snapshot/i);
+
+    query.mockResolvedValueOnce({ rows: [{ id: 'acct-1' }] });
+    await expect(ImapManager.prototype.copyMessage.call(
+      { providerOperationExecutor: { execute }, pluginFacade: {} },
+      'acct-1', 7, 'INBOX', 'Todo', { operationKey: 'copy-without-row' },
+    )).rejects.toThrow(/exact live message snapshot/i);
+
+    await expect(ImapManager.prototype.bulkMoveMessages.call(
+      { moveMessage: vi.fn() }, { id: 'acct-1' }, [7], 'INBOX', 'Archive',
+      { operationKey: 'bulk-without-rows' },
+    )).rejects.toThrow(/exact source snapshot.*uid 7/i);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('classifies permanent frozen MOVE capability failures explicitly', () => {
+    const marker = '$MailFlowOp-test';
+    expect(() => validateFrozenMoveCapabilities({
+      client: { capabilities: new Set(), mailbox: { permanentFlags: new Set(['\\*']) } },
+    }, marker, { role: 'Source', requireMove: true })).toThrow(expect.objectContaining({
+      code: 'PROVIDER_NATIVE_MOVE_UNSUPPORTED', retryable: false,
+    }));
+    expect(() => validateFrozenMoveCapabilities({
+      client: { capabilities: new Set(['MOVE']), mailbox: { permanentFlags: new Set() } },
+    }, marker, { role: 'Source', requireMove: true })).toThrow(expect.objectContaining({
+      code: 'PROVIDER_RECOVERY_MARKER_UNSUPPORTED', retryable: false,
+    }));
+    expect(() => validateFrozenMoveCapabilities({
+      client: { capabilities: new Set(['MOVE']), mailbox: { permanentFlags: new Set() } },
+    }, marker, { role: 'Destination', requireMove: false })).toThrow(expect.objectContaining({
+      code: 'PROVIDER_RECOVERY_MARKER_UNSUPPORTED', retryable: false,
+    }));
+  });
+
+  it('normalizes only explicit frozen mailbox-not-found acquisition failures', () => {
+    const missing = Object.assign(new Error('Mailbox does not exist'), { responseStatus: 'NONEXISTENT' });
+    expect(normalizeFrozenMailboxAcquisitionError(missing, ['INBOX', 'Archive'])).toMatchObject({
+      code: 'PROVIDER_MAILBOX_SUPERSEDED', retryable: false,
+    });
+    const transient = Object.assign(new Error('socket timeout'), { code: 'ETIMEDOUT', retryable: true });
+    expect(normalizeFrozenMailboxAcquisitionError(transient, ['INBOX', 'Archive'])).toBe(transient);
+  });
+
+  it.each([
+    ['deleted destination', [
+      { uid_validity: '202', observation_generation: '8', is_present: false },
+    ], 'FOLDER_OBSERVATION_UNSAFE'],
+    ['renamed destination', [
+      Object.assign(new Error('Archive observation missing'), { code: 'FOLDER_OBSERVATION_SUPERSEDED' }),
+    ], 'FOLDER_OBSERVATION_SUPERSEDED'],
+    ['deleted source', [
+      { uid_validity: '202', observation_generation: '8', is_present: true },
+      { uid_validity: '101', observation_generation: '4', is_present: false },
+    ], 'FOLDER_OBSERVATION_UNSAFE'],
+    ['renamed source', [
+      { uid_validity: '202', observation_generation: '8', is_present: true },
+      Object.assign(new Error('INBOX observation missing'), { code: 'FOLDER_OBSERVATION_SUPERSEDED' }),
+    ], 'FOLDER_OBSERVATION_SUPERSEDED'],
+  ])('preflights a frozen MOVE before provider acquisition when the %s is stale', async (
+    _case, observations, expectedCode,
+  ) => {
+    for (const observation of observations) {
+      if (observation instanceof Error) assertFolderObservation.mockRejectedValueOnce(observation);
+      else assertFolderObservation.mockResolvedValueOnce(observation);
+    }
+    const execute = vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202' });
+    const operationTokens = [
+      { folder: 'INBOX', uidValidity: '101', generation: '4', isPresent: true },
+      { folder: 'Archive', uidValidity: '202', generation: '8', isPresent: true },
+    ];
+
+    await expect(ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        operationKey: 'frozen-move-1', snapshot: exactSourceSnapshot, operationTokens,
+      },
+    )).rejects.toMatchObject({ code: expectedCode, retryable: false });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('does not classify a transient provider connection error as frozen-plan supersession', async () => {
+    assertFolderObservation
+      .mockResolvedValueOnce({ uid_validity: '202', observation_generation: '8', is_present: true })
+      .mockResolvedValueOnce({ uid_validity: '101', observation_generation: '4', is_present: true });
+    const transient = Object.assign(new Error('ECONNRESET'), { code: 'ECONNRESET', retryable: true });
+    const execute = vi.fn().mockRejectedValue(transient);
+
+    await expect(ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        operationKey: 'frozen-move-2', snapshot: exactSourceSnapshot,
+        operationTokens: [
+          { folder: 'INBOX', uidValidity: '101', generation: '4', isPresent: true },
+          { folder: 'Archive', uidValidity: '202', generation: '8', isPresent: true },
+        ],
+      },
+    )).rejects.toBe(transient);
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it('does not expose orphan raw provider mutation helpers', () => {
+    for (const name of ['moveMessageOnClient', 'copyMessageOnClient', 'appendMessageOnClient']) {
+      expect(imapModule).not.toHaveProperty(name);
+    }
+    for (const name of [
+      'setFlag', 'moveMessageGetNewUid', 'emptyFolder', 'markAllReadImap',
+      'clearMoveRecoveryKeyword', '_bulkMoveMessages', 'bulkPermanentDelete',
+    ]) {
+      expect(ImapManager.prototype).not.toHaveProperty(name);
+    }
+  });
+
+  it('routes a headerful MOVE through the same marker identity as a headerless MOVE', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      isPresent: true,
+    }));
+    const execute = vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202' });
+    const ctx = { providerOperationExecutor: { execute } };
+
+    await expect(ImapManager.prototype.moveMessage.call(
+      ctx, { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        messageId: '<duplicate@x>', operationKey: 'move-request-1',
+        snapshot: exactSourceSnapshot,
+      },
+    )).resolves.toBe(88);
+    const headerful = execute.mock.calls[0][0].intent;
+    execute.mockClear();
+    await ImapManager.prototype.moveMessage.call(
+      ctx, { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        messageId: null, operationKey: 'move-request-1', snapshot: exactSourceSnapshot,
+      },
+    );
+    const headerless = execute.mock.calls[0][0].intent;
+
+    expect(headerful.id).toBe(headerless.id);
+    expect(headerful.marker).toBe(headerless.marker);
+  });
+
+  it('extends a nested observation context by claiming the destination while reusing source ownership', async () => {
+    const source = {
+      folder: 'INBOX', uidValidity: '101', generation: '4',
+      topologyIdentity: 'source-incarnation', isPresent: true,
+    };
+    const destination = {
+      folder: 'Archive', uidValidity: '202', generation: '9',
+      topologyIdentity: 'dest-incarnation', isPresent: true,
+    };
+    const observationContext = { accountId: 'acct-1', tokens: [source] };
+    claimFolderObservations.mockResolvedValueOnce([destination, source]);
+    const execute = vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202' });
+
+    await ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        operationKey: 'nested-rule-move', observationContext, snapshot: exactSourceSnapshot,
+      },
+    );
+
+    expect(claimFolderObservations).toHaveBeenCalledWith(
+      'acct-1', ['INBOX', 'Archive'], { context: [source] },
+    );
+    expect(observationContext.tokens).toEqual([destination, source]);
+    expect(execute.mock.calls[0][0].intent.source).toMatchObject({
+      folder: source.folder, uidValidity: source.uidValidity,
+      generation: source.generation, topologyIdentity: source.topologyIdentity,
+    });
+    expect(execute.mock.calls[0][0].intent.destination).toMatchObject({
+      folder: destination.folder, uidValidity: destination.uidValidity,
+      generation: destination.generation, topologyIdentity: destination.topologyIdentity,
+    });
+    expect(readFolderObservation).not.toHaveBeenCalled();
+  });
+
+  it('runs MOVE materialization inside the durable completion fence transaction', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      isPresent: true,
+    }));
+    const tx = { query: vi.fn() };
+    const providerReceipt = {
+      uid: 88, uidValidity: '202', folder: 'Archive', marker: '$MailFlowOp-test',
+    };
+    const materialize = vi.fn().mockResolvedValue({ archived: true });
+    const execute = vi.fn(spec => spec.complete(providerReceipt, spec.intent, tx));
+    const ctx = { providerOperationExecutor: { execute } };
+
+    await expect(ImapManager.prototype.moveMessage.call(
+      ctx, { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        operationKey: 'archive:row-1', returnReceipt: true, materialize,
+        snapshot: exactSourceSnapshot,
+      },
+    )).resolves.toBe(providerReceipt);
+
+    expect(materialize).toHaveBeenCalledWith(providerReceipt, expect.objectContaining({
+      kind: 'move', accountId: 'acct-1',
+    }), tx, undefined);
+  });
+
+  it('cleans a completed MOVE marker from each still-live epoch while accepting a reset side', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      topologyIdentity: folder === 'INBOX' ? 'source-incarnation' : 'dest-incarnation',
+      isPresent: true,
+    }));
+    let spec;
+    const execute = vi.fn(async value => {
+      spec = value;
+      return { uid: 88, uidValidity: '202', folder: 'Archive' };
+    });
+    await ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        operationKey: 'cleanup-reset-side', snapshot: exactSourceSnapshot,
+      },
+    );
+    const present = new Set([`${spec.intent.marker}:88`]);
+    const client = {
+      mailbox: { path: 'Archive', uidValidity: 202 },
+      search: vi.fn(async queryValue => (
+        present.has(`${queryValue.keyword}:${queryValue.uid}`) ? [Number(queryValue.uid)] : []
+      )),
+      messageFlagsRemove: vi.fn(async (uid, [marker]) => {
+        present.delete(`${marker}:${uid}`);
+        return true;
+      }),
+    };
+    const switchTo = vi.fn(async folder => {
+      client.mailbox = {
+        path: folder,
+        uidValidity: folder === 'INBOX' ? 999 : 202,
+      };
+    });
+    const operation = {
+      ...spec.intent,
+      state: 'completed',
+      receipt: {
+        uid: 88, folder: 'Archive', uidValidity: '202', marker: spec.intent.marker,
+        sourceToken: spec.intent.source, destinationToken: spec.intent.destination,
+      },
+    };
+
+    await expect(spec.cleanup(
+      { client, switchTo }, spec.intent.marker, operation.receipt, operation,
+    )).resolves.toBeUndefined();
+    expect(client.messageFlagsRemove).toHaveBeenCalledOnce();
+    expect(client.messageFlagsRemove).toHaveBeenCalledWith('88', [spec.intent.marker], { uid: true });
+  });
+
+  it('autonomously retries a bounded batch of completed pending marker cleanups', async () => {
+    const operation = {
+      id: 'operation-1', accountId: 'acct-1', kind: 'move', marker: '$MailFlowOp-one',
+      state: 'completed', cleanupState: 'pending', requestKey: 'request-1',
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+      destination: { folder: 'Archive', uidValidity: '202', generation: '8' },
+      receipt: { folder: 'Archive', uid: 88, uidValidity: '202' },
+    };
+    const listPendingCleanup = vi.fn().mockResolvedValue([operation]);
+    const removed = [];
+    const completeExisting = vi.fn(async (_id, spec) => {
+      let present = true;
+      const client = {
+        mailbox: { path: 'Archive', uidValidity: 202 },
+        search: vi.fn(async () => present ? [88] : []),
+        messageFlagsRemove: vi.fn(async (uid, markers) => {
+          removed.push([uid, markers]);
+          present = false;
+          return true;
+        }),
+      };
+      await spec.cleanup({
+        client,
+        switchTo: async folder => {
+          client.mailbox = {
+            path: folder, uidValidity: folder === 'INBOX' ? 999 : 202,
+          };
+        },
+      }, operation.marker, operation.receipt, operation);
+      return { status: 'completed', replayed: true };
+    });
+    query.mockImplementation(async sql => (
+      /SELECT \* FROM email_accounts/.test(sql)
+        ? { rows: [{ id: 'acct-1', enabled: true, protocol: 'imap' }] }
+        : { rows: [] }
+    ));
+
+    await expect(ImapManager.prototype._sweepProviderOperationCleanup.call({
+      providerOperationExecutor: { listPendingCleanup, completeExisting },
+    }, 5)).resolves.toBe(1);
+
+    expect(listPendingCleanup).toHaveBeenCalledWith(5);
+    expect(completeExisting).toHaveBeenCalledWith(
+      'operation-1', expect.objectContaining({
+        acquireProvider: expect.any(Function), cleanup: expect.any(Function),
+      }),
+    );
+    expect(removed).toEqual([['88', ['$MailFlowOp-one']]]);
+  });
+
+  it('defers APPEND before executor/provider access when destination epoch is unknown', async () => {
+    readFolderObservation.mockResolvedValueOnce({
+      folder: 'Drafts', uidValidity: null, generation: '8', isPresent: true,
+    });
+    const execute = vi.fn();
+    const ctx = { providerOperationExecutor: { execute } };
+
+    await expect(ImapManager.prototype.appendToFolder.call(
+      ctx, { id: 'acct-1' }, 'Drafts', Buffer.from('mime'), ['\\Draft'],
+      { operationKey: 'draft-request-1' },
+    )).rejects.toThrow(/destination uidvalidity/i);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('never issues DELETE during provider_started takeover when the persisted marker is absent', async () => {
+    readFolderObservation.mockResolvedValueOnce({
+      folder: 'Trash', uidValidity: '303', generation: '12',
+      topologyIdentity: 'trash-incarnation', isPresent: true,
+    });
+    let spec;
+    const execute = vi.fn(async value => { spec = value; return { status: 'pending' }; });
+    const snapshot = sourceSnapshot(7, {
+      folder: 'Trash', uidValidity: '303', generation: '12',
+    });
+    await ImapManager.prototype.permanentDeleteMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'Trash', {
+        snapshot, operationKey: 'delete-row-7', expectedUidValidity: '303',
+      },
+    );
+    const client = {
+      capabilities: new Set(['UIDPLUS']),
+      search: vi.fn().mockResolvedValue([]),
+      messageDelete: vi.fn(),
+    };
+
+    await expect(spec.recover({ client }, spec.intent.marker, spec.intent))
+      .resolves.toEqual({ status: 'absent' });
+    expect(client.messageDelete).not.toHaveBeenCalled();
+    expect(client.search).toHaveBeenCalledWith(
+      { uid: '7', keyword: spec.intent.marker }, { uid: true },
+    );
+  });
+
+  it('passes APPEND local materialization through durable completion', async () => {
+    readFolderObservation.mockResolvedValueOnce({
+      folder: 'Sent', uidValidity: '202', generation: '8', isPresent: true,
+    });
+    const materialize = vi.fn();
+    const execute = vi.fn(async spec => spec.complete({ uid: 88, uidValidity: '202' }));
+    const ctx = { providerOperationExecutor: { execute } };
+
+    await expect(ImapManager.prototype.appendToFolder.call(
+      ctx, { id: 'acct-1' }, 'Sent', Buffer.from('mime'), ['\\Seen'],
+      { operationKey: 'send-request-1', materialize },
+    )).resolves.toEqual({ uid: 88, uidValidity: '202', folder: 'Sent' });
+    expect(materialize).toHaveBeenCalledWith({ uid: 88, uidValidity: '202', folder: 'Sent' });
+  });
+
+  it('routes COPY through a durable marker operation before local sibling work', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 'acct-1' }] });
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      isPresent: true,
+    }));
+    const execute = vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202', folder: 'Todo' });
+    const ctx = { providerOperationExecutor: { execute }, pluginFacade: {} };
+
+    await expect(ImapManager.prototype.copyMessage.call(
+      ctx, 'acct-1', 7, 'INBOX', 'Todo', {
+        operationKey: 'label-apply-1', snapshot: exactSourceSnapshot,
+      },
+    )).resolves.toBe(88);
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(execute.mock.calls[0][0].intent).toMatchObject({ kind: 'copy', accountId: 'acct-1' });
+  });
+
+  it('defers afterLabelCopy until the durable completion transaction has committed', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 'acct-1' }] });
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder, uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8', isPresent: true,
+    }));
+    const runHook = vi.spyOn(pluginRegistry, 'runHook').mockResolvedValue(undefined);
+    let spec;
+    const execute = vi.fn(async value => { spec = value; return { uid: 88 }; });
+
+    await ImapManager.prototype.copyMessage.call(
+      { providerOperationExecutor: { execute }, pluginFacade: {} },
+      'acct-1', 7, 'INBOX', 'Todo', {
+        operationKey: 'label-apply-post-commit', snapshot: exactSourceSnapshot,
+      },
+    );
+
+    await spec.complete({
+      uid: 88, uidValidity: '202', folder: 'Todo', marker: spec.intent.marker,
+      sourceToken: spec.intent.source, destinationToken: spec.intent.destination,
+    }, spec.intent, { query: vi.fn().mockResolvedValue({ rows: [{ id: 'copy-row', is_read: true }] }) });
+    expect(runHook).not.toHaveBeenCalled();
+    await spec.afterCommit(spec.intent.receipt || {
+      uid: 88, uidValidity: '202', folder: 'Todo', marker: spec.intent.marker,
+    });
+    expect(runHook).toHaveBeenCalledWith('afterLabelCopy', expect.objectContaining({ newUid: 88 }));
+    runHook.mockRestore();
+  });
+
+  it('fans bulk MOVE into independently durable causal operations', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      isPresent: true,
+    }));
+    const execute = vi.fn(async spec => ({
+      uid: spec.intent.source.uid + 80,
+      uidValidity: '202',
+      folder: 'Archive',
+    }));
+    const ctx = {
+      providerOperationExecutor: { execute },
+      moveMessage: ImapManager.prototype.moveMessage,
+    };
+
+    await expect(ImapManager.prototype.bulkMoveMessages.call(
+      ctx, { id: 'acct-1' }, [7, 8], 'INBOX', 'Archive', {
+        operationKey: 'bulk-archive-1', sourceSnapshots: sourceSnapshotMap(7, 8),
+      },
+    )).resolves.toEqual({
+      uidMap: new Map([[7, 87], [8, 88]]), succeeded: [7, 8], failed: [],
+    });
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('extends nested bulk MOVE ownership to its destination before fanning out operations', async () => {
+    const source = {
+      folder: 'INBOX', uidValidity: '101', generation: '4',
+      topologyIdentity: 'source-incarnation', isPresent: true,
+    };
+    const destination = {
+      folder: 'Archive', uidValidity: '202', generation: '9',
+      topologyIdentity: 'dest-incarnation', isPresent: true,
+    };
+    const observationContext = { accountId: 'acct-1', tokens: [source] };
+    claimFolderObservations.mockResolvedValueOnce([destination, source]);
+    const moveMessage = vi.fn().mockResolvedValue({
+      uid: 88, uidValidity: '202', folder: 'Archive',
+    });
+
+    await ImapManager.prototype.bulkMoveMessages.call(
+      { moveMessage }, { id: 'acct-1' }, [7], 'INBOX', 'Archive', {
+        operationKey: 'nested-bulk', observationContext,
+        sourceSnapshots: sourceSnapshotMap(7),
+      },
+    );
+
+    expect(claimFolderObservations).toHaveBeenCalledWith(
+      'acct-1', ['INBOX', 'Archive'], { context: [source] },
+    );
+    expect(observationContext.tokens).toEqual([destination, source]);
+    expect(moveMessage).toHaveBeenCalledWith(
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', expect.objectContaining({
+        operationTokens: [destination, source],
+      }),
+    );
+  });
+
+  it('reuses each exact source row snapshot through bulk MOVE provider validation', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      isPresent: true,
+    }));
+    const source = {
+      id: '11111111-1111-4111-8111-111111111111', accountId: 'acct-1', uid: 7,
+      folder: 'INBOX', uidValidity: '101', folderGeneration: '4',
+      readRevision: 1, starRevision: 2,
+    };
+    const moveMessage = vi.fn().mockResolvedValue({
+      uid: 87, uidValidity: '202', folder: 'Archive',
+    });
+
+    await ImapManager.prototype.bulkMoveMessages.call(
+      { moveMessage }, { id: 'acct-1' }, [7], 'INBOX', 'Archive', {
+        operationKey: 'bulk-move', operationKeys: new Map([[7, 'row-key']]),
+        sourceSnapshots: new Map([[7, source]]),
+      },
+    );
+
+    expect(moveMessage).toHaveBeenCalledWith(
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', expect.objectContaining({
+        operationKey: 'row-key', expectedUidValidity: '101', snapshot: source,
+      }),
+    );
+  });
+
+  it('forwards the exact source snapshot through the receipt MOVE helper', async () => {
+    const snapshot = {
+      id: '11111111-1111-4111-8111-111111111111', accountId: 'acct-1', uid: 7,
+      folder: 'INBOX', uidValidity: '101', folderGeneration: '4',
+      readRevision: 1, starRevision: 2,
+    };
+    const moveMessage = vi.fn().mockResolvedValue({ uid: 87, folder: 'Archive' });
+
+    await ImapManager.prototype.moveMessageWithReceipt.call(
+      { moveMessage }, { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        expectedUidValidity: '101', operationKey: 'archive:row-1', snapshot,
+      },
+    );
+
+    expect(moveMessage).toHaveBeenCalledWith(
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        expectedUidValidity: '101', observationContext: null,
+        operationKey: 'archive:row-1', materialize: null, snapshot, returnReceipt: true,
+      },
+    );
+  });
+
+  it('reuses the uncertain row operation when a bulk retry contains only the failed subset', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      isPresent: true,
+    }));
+    const idsForSeven = [];
+    const execute = vi.fn(async spec => {
+      if (spec.intent.source.uid === 7) {
+        idsForSeven.push(spec.intent.id);
+        if (idsForSeven.length === 1) throw new Error('uncertain');
+      }
+      return { uid: spec.intent.source.uid + 80, uidValidity: '202', folder: 'Archive' };
+    });
+    const ctx = {
+      providerOperationExecutor: { execute },
+      moveMessage: ImapManager.prototype.moveMessage,
+    };
+    const operationKeys = new Map([
+      [7, 'bulk-archive:request-1:row-7'],
+      [8, 'bulk-archive:request-1:row-8'],
+    ]);
+
+    await ImapManager.prototype.bulkMoveMessages.call(
+      ctx, { id: 'acct-1' }, [7, 8], 'INBOX', 'Archive', {
+        operationKey: 'batch:7,8', operationKeys, sourceSnapshots: sourceSnapshotMap(7, 8),
+      },
+    );
+    await ImapManager.prototype.bulkMoveMessages.call(
+      ctx, { id: 'acct-1' }, [7], 'INBOX', 'Archive', {
+        operationKey: 'batch:7', operationKeys, sourceSnapshots: sourceSnapshotMap(7),
+      },
+    );
+
+    expect(idsForSeven).toHaveLength(2);
+    expect(idsForSeven[1]).toBe(idsForSeven[0]);
+  });
+
+  it('fails a row closed when an exact bulk operation-key map omits its uid', async () => {
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '4' : '8',
+      isPresent: true,
+    }));
+    const moveMessage = vi.fn().mockResolvedValue({
+      uid: 87, uidValidity: '202', folder: 'Archive',
+    });
+    const ctx = { moveMessage };
+
+    await expect(ImapManager.prototype.bulkMoveMessages.call(
+      ctx, { id: 'acct-1' }, [7, 8], 'INBOX', 'Archive', {
+        operationKey: 'bulk-archive',
+        operationKeys: new Map([[7, 'exact-row-key-7']]),
+        sourceSnapshots: sourceSnapshotMap(7, 8),
+      },
+    )).resolves.toEqual({
+      uidMap: new Map([[7, 87]]), succeeded: [7], failed: [8],
+    });
+    expect(moveMessage).toHaveBeenCalledOnce();
+    expect(moveMessage).toHaveBeenCalledWith(
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', expect.objectContaining({
+        operationKey: 'exact-row-key-7',
+      }),
+    );
+  });
+
+  it('wakes a snooze by exact row and durable receipt without Message-ID selection', async () => {
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM snoozed_messages sm') && sql.includes('JOIN messages')) {
+        return { rows: [{
+          snooze_id: 'snooze-1', user_id: 'user-1', account_id: 'acct-1',
+          message_row_id: 'row-1', message_id_header: '<duplicate@x>',
+          original_folder: 'INBOX', snoozed_folder: 'Snoozed', uid: 7, is_read: true,
+          folder_uid_validity: '101', folder_observation_generation: '7',
+        }] };
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [{ id: 'acct-1' }] };
+      return { rows: [], rowCount: 1 };
+    });
+    const moveMessage = vi.fn().mockResolvedValue({
+      uid: 88, uidValidity: '202', folder: 'INBOX', destinationToken: { generation: '8' },
+    });
+    const ctx = {
+      moveMessage,
+      setDesiredFlag: vi.fn().mockResolvedValue({ delivery: { state: 'confirmed' } }),
+      _guardMoveUid: vi.fn(), _unguardMoveUid: vi.fn(), broadcast: vi.fn(),
+    };
+
+    await ImapManager.prototype._runSnoozeWakeup.call(ctx);
+
+    expect(moveMessage).toHaveBeenCalledWith(
+      { id: 'acct-1' }, 7, 'Snoozed', 'INBOX', expect.objectContaining({
+        operationKey: 'snooze-wakeup:snooze-1', returnReceipt: true,
+        snapshot: expect.objectContaining({ id: 'row-1', uidValidity: '101' }),
+        materialize: expect.any(Function),
+      }),
+    );
+    expect(ctx.setDesiredFlag).toHaveBeenCalledWith(
+      { id: 'acct-1' }, 'row-1', 'read', false,
+      expect.objectContaining({ snapshot: expect.objectContaining({ uid: 88, folder: 'INBOX' }) }),
+    );
+    expect(query.mock.calls.some(([sql]) => (
+      sql.includes('DELETE FROM snoozed_messages sm') && sql.includes('5 minutes')
+    ))).toBe(false);
+    const dueSql = query.mock.calls[0][0];
+    expect(dueSql).toMatch(/m\.metadata_complete\s*=\s*true/i);
+    expect(dueSql).toMatch(/JOIN folders live_folder[\s\S]*live_folder\.is_present\s*=\s*true/i);
+    expect(dueSql).toMatch(/live_folder\.uid_validity\s+IS\s+NOT\s+NULL/i);
+    expect(dueSql).toMatch(/sm\.resolution_state\s*=\s*'active'/i);
+  });
+
+  it('keeps the snooze and reports no wakeup when the exact message-row CAS updates zero rows', async () => {
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM snoozed_messages sm') && sql.includes('JOIN messages')) {
+        return { rows: [{
+          snooze_id: 'snooze-1', user_id: 'user-1', account_id: 'acct-1',
+          message_row_id: 'row-1', message_id_header: '<duplicate@x>',
+          original_folder: 'INBOX', snoozed_folder: 'Snoozed', uid: 7, is_read: true,
+          folder_uid_validity: '101', folder_observation_generation: '7',
+        }] };
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [{ id: 'acct-1' }] };
+      if (/DELETE FROM snoozed_messages/.test(sql)) return { rows: [], rowCount: 0 };
+      return { rows: [], rowCount: 1 };
+    });
+    const ctx = {
+      moveMessage: vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202', folder: 'INBOX', destinationToken: { generation: '8' } }),
+      setDesiredFlag: vi.fn().mockResolvedValue({ delivery: { state: 'confirmed' } }),
+      _guardMoveUid: vi.fn(), _unguardMoveUid: vi.fn(), broadcast: vi.fn(),
+    };
+
+    await ImapManager.prototype._runSnoozeWakeup.call(ctx);
+
+    expect(query.mock.calls.some(([sql]) => (
+      /^DELETE FROM snoozed_messages WHERE id/.test(sql)
+    ))).toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('5 minutes'))).toBe(false);
+    expect(ctx.broadcast).not.toHaveBeenCalled();
+  });
+
+  it('does not select a prior zero-CAS manual snooze on a later watcher run', async () => {
+    query.mockResolvedValue({ rows: [], rowCount: 0 });
+    const ctx = {
+      moveMessage: vi.fn(), setFlag: vi.fn(),
+      _guardMoveUid: vi.fn(), _unguardMoveUid: vi.fn(), broadcast: vi.fn(),
+    };
+
+    await ImapManager.prototype._runSnoozeWakeup.call(ctx);
+
+    expect(query.mock.calls[0][0]).toMatch(/sm\.resolution_state\s*=\s*'active'/i);
+    expect(query.mock.calls).toHaveLength(1);
+    expect(ctx.moveMessage).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a typed persistence failure when zero-CAS cannot retain the snooze', async () => {
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => {});
+    query.mockImplementation(async sql => {
+      if (sql.includes('FROM snoozed_messages sm') && sql.includes('JOIN messages')) {
+        return { rows: [{
+          snooze_id: 'snooze-vanished', user_id: 'user-1', account_id: 'acct-1',
+          message_row_id: 'row-1', message_id_header: '<gone@x>',
+          original_folder: 'INBOX', snoozed_folder: 'Snoozed', uid: 7, is_read: true,
+          folder_uid_validity: '101', folder_observation_generation: '7',
+        }] };
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) return { rows: [{ id: 'acct-1' }] };
+      if (/DELETE FROM snoozed_messages/.test(sql)) return { rows: [], rowCount: 0 };
+      return { rows: [], rowCount: 1 };
+    });
+    const ctx = {
+      moveMessage: vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202', folder: 'INBOX', destinationToken: { generation: '8' } }),
+      setDesiredFlag: vi.fn().mockResolvedValue({ delivery: { state: 'confirmed' } }),
+      _guardMoveUid: vi.fn(), _unguardMoveUid: vi.fn(), broadcast: vi.fn(),
+    };
+
+    await ImapManager.prototype._runSnoozeWakeup.call(ctx);
+
+    expect(errorLog.mock.calls.flat().join(' ')).toMatch(/SNOOZE_RESOLUTION_PERSISTENCE_FAILED/);
+    expect(query.mock.calls.some(([sql]) => /^DELETE FROM snoozed_messages/.test(sql))).toBe(true);
+    expect(ctx.broadcast).not.toHaveBeenCalled();
+    errorLog.mockRestore();
+  });
+
+  it('re-enters one MOVE operation across fresh manager/process observations', async () => {
+    readFolderObservation
+      .mockResolvedValueOnce({ folder: 'INBOX', uidValidity: '101', generation: '4', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Archive', uidValidity: '202', generation: '8', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'INBOX', uidValidity: '101', generation: '40', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Archive', uidValidity: '202', generation: '80', isPresent: true });
+    let operationId;
+    let providerCommands = 0;
+    const replayingExecutor = {
+      async execute(spec) {
+        if (operationId == null) {
+          operationId = spec.intent.id;
+          providerCommands++;
+          return { uid: 88, uidValidity: '202', folder: 'Archive' };
+        }
+        expect(spec.intent.id).toBe(operationId);
+        return { uid: 88, uidValidity: '202', folder: 'Archive' };
+      },
+    };
+
+    const firstManager = { providerOperationExecutor: replayingExecutor };
+    const restartedManager = { providerOperationExecutor: replayingExecutor };
+    await ImapManager.prototype.moveMessage.call(
+      firstManager, { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        returnReceipt: true, operationKey: 'archive-row-1', snapshot: exactSourceSnapshot,
+      },
+    );
+    await ImapManager.prototype.moveMessage.call(
+      restartedManager, { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        returnReceipt: true, operationKey: 'archive-row-1', snapshot: exactSourceSnapshot,
+      },
+    );
+
+    expect(providerCommands).toBe(1);
+    expect(claimFolderObservations).not.toHaveBeenCalled();
+  });
+
+  it('re-enters one APPEND operation across a fresh destination observation', async () => {
+    readFolderObservation
+      .mockResolvedValueOnce({ folder: 'Sent', uidValidity: '202', generation: '8', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Sent', uidValidity: '202', generation: '80', isPresent: true });
+    const ids = [];
+    const executor = { execute: vi.fn(async spec => {
+      ids.push(spec.intent.id);
+      return { uid: 88, uidValidity: '202', folder: 'Sent' };
+    }) };
+
+    await ImapManager.prototype.appendToFolder.call(
+      { providerOperationExecutor: executor }, { id: 'acct-1' }, 'Sent', Buffer.from('mime'),
+      ['\\Seen'], { operationKey: 'send-request-1' },
+    );
+    await ImapManager.prototype.appendToFolder.call(
+      { providerOperationExecutor: executor }, { id: 'acct-1' }, 'Sent', Buffer.from('mime'),
+      ['\\Seen'], { operationKey: 'send-request-1' },
+    );
+
+    expect(ids[1]).toBe(ids[0]);
+    expect(claimFolderObservation).not.toHaveBeenCalled();
+  });
+
+  it('re-enters one COPY operation across fresh manager/process observations', async () => {
+    query.mockResolvedValue({ rows: [{ id: 'acct-1' }] });
+    readFolderObservation
+      .mockResolvedValueOnce({ folder: 'INBOX', uidValidity: '101', generation: '4', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Todo', uidValidity: '202', generation: '8', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'INBOX', uidValidity: '101', generation: '40', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Todo', uidValidity: '202', generation: '80', isPresent: true });
+    let operationId;
+    let providerCommands = 0;
+    const replayingExecutor = {
+      async execute(spec) {
+        if (operationId == null) {
+          operationId = spec.intent.id;
+          providerCommands++;
+        } else {
+          expect(spec.intent.id).toBe(operationId);
+        }
+        return { uid: 88, uidValidity: '202', folder: 'Todo' };
+      },
+    };
+
+    await ImapManager.prototype.copyMessage.call(
+      { providerOperationExecutor: replayingExecutor, pluginFacade: {} },
+      'acct-1', 7, 'INBOX', 'Todo', {
+        operationKey: 'label-apply-1', snapshot: exactSourceSnapshot,
+      },
+    );
+    await ImapManager.prototype.copyMessage.call(
+      { providerOperationExecutor: replayingExecutor, pluginFacade: {} },
+      'acct-1', 7, 'INBOX', 'Todo', {
+        operationKey: 'label-apply-1', snapshot: exactSourceSnapshot,
+      },
+    );
+
+    expect(providerCommands).toBe(1);
+    expect(claimFolderObservations).not.toHaveBeenCalled();
+  });
+
+  it('returns the persisted MOVE observation tokens from marker crash recovery', async () => {
+    readFolderObservation
+      .mockResolvedValueOnce({ folder: 'INBOX', uidValidity: '101', generation: '4', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Archive', uidValidity: '202', generation: '8', isPresent: true });
+    let captured;
+    const execute = vi.fn(async spec => {
+      captured = spec;
+      return { uid: 88, uidValidity: '202', folder: 'Archive' };
+    });
+    await ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        returnReceipt: true, operationKey: 'archive-row-1', snapshot: exactSourceSnapshot,
+      },
+    );
+    query.mockResolvedValueOnce({ rows: [{ uid_validity: 202 }] });
+    const client = {
+      mailbox: { uidValidity: 202 },
+      search: vi.fn().mockResolvedValue([88]),
+      close: vi.fn(),
+    };
+
+    await expect(captured.recover(
+      { client, switchTo: vi.fn() }, captured.intent.marker, captured.intent,
+    )).resolves.toEqual({
+      status: 'unique', uid: 88, uidValidity: '202', folder: 'Archive',
+      sourceToken: captured.intent.source,
+      destinationToken: captured.intent.destination,
+      marker: captured.intent.marker,
+    });
+  });
+
+  it('uses persisted destination facts for APPEND validation after public re-entry', async () => {
+    readFolderObservation.mockResolvedValueOnce({
+      folder: 'Sent', uidValidity: '999', generation: '80', isPresent: true,
+    });
+    const persisted = {
+      destination: { folder: 'Sent', uidValidity: '202', generation: '8', isPresent: true },
+    };
+    const execute = vi.fn(async spec => {
+      await expect(spec.validate(
+        {
+          client: { mailbox: { permanentFlags: new Set(['\\*']), uidValidity: 202 } },
+          folder: 'Sent',
+        },
+        { query },
+        persisted,
+      )).resolves.toBeUndefined();
+      return { uid: 88, uidValidity: '202', folder: 'Sent' };
+    });
+
+    await ImapManager.prototype.appendToFolder.call(
+      { providerOperationExecutor: { execute } }, { id: 'acct-1' }, 'Sent', Buffer.from('mime'),
+      ['\\Seen'], { operationKey: 'send-request-1' },
+    );
+  });
+
+  it('rejects a live destination epoch mismatch before first MOVE command', async () => {
+    readFolderObservation
+      .mockResolvedValueOnce({ folder: 'INBOX', uidValidity: '101', generation: '4', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Archive', uidValidity: '202', generation: '8', isPresent: true });
+    const execute = vi.fn(async spec => {
+      const operation = spec.intent;
+      const tx = { query: vi.fn(async sql => ({
+        rows: sql.includes('jsonb_to_recordset') ? [{ id: exactSourceSnapshot.id }] : [],
+      })) };
+      await expect(spec.validate({
+        client: {
+          capabilities: new Set(['MOVE']),
+          mailbox: { permanentFlags: new Set(['\\*']), uidValidity: 101 },
+        },
+        uidValidities: new Map([['INBOX', '101'], ['Archive', '999']]),
+      }, tx, operation)).rejects.toThrow(/destination uidvalidity/i);
+      return { uid: 88, uidValidity: '202', folder: 'Archive' };
+    });
+
+    await ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        returnReceipt: true, operationKey: 'archive-row-1', snapshot: exactSourceSnapshot,
+      },
+    );
+  });
+
+  it('validates persisted destination generation and live epoch through MOVE recovery', async () => {
+    readFolderObservation
+      .mockResolvedValueOnce({ folder: 'INBOX', uidValidity: '101', generation: '40', isPresent: true })
+      .mockResolvedValueOnce({ folder: 'Archive', uidValidity: '999', generation: '80', isPresent: true });
+    const persisted = {
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+      destination: { folder: 'Archive', uidValidity: '202', generation: '8' },
+    };
+    const execute = vi.fn(async spec => {
+      await expect(spec.validateRecovery({
+        client: { mailbox: { uidValidity: 999 } },
+        uidValidities: new Map([['Archive', '999']]),
+      }, { query }, persisted)).rejects.toThrow(/destination uidvalidity/i);
+      return { uid: 88, uidValidity: '202', folder: 'Archive' };
+    });
+
+    await ImapManager.prototype.moveMessage.call(
+      { providerOperationExecutor: { execute } },
+      { id: 'acct-1' }, 7, 'INBOX', 'Archive', {
+        returnReceipt: true, operationKey: 'archive-row-1', snapshot: exactSourceSnapshot,
+      },
+    );
+    expect(assertFolderObservation).toHaveBeenCalledWith(
+      expect.anything(), 'acct-1', persisted.destination,
+    );
+  });
+});
 
 // ── providerProfile — host detection ─────────────────────────────────────────
 
@@ -289,12 +1410,16 @@ const countAdjusts = () => query.mock.calls.filter(([sql]) => sql.includes('UPDA
 
 describe('insertCopiedSibling', () => {
   beforeEach(() => query.mockReset());
+  const receipt = {
+    uid: 5001, marker: '$MailFlowOp-copy-row-1',
+    destinationToken: { folder: 'Todo', uidValidity: '202', generation: '8' },
+  };
 
   it('inserts the destination sibling from the source row with the copied UID', async () => {
     query.mockResolvedValueOnce({ rows: [{ id: 'row-new', is_read: true }] });
     query.mockResolvedValue({ rows: [] });
 
-    await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001);
+    await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001, { receipt });
 
     const ins = findCall('INSERT INTO messages');
     expect(ins).toBeTruthy();
@@ -303,15 +1428,18 @@ describe('insertCopiedSibling', () => {
     expect(ins[0]).toContain('WHERE account_id = $1 AND folder = $2 AND uid = $3');
     // Idempotent against the next destination-folder sync.
     expect(ins[0]).toContain('ON CONFLICT (account_id, uid, folder) DO NOTHING');
-    expect(ins[1]).toEqual(['acct-1', 'INBOX', 100, 5001, 'Todo']);
+    expect(ins[1]).toEqual([
+      'acct-1', 'INBOX', 100, 5001, 'Todo', receipt.marker,
+    ]);
     // delivery_addresses is copied verbatim from the source row, same as list_unsubscribe.
     expect(ins[0]).toContain('delivery_addresses');
+    expect(ins[0]).toMatch(/has_attachments, flags,\s+body_html[\s\S]*SELECT[\s\S]*has_attachments, COALESCE\(flags/);
   });
 
   it('increments destination unread only when the copied message is unread', async () => {
     query.mockResolvedValueOnce({ rows: [{ id: 'row-new', is_read: false }] });
     query.mockResolvedValue({ rows: [] });
-    await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001);
+    await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001, { receipt });
     // total +1, unread +1 for an unread copy.
     expect(countAdjusts()[0][1]).toEqual([1, 1, 'acct-1', 'Todo']);
   });
@@ -319,14 +1447,33 @@ describe('insertCopiedSibling', () => {
   it('counts total but not unread for a read copy', async () => {
     query.mockResolvedValueOnce({ rows: [{ id: 'row-new', is_read: true }] });
     query.mockResolvedValue({ rows: [] });
-    await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001);
+    await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001, { receipt });
     expect(countAdjusts()[0][1]).toEqual([1, 0, 'acct-1', 'Todo']);
   });
 
-  it('adjusts no counts when a prior sync already inserted the sibling (ON CONFLICT hit)', async () => {
+  it('fails closed when a conflicting destination row is not an exact live marker receipt', async () => {
     query.mockResolvedValueOnce({ rows: [] }); // DO NOTHING → no RETURNING row
-    await insertCopiedSibling('acct-1', 100, 'INBOX', 'Todo', 5001);
+    query.mockResolvedValueOnce({ rows: [] });
+    await expect(insertCopiedSibling(
+      'acct-1', 100, 'INBOX', 'Todo', 5001, { receipt },
+    )).rejects.toMatchObject({ code: 'COPY_DESTINATION_NOT_ACTIONABLE' });
     expect(countAdjusts()).toHaveLength(0);
+  });
+
+  it('accepts only an exact live marker-bearing conflict as idempotent completion', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    query.mockResolvedValueOnce({ rows: [{ id: 'row-synced' }] });
+
+    await expect(insertCopiedSibling(
+      'acct-1', 100, 'INBOX', 'Todo', 5001, { receipt },
+    )).resolves.toBe('row-synced');
+    const verify = query.mock.calls[1];
+    expect(verify[0]).toMatch(/m\.metadata_complete = true/);
+    expect(verify[0]).toMatch(/m\.is_deleted = false/);
+    expect(verify[0]).toMatch(/m\.flags @> jsonb_build_array/);
+    expect(verify[0]).toMatch(/f\.uid_validity = \$5/);
+    expect(verify[0]).toMatch(/f\.observation_generation = \$6/);
+    expect(verify[1]).toEqual(['acct-1', 5001, 'Todo', receipt.marker, '202', '8']);
   });
 });
 
@@ -336,6 +1483,7 @@ describe('deleteMessageCopyRow', () => {
   beforeEach(() => query.mockReset());
 
   it('deletes exactly one folder copy, scoped by (account_id, uid, folder)', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
     query.mockResolvedValueOnce({ rows: [{ is_read: true }] });
     query.mockResolvedValue({ rows: [] });
 
@@ -349,17 +1497,350 @@ describe('deleteMessageCopyRow', () => {
   });
 
   it('decrements the folder count, dropping unread only if the removed copy was unread', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
     query.mockResolvedValueOnce({ rows: [{ is_read: false }] });
     query.mockResolvedValue({ rows: [] });
     await deleteMessageCopyRow('acct-1', 100, 'Todo');
     expect(countAdjusts()[0][1]).toEqual([-1, -1, 'acct-1', 'Todo']);
   });
 
+  it('waits for the label-folder count write before confirming the row deletion', async () => {
+    let releaseCount;
+    query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ is_read: false }] })
+      .mockReturnValueOnce(new Promise(resolve => { releaseCount = resolve; }));
+    let settled = false;
+
+    const pending = deleteMessageCopyRow('acct-1', 100, 'Todo')
+      .then(result => { settled = true; return result; });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    releaseCount({ rows: [] });
+    await expect(pending).resolves.toBe(1);
+  });
+
   it('adjusts no counts when the row was already gone', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
     query.mockResolvedValueOnce({ rows: [] });
     await deleteMessageCopyRow('acct-1', 100, 'Todo');
     expect(countAdjusts()).toHaveLength(0);
   });
+
+  it('CAS-deletes the exact snapshot id when one is supplied', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    query.mockResolvedValueOnce({ rows: [{ is_read: true }] });
+    query.mockResolvedValue({ rows: [] });
+
+    await deleteMessageCopyRow('acct-1', 100, 'Todo', 'row-1');
+
+    const del = findCall('DELETE FROM messages');
+    expect(del[0]).toContain('id = $4');
+    expect(del[1]).toEqual(['acct-1', 100, 'Todo', 'row-1']);
+  });
+});
+
+describe('interrupted message-copy mutation recovery', () => {
+  beforeEach(() => query.mockReset());
+
+  const archiveRow = {
+    id: 'row-1', account_id: 'acct-1', uid: 7, folder: 'INBOX',
+    message_id: '<duplicate@x>', is_read: true, folder_uid_validity: 101,
+  };
+  const archiveReceipt = {
+    folder: 'Archive', uid: 88, uidValidity: '202',
+    sourceToken: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+    destinationToken: { folder: 'Archive', uidValidity: '202', generation: '8' },
+  };
+  const archiveOperationId = buildProviderOperationId({
+    kind: 'move', accountId: 'acct-1', requestKey: 'archive:row-1',
+    source: archiveReceipt.sourceToken, destinationFolder: 'Archive',
+  });
+  const exactArchiveOperation = state => ({
+    id: archiveOperationId,
+    kind: 'move',
+    accountId: 'acct-1',
+    marker: providerOperationMarker(archiveOperationId),
+    source: archiveReceipt.sourceToken,
+    destination: archiveReceipt.destinationToken,
+    state,
+    receipt: state === 'provider_started' ? null : {
+      ...archiveReceipt, marker: providerOperationMarker(archiveOperationId),
+    },
+  });
+
+  function archiveQueries({ coarseRows = [], allMail = false, confirmed = true } = {}) {
+    query.mockImplementation(async sql => {
+      if (typeof sql !== 'string') return { rows: [] };
+      if (sql.includes('no_select = false')) return { rows: [{ '?column?': 1 }] };
+      if (sql.includes("special_use = '\\All'")) {
+        return { rows: allMail ? [{ '?column?': 1 }] : [] };
+      }
+      if (sql.includes('FROM provider_operations')) return { rows: coarseRows };
+      if (sql.includes('JOIN folders live_folder')) {
+        return { rows: confirmed ? [{ id: 'row-1' }] : [] };
+      }
+      if (sql.includes('SELECT 1 FROM messages WHERE id')) {
+        return { rows: confirmed ? [{ '?column?': 1 }] : [] };
+      }
+      return { rows: [] };
+    });
+  }
+
+  it('never uses a duplicate Message-ID as causal evidence when no durable receipt exists', async () => {
+    const acct = { id: 'acct-1', folder_mappings: { archive: 'Archive' } };
+    const stale = {
+      id: 'row-1', account_id: 'acct-1', uid: 7, folder: 'INBOX',
+      message_id: '<duplicate@x>', is_read: true,
+    };
+    const ctx = {
+      findUidByMessageIdReceipt: vi.fn(),
+      findUidByRecoveryKeywordReceipt: vi.fn(),
+    };
+    query.mockImplementation(async sql => {
+      if (typeof sql !== 'string') return { rows: [] };
+      if (sql.includes("special_use = '\\All'")) return { rows: [] };
+      if (sql.includes('SELECT 1 FROM folders')) return { rows: [{ '?column?': 1 }] };
+      if (sql.includes('SELECT receipt')) return { rows: [] };
+      return { rows: [] };
+    });
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call(ctx, acct, stale))
+      .resolves.toEqual({ reconciled: false, changed: 0 });
+    expect(ctx.findUidByMessageIdReceipt).not.toHaveBeenCalled();
+    expect(ctx.findUidByRecoveryKeywordReceipt).not.toHaveBeenCalled();
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE messages SET folder'))).toBe(false);
+  });
+
+  it.each(['ordinary', 'bulk'])('ignores an unrelated %s MOVE with the same coarse tuple', async kind => {
+    const acct = { id: 'acct-1', folder_mappings: { archive: 'Archive' } };
+    archiveQueries({ coarseRows: [{ receipt: { ...archiveReceipt, marker: `$${kind}-move` } }] });
+    const completeExisting = vi.fn().mockResolvedValue({ status: 'missing' });
+    const ctx = {
+      providerOperationExecutor: { completeExisting },
+      moveMessage: vi.fn(), moveMessageWithReceipt: vi.fn(),
+    };
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call(ctx, acct, archiveRow))
+      .resolves.toEqual({ reconciled: false, changed: 0 });
+    expect(completeExisting).toHaveBeenCalledWith(archiveOperationId, expect.any(Object));
+    expect(query.mock.calls.some(([sql]) => sql.includes('FROM provider_operations'))).toBe(false);
+    expect(ctx.moveMessage).not.toHaveBeenCalled();
+    expect(ctx.moveMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  it('selects the exact archive operation when multiple coarse MOVE receipts exist', async () => {
+    const acct = { id: 'acct-1', folder_mappings: { archive: 'Archive' } };
+    archiveQueries({ coarseRows: [{ receipt: { uid: 40 } }, { receipt: archiveReceipt }] });
+    const operation = exactArchiveOperation('completed');
+    const completeExisting = vi.fn(async (operationId, spec) => {
+      expect(operationId).toBe(archiveOperationId);
+      await spec.validateExisting(operation);
+      return { status: 'completed', operation, receipt: operation.receipt, replayed: true };
+    });
+    const ctx = {
+      providerOperationExecutor: { completeExisting },
+      moveMessage: vi.fn(), moveMessageWithReceipt: vi.fn(),
+    };
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call(ctx, acct, archiveRow))
+      .resolves.toEqual({ reconciled: true, changed: 0 });
+    expect(query.mock.calls.some(([sql]) => sql.includes('FROM provider_operations'))).toBe(false);
+    expect(ctx.moveMessage).not.toHaveBeenCalled();
+    expect(ctx.moveMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  it('supplies a topology-safe fresh intent when completing an interrupted archive MOVE', async () => {
+    const acct = { id: 'acct-1', folder_mappings: { archive: 'Archive' } };
+    const recoverableRow = {
+      ...archiveRow,
+      folder_observation_generation: '4',
+      folder_topology_identity: 'source-incarnation',
+    };
+    archiveQueries();
+    readFolderObservation.mockImplementation(async (_accountId, folder) => ({
+      folder,
+      uidValidity: folder === 'INBOX' ? '101' : '202',
+      generation: folder === 'INBOX' ? '40' : '80',
+      topologyIdentity: folder === 'INBOX' ? 'source-incarnation' : 'dest-incarnation',
+      isPresent: true,
+    }));
+    const completeExisting = vi.fn(async (_operationId, spec) => {
+      expect(spec.intent).toMatchObject({
+        source: { generation: '40', topologyIdentity: 'source-incarnation' },
+        destination: { generation: '80', topologyIdentity: 'dest-incarnation' },
+      });
+      return { status: 'pending', operation: exactArchiveOperation('provider_started') };
+    });
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call({
+      providerOperationExecutor: { completeExisting },
+    }, acct, recoverableRow)).resolves.toEqual({ reconciled: false, changed: 0 });
+  });
+
+  it.each([
+    ['provider_started', false],
+    ['provider_applied', true],
+    ['completed', true],
+  ])('consumes only the exact archive %s state without provider work', async (state, reconciled) => {
+    const acct = { id: 'acct-1', folder_mappings: { archive: 'Archive' } };
+    archiveQueries();
+    const operation = exactArchiveOperation(state);
+    const completeExisting = vi.fn(async (operationId, spec) => {
+      expect(operationId).toBe(archiveOperationId);
+      await spec.validateExisting(operation);
+      if (state === 'provider_started') return { status: 'pending', operation };
+      return {
+        status: 'completed', operation, receipt: operation.receipt,
+        replayed: state === 'completed',
+      };
+    });
+    const ctx = {
+      providerOperationExecutor: { completeExisting },
+      moveMessage: vi.fn(), moveMessageWithReceipt: vi.fn(),
+    };
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call(ctx, acct, archiveRow))
+      .resolves.toEqual({ reconciled, changed: 0 });
+    expect(ctx.moveMessage).not.toHaveBeenCalled();
+    expect(ctx.moveMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['operation marker', operation => ({ ...operation, marker: '$wrong-marker' })],
+    ['source generation', operation => ({
+      ...operation, source: { ...operation.source, generation: null },
+    })],
+    ['destination generation', operation => ({
+      ...operation, destination: { ...operation.destination, generation: '999' },
+    })],
+    ['receipt source token', operation => ({
+      ...operation,
+      receipt: {
+        ...operation.receipt,
+        sourceToken: { ...operation.receipt.sourceToken, generation: '999' },
+      },
+    })],
+  ])('rejects a stored archive operation with mismatched exact %s', async (_field, mutate) => {
+    const acct = { id: 'acct-1', folder_mappings: { archive: 'Archive' } };
+    archiveQueries();
+    const operation = mutate(exactArchiveOperation('completed'));
+    const completeExisting = vi.fn(async (_operationId, spec) => {
+      await spec.validateExisting(operation);
+      return { status: 'completed', operation, receipt: operation.receipt, replayed: true };
+    });
+    const ctx = {
+      providerOperationExecutor: { completeExisting },
+      moveMessage: vi.fn(), moveMessageWithReceipt: vi.fn(),
+    };
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call(ctx, acct, archiveRow))
+      .rejects.toMatchObject({
+        code: 'PROVIDER_OPERATION_IDENTITY_MISMATCH', retryable: true, uncertain: true,
+      });
+    expect(ctx.moveMessage).not.toHaveBeenCalled();
+    expect(ctx.moveMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  it('idempotently confirms a completed All Mail archive without provider work', async () => {
+    const acct = { id: 'acct-1', folder_mappings: { archive: 'All Mail' } };
+    const allMailReceipt = {
+      ...archiveReceipt,
+      folder: 'All Mail',
+      destinationToken: { folder: 'All Mail', uidValidity: '202', generation: '8' },
+    };
+    const operationId = buildProviderOperationId({
+      kind: 'move', accountId: 'acct-1', requestKey: 'archive:row-1',
+      source: allMailReceipt.sourceToken, destinationFolder: 'All Mail',
+    });
+    const operation = {
+      ...exactArchiveOperation('completed'),
+      id: operationId,
+      marker: providerOperationMarker(operationId),
+      destination: allMailReceipt.destinationToken,
+      receipt: { ...allMailReceipt, marker: providerOperationMarker(operationId) },
+    };
+    archiveQueries({ allMail: true, confirmed: false });
+    const completeExisting = vi.fn(async (_operationId, spec) => {
+      await spec.validateExisting(operation);
+      return { status: 'completed', operation, receipt: operation.receipt, replayed: true };
+    });
+    const ctx = {
+      providerOperationExecutor: { completeExisting },
+      moveMessage: vi.fn(), moveMessageWithReceipt: vi.fn(),
+    };
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call(ctx, acct, archiveRow))
+      .resolves.toEqual({ reconciled: true, changed: 0 });
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call(ctx, acct, archiveRow))
+      .resolves.toEqual({ reconciled: true, changed: 0 });
+    expect(completeExisting).toHaveBeenCalledTimes(2);
+    expect(ctx.moveMessage).not.toHaveBeenCalled();
+    expect(ctx.moveMessageWithReceipt).not.toHaveBeenCalled();
+  });
+
+  it('keeps a concurrently relocated label copy retryable after a zero-row exact delete', async () => {
+    const acct = { id: 'acct-1' };
+    const stale = { id: 'row-1', account_id: 'acct-1', uid: 7, folder: 'Todo', message_id: '<m@x>', is_read: true };
+    query.mockImplementation(async (sql) => {
+      if (typeof sql !== 'string') return { rows: [] };
+      if (sql.includes('DELETE FROM messages')) return { rowCount: 0, rows: [] };
+      if (sql.includes('SELECT 1 FROM messages') && sql.includes('id = $1')) {
+        return { rows: [{ '?column?': 1 }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(ImapManager.prototype.reconcileMissingMessageCopy.call({}, acct, stale))
+      .resolves.toEqual({ reconciled: false, changed: 0 });
+  });
+
+  it('does not suppress a provider failure merely because old coordinates disappeared', async () => {
+    const acct = { id: 'acct-1' };
+    const ctx = { permanentDeleteMessage: vi.fn().mockRejectedValue(new Error('no matching message')) };
+    query
+      .mockResolvedValueOnce({ rows: [acct] })
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+      .mockResolvedValueOnce({ rows: [{ '?column?': 1 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(ImapManager.prototype.removeMessageCopy.call(
+      ctx, 'acct-1', 7, 'Todo', {
+        expectedId: 'row-1', notify: false,
+        snapshot: { ...sourceSnapshot(7, { folder: 'Todo' }), id: 'row-1' },
+      }
+    )).rejects.toThrow('no matching message');
+    expect(ctx.permanentDeleteMessage).toHaveBeenCalledOnce();
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('never suppresses a snapshot epoch change as a concurrent label delete', async () => {
+    const acct = { id: 'acct-1' };
+    const epochErr = Object.assign(new Error('Snapshot UIDVALIDITY changed'), {
+      code: 'SNAPSHOT_UIDVALIDITY_CHANGED',
+    });
+    const ctx = { permanentDeleteMessage: vi.fn().mockRejectedValue(epochErr) };
+    query
+      .mockResolvedValueOnce({ rows: [acct] })
+      .mockResolvedValue({ rows: [] });
+
+    await expect(ImapManager.prototype.removeMessageCopy.call(
+      ctx,
+      'acct-1',
+      7,
+      'Todo',
+      {
+        expectedId: 'row-1', notify: false, expectedUidValidity: 100,
+        snapshot: {
+          ...sourceSnapshot(7, { folder: 'Todo', uidValidity: '100' }), id: 'row-1',
+        },
+      },
+    )).rejects.toBe(epochErr);
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
 });
 
 
@@ -959,16 +2440,619 @@ describe('planModseqSync', () => {
   });
 });
 
+describe('_applyFlagUpdates — UIDVALIDITY fence', () => {
+  it('publishes a bulk pull through the per-row revisions captured before FETCH began', async () => {
+    const applyPull = vi.fn().mockResolvedValue(1);
+    const pullSnapshot = {
+      uidValidity: '100', folderGeneration: '9',
+      rows: [{ id: 'row-1', uid: 7, readRevision: 3, starRevision: 5 }],
+    };
+
+    await expect(ImapManager.prototype._applyFlagUpdates.call(
+      { _desiredFlagRepository: { applyPull } },
+      { id: 'acct-1' }, 'INBOX',
+      [{ uid: 7, isRead: true, isStarred: false, modseq: 51n }],
+      100, null, pullSnapshot,
+    )).resolves.toBe(1);
+
+    expect(applyPull).toHaveBeenCalledWith({
+      accountId: 'acct-1', folder: 'INBOX', uidValidity: '100', folderGeneration: '9',
+      rows: [{
+        id: 'row-1', uid: 7, readRevision: 3, starRevision: 5,
+        isRead: true, isStarred: false, modseq: '51',
+      }],
+    });
+  });
+
+  it('rejects stale flag data before it can mutate reused UIDs in a new epoch', async () => {
+    query.mockReset();
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 200 }] });
+      }
+      if (sql.includes('UPDATE messages SET')) return Promise.resolve({ rowCount: 1, rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    await expect(ImapManager.prototype._applyFlagUpdates.call(
+      {}, { id: 'acct-1' }, 'INBOX', [{ uid: 7, isRead: true, isStarred: false }], 100
+    )).rejects.toThrow(/UIDVALIDITY/i);
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE messages SET'))).toBe(false);
+  });
+});
+
+describe('_reconcileFolderDeletes — UIDVALIDITY fence', () => {
+  it('routes a missing source row through durable provider recovery instead of hard deletion', async () => {
+    query.mockReset();
+    const orphan = {
+      id: 'row-1', account_id: 'acct-1', uid: 2, folder: 'INBOX', is_read: false,
+      folder_uid_validity: '100', folder_observation_generation: '7',
+      folder_topology_identity: 'inbox-incarnation',
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('FROM messages m') && sql.includes('f.topology_identity')) {
+        return Promise.resolve({ rows: [orphan] });
+      }
+      if (sql.includes('DELETE FROM messages')) return Promise.resolve({ rowCount: 1, rows: [] });
+      if (sql.includes('uid_validity') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      }
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    const reconcileMissingMessageCopy = vi.fn().mockResolvedValue({ reconciled: true, changed: 1 });
+
+    const changed = await ImapManager.prototype._reconcileFolderDeletes.call(
+      { _isMoveUidGuarded: vi.fn().mockReturnValue(false), reconcileMissingMessageCopy },
+      { id: 'acct-1' }, 'INBOX', new Set([1]), 100,
+      new Date('2026-08-25T10:00:00Z'),
+    );
+
+    expect(changed).toBe(1);
+    expect(reconcileMissingMessageCopy).toHaveBeenCalledWith(
+      { id: 'acct-1' }, orphan, { deleteIfUncaused: true },
+    );
+    expect(query.mock.calls.some(([sql]) => sql.includes('DELETE FROM messages'))).toBe(false);
+  });
+
+  it('validates every folder in the authoritative reconcile context before deleting', async () => {
+    query.mockReset();
+    assertFolderObservation.mockClear();
+    query.mockImplementation((sql) => {
+      if (sql.includes('FROM messages m') && sql.includes('f.topology_identity')) {
+        return Promise.resolve({ rows: [{ uid: 2 }] });
+      }
+      if (sql.includes('DELETE FROM messages')) return Promise.resolve({ rowCount: 1, rows: [] });
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    const observationContext = {
+      accountId: 'acct-1',
+      tokens: [
+        { folder: 'Archive', uidValidity: '100', generation: '8' },
+        { folder: 'INBOX', uidValidity: '100', generation: '7' },
+      ],
+    };
+
+    const changed = await ImapManager.prototype._reconcileFolderDeletes.call(
+      {
+        _isMoveUidGuarded: vi.fn().mockReturnValue(false),
+        reconcileMissingMessageCopy: vi.fn().mockResolvedValue({ changed: 1 }),
+      },
+      { id: 'acct-1' }, 'INBOX', new Set([1]), 100,
+      new Date('2026-08-25T10:00:00Z'), observationContext
+    );
+
+    expect(changed).toBe(1);
+    expect(assertFolderObservation.mock.calls.map(([, , token]) => token.folder))
+      .toEqual(['Archive', 'INBOX', 'Archive', 'INBOX']);
+  });
+
+  it('skips destructive reconciliation when a pooled snapshot belongs to an old epoch', async () => {
+    query.mockReset();
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({ rows: [{ uid_validity: 200 }] });
+      }
+      if (sql.includes('DELETE FROM messages')) return Promise.resolve({ rowCount: 1, rows: [] });
+      return Promise.resolve({ rows: [] });
+    });
+
+    const changed = await ImapManager.prototype._reconcileFolderDeletes.call(
+      { _isMoveUidGuarded: vi.fn().mockReturnValue(false) },
+      { id: 'acct-1' }, 'INBOX', new Set([1]), 100, new Date('2026-08-25T10:00:00Z')
+    );
+
+    expect(changed).toBe(0);
+    expect(query.mock.calls.some(([sql]) => sql.includes('DELETE FROM messages'))).toBe(false);
+  });
+
+  it('keeps the server total authoritative and marks a hidden historical UID for backfill', async () => {
+    query.mockReset();
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      }
+      if (sql.includes('FROM messages m') && sql.includes('f.topology_identity')) {
+        return Promise.resolve({ rows: [{ uid: 1 }, { uid: 2 }, { uid: 4 }] });
+      }
+      if (sql.includes('DELETE FROM messages')) return Promise.resolve({ rowCount: 1, rows: [] });
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+
+    const changed = await ImapManager.prototype._reconcileFolderDeletes.call(
+      {
+        _isMoveUidGuarded: vi.fn().mockReturnValue(false),
+        reconcileMissingMessageCopy: vi.fn().mockImplementation(async (_account, row) => ({
+          changed: Number(row.uid) === 2 ? 1 : 0,
+        })),
+      },
+      { id: 'acct-1' }, 'INBOX', new Set([1, 3, 4]), 100, new Date('2026-08-25T10:00:00Z')
+    );
+
+    expect(changed).toBe(1);
+    const countWrite = query.mock.calls.find(([sql]) => sql.includes('UPDATE folders f'));
+    expect(countWrite[0]).toMatch(/total_count\s*= \$3/);
+    expect(countWrite[0]).toContain('backfill_incomplete');
+    expect(countWrite[1]).toEqual(['acct-1', 'INBOX', 3]);
+  });
+});
+
+describe('pool epoch eviction', () => {
+  it('synchronously closes active clients instead of queueing graceful logout', () => {
+    const clients = [
+      { close: vi.fn(), logout: vi.fn() },
+      { close: vi.fn(), logout: vi.fn() },
+    ];
+    abortPoolClients(clients);
+    for (const client of clients) {
+      expect(client.close).toHaveBeenCalledOnce();
+      expect(client.logout).not.toHaveBeenCalled();
+    }
+  });
+
+  it('rejects a pooled UID operation when selected and durable epochs differ', async () => {
+    query.mockReset().mockResolvedValueOnce({ rows: [{ uid_validity: 200 }] });
+    const client = { mailbox: { uidValidity: 100 }, close: vi.fn() };
+    const operation = vi.fn();
+
+    await expect(withUidEpochFence('acct-1', 'INBOX', client, operation))
+      .rejects.toThrow(/UIDVALIDITY/i);
+
+    expect(operation).not.toHaveBeenCalled();
+    expect(client.close).toHaveBeenCalled();
+    expect(query.mock.calls[0][0]).toMatch(/FOR SHARE/);
+  });
+
+  it('holds a shared folder-epoch lock through the pooled UID operation', async () => {
+    query.mockReset().mockResolvedValueOnce({ rows: [{ uid_validity: 200 }] });
+    const client = { mailbox: { uidValidity: 200 }, close: vi.fn() };
+    const operation = vi.fn().mockResolvedValue('ok');
+
+    await expect(withUidEpochFence('acct-1', 'INBOX', client, operation)).resolves.toBe('ok');
+
+    expect(operation).toHaveBeenCalledOnce();
+    expect(withTransaction).toHaveBeenCalled();
+    expect(client.close).not.toHaveBeenCalled();
+  });
+
+  it('rejects a UID operation when its authorized snapshot belongs to an older epoch', async () => {
+    query.mockReset().mockResolvedValueOnce({ rows: [{ uid_validity: 200 }] });
+    const client = { mailbox: { uidValidity: 200 }, close: vi.fn() };
+    const operation = vi.fn();
+
+    await expect(withUidEpochFence('acct-1', 'INBOX', client, operation, 100))
+      .rejects.toThrow(/snapshot.*UIDVALIDITY/i);
+
+    expect(operation).not.toHaveBeenCalled();
+    expect(client.close).toHaveBeenCalled();
+  });
+
+  it('rejects a provider read when its exact message row relocated after authorization', async () => {
+    query.mockReset()
+      .mockResolvedValueOnce({ rows: [{ uid_validity: 200 }] })
+      .mockResolvedValueOnce({ rows: [] });
+    const client = { mailbox: { uidValidity: 200 }, close: vi.fn() };
+    const operation = vi.fn();
+    const snapshot = {
+      id: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+      uidValidity: '200', folderGeneration: '9', readRevision: 2, starRevision: 3,
+    };
+
+    await expect(withUidEpochFence(
+      'acct-1', 'INBOX', client, operation, 200, null, [snapshot]
+    )).rejects.toMatchObject({ code: 'MESSAGE_SNAPSHOT_SUPERSEDED' });
+
+    expect(operation).not.toHaveBeenCalled();
+    expect(query.mock.calls[1][0]).toMatch(/FOR SHARE OF f, m/);
+  });
+
+  it('discards a whole snippet batch before FETCH/publication when one captured row relocates', async () => {
+    query.mockReset()
+      .mockResolvedValueOnce({ rows: [{ uid_validity: 200 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'row-1' }] });
+    const client = { mailbox: { uidValidity: 200 }, close: vi.fn(), fetch: vi.fn() };
+    const publishSnippetBatch = vi.fn(async tx => {
+      await tx.query('UPDATE messages SET snippet = $1 WHERE id = $2', ['wrong', 'row-1']);
+    });
+    const snapshots = [
+      { id: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+        uidValidity: '200', folderGeneration: '9', readRevision: 2, starRevision: 3 },
+      { id: 'row-2', accountId: 'acct-1', uid: 8, folder: 'INBOX',
+        uidValidity: '200', folderGeneration: '9', readRevision: 0, starRevision: 0 },
+    ];
+
+    await expect(withUidEpochFence(
+      'acct-1', 'INBOX', client, publishSnippetBatch, 200, null, snapshots,
+    )).rejects.toMatchObject({ code: 'MESSAGE_SNAPSHOT_SUPERSEDED' });
+
+    expect(publishSnippetBatch).not.toHaveBeenCalled();
+    expect(client.fetch).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks overflow clients so epoch eviction aborts their in-flight commands too', () => {
+    const pooled = { close: vi.fn(), logout: vi.fn() };
+    const overflow = { close: vi.fn(), logout: vi.fn() };
+    const pool = {
+      clients: [pooled], inUse: new Set([pooled]), waiters: [],
+      temporaryClients: new Set(), evicted: false,
+    };
+
+    expect(registerTemporaryPoolClient(pool, overflow)).toBe(true);
+    abortConnectionPool(pool);
+
+    expect(pooled.close).toHaveBeenCalledOnce();
+    expect(overflow.close).toHaveBeenCalledOnce();
+  });
+
+  it('aborts a temporary client whose connection finishes after eviction', () => {
+    const pool = {
+      clients: [], inUse: new Set(), waiters: [],
+      temporaryClients: new Set(), evicted: true,
+    };
+    const late = { close: vi.fn(), logout: vi.fn() };
+
+    expect(registerTemporaryPoolClient(pool, late)).toBe(false);
+    expect(late.close).toHaveBeenCalledOnce();
+    expect(pool.temporaryClients).not.toContain(late);
+  });
+});
+
 // ── syncMessages — empty-cache/modseq wiring ─────────────────────────────────
 
 describe('syncMessages — empty local cache vs nonempty server (wiring)', () => {
+  const parsedFetch = uid => ({
+    uid,
+    messageId: null,
+    subject: 'Valid message',
+    fromName: 'External',
+    fromEmail: 'them@example.com',
+    to: [],
+    cc: [],
+    replyTo: [],
+    inReplyTo: null,
+    references: null,
+    date: new Date('2026-08-25T10:00:00Z'),
+    snippet: 'hi',
+    isRead: true,
+    isStarred: false,
+    hasAttachments: false,
+    flags: ['\\Seen'],
+    isBulk: false,
+    parsedHeaders: {},
+  });
+
+  const stubSyncQueries = ({ maxUid, storedModseq = '500' }) => {
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: storedModseq }] });
+      }
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false)')) return Promise.resolve({ rows: [{ n: 0 }] });
+      if (sql.includes('COALESCE(MAX(uid), 0)')) return Promise.resolve({ rows: [{ max_uid: maxUid }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'new-message', is_new: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+  };
+
   beforeEach(() => {
     query.mockReset();
     parseMessage.mockReset();
     ['acct-sync-empty-cache', 'acct-sync-watermark'].forEach(invalidateGtdConfigCache);
   });
 
-  it('empty cache forces the full metadata scan', async () => {
+  it('restarts a superseded sync once with a fresh SELECT and recomputed UID search', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const makeClient = uid => ({
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: uid, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue([uid]),
+      fetch: vi.fn(async function* () {
+        yield { uid, envelope: { subject: `Message ${uid}` }, flags: new Set() };
+      }),
+      close: vi.fn(),
+    });
+    const staleClient = makeClient(51);
+    const freshClient = makeClient(52);
+    const originalClaim = claimFolderObservation.getMockImplementation();
+    const originalAssert = assertFolderObservation.getMockImplementation();
+    let assertionCount = 0;
+    claimFolderObservation
+      .mockResolvedValueOnce({ folder: 'Watch', uidValidity: '100', generation: '1' })
+      .mockResolvedValueOnce({ folder: 'Watch', uidValidity: '100', generation: '2' });
+    assertFolderObservation.mockImplementation(async () => {
+      assertionCount++;
+      if (assertionCount === 2) {
+        const err = new Error('newer observation won');
+        err.code = 'FOLDER_OBSERVATION_SUPERSEDED';
+        throw err;
+      }
+      return { uid_validity: 100, highest_modseq: '500' };
+    });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: '500' }] });
+      }
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false)') && !sql.includes('UPDATE folders')) {
+        return Promise.resolve({ rows: [{ n: 0 }] });
+      }
+      if (sql.includes('COALESCE(MAX(uid), 0)')) return Promise.resolve({ rows: [{ max_uid: 50 }] });
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'fresh-52', is_new: true }] });
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const ctx = {
+      pluginFacade: {},
+      _withFreshSyncSession: vi.fn((_account, callback) => callback(freshClient)),
+    };
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        ctx, account, staleClient, 'Watch', 20, false, true
+      );
+
+      expect(staleClient.search).toHaveBeenCalledWith({ uid: '51:*' }, { uid: true });
+      expect(freshClient.getMailboxLock).toHaveBeenCalledWith('Watch');
+      expect(freshClient.search).toHaveBeenCalledWith({ uid: '51:*' }, { uid: true });
+      expect(claimFolderObservation.mock.calls.map(([, folder]) => folder)).toEqual(['Watch', 'Watch']);
+      expect(query.mock.calls.filter(([sql]) => sql.includes('INSERT INTO messages')))
+        .toHaveLength(1);
+      expect(result).toEqual(expect.objectContaining({ insertedCount: 1 }));
+      expect(staleClient.close).toHaveBeenCalledOnce();
+    } finally {
+      error.mockRestore();
+      claimFolderObservation.mockReset().mockImplementation(originalClaim);
+      assertFolderObservation.mockReset().mockImplementation(originalAssert);
+    }
+  });
+
+  it('purges stale rows when an empty mailbox has a new UIDVALIDITY epoch', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 0, uidValidity: 200, highestModseq: null },
+      status: vi.fn().mockResolvedValue({ uidValidity: 200 }),
+      fetch: vi.fn(async function* () {}),
+    };
+    let storedValidity = 100;
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: storedValidity, highest_modseq: '500' }] });
+      }
+      if (sql.includes('SELECT uid_validity FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: storedValidity }] });
+      }
+      if (sql.includes('SET uid_validity = $1, highest_modseq = NULL')) {
+        storedValidity = 200;
+        return Promise.resolve({ rowCount: 1, rows: [] });
+      }
+      if (sql.includes('DELETE FROM messages')) return Promise.resolve({ rowCount: 3, rows: [] });
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    const ctx = {
+      pluginFacade: {},
+      _bgConnSem: { acquire: vi.fn(), release: vi.fn() },
+      backfillMessages: vi.fn(),
+      _evictPool: vi.fn(),
+    };
+
+    const result = await ImapManager.prototype.syncMessages.call(
+      ctx, account, client, 'Watch', 50, false, true
+    );
+
+    const epochWrite = query.mock.calls.find(([sql]) =>
+      sql.includes('SET uid_validity = $1, highest_modseq = NULL, backfill_incomplete = true'));
+    const purge = query.mock.calls.find(([sql]) => sql.includes('DELETE FROM messages'));
+    const emptyReconcile = query.mock.calls.find(([sql]) =>
+      sql.includes('UPDATE folders f') && sql.includes('stats.complete_count'));
+    expect(epochWrite).toBeTruthy();
+    expect(purge).toBeTruthy();
+    expect(query.mock.calls.indexOf(epochWrite)).toBeLessThan(query.mock.calls.indexOf(purge));
+    expect(emptyReconcile).toBeTruthy();
+    expect(client.fetch).not.toHaveBeenCalled();
+    expect(ctx.backfillMessages).not.toHaveBeenCalled();
+    expect(ctx._evictPool).toHaveBeenCalledWith(account.id);
+    expect(result).toEqual({ insertedCount: 0, broadcastedNewMessages: false });
+  });
+
+  it('does not delete a current-epoch row synced after an older empty mailbox snapshot', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 0, uidValidity: 100, highestModseq: null },
+      fetch: vi.fn(async function* () {}),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: null }] });
+      }
+      if (sql.includes('SELECT uid_validity FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      }
+      if (sql.includes('DELETE FROM messages')) return Promise.resolve({ rowCount: 0, rows: [] });
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+
+    await ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'INBOX', 50, false, true
+    );
+
+    const deletion = query.mock.calls.find(([sql]) => sql.includes('DELETE FROM messages'));
+    expect(deletion[0]).toMatch(/synced_at.*< \$3/s);
+    expect(deletion[1][2]).toBeInstanceOf(Date);
+    const countWrite = query.mock.calls.find(([sql]) => sql.includes('UPDATE folders f'));
+    expect(countWrite?.[0]).toContain('backfill_incomplete');
+    expect(countWrite?.[0]).not.toMatch(/total_count\s*=\s*0/);
+  });
+
+  it('evicts this process pool when another process already committed the observed epoch', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 0, uidValidity: 200, highestModseq: null },
+      status: vi.fn().mockResolvedValue({ uidValidity: 200 }),
+      fetch: vi.fn(async function* () {}),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders') && sql.includes('FOR UPDATE')) {
+        return Promise.resolve({ rows: [{ uid_validity: 200, highest_modseq: null }] });
+      }
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: '500' }] });
+      }
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    const ctx = {
+      pluginFacade: {},
+      _bgConnSem: { acquire: vi.fn(), release: vi.fn() },
+      backfillMessages: vi.fn(),
+      _evictPool: vi.fn(),
+    };
+
+    await ImapManager.prototype.syncMessages.call(ctx, account, client, 'Watch', 50, false, true);
+
+    expect(ctx._evictPool).toHaveBeenCalledWith(account.id);
+  });
+
+  it('evicts an old local pool generation when durable and selected epochs already match', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 0, uidValidity: 200, highestModseq: null },
+      fetch: vi.fn(async function* () {}),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 200, highest_modseq: null }] });
+      }
+      if (sql.includes('SELECT uid_validity FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 200 }] });
+      }
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    const ctx = {
+      pluginFacade: {},
+      _observedSyncEpochs: new Map([[`${account.id}:INBOX`, 100]]),
+      _observeSyncEpoch: ImapManager.prototype._observeSyncEpoch,
+      _evictPool: vi.fn(),
+    };
+
+    await ImapManager.prototype.syncMessages.call(ctx, account, client, 'INBOX', 50, false, true);
+
+    expect(ctx._evictPool).toHaveBeenCalledWith(account.id);
+    expect(ctx._observedSyncEpochs.get(`${account.id}:INBOX`)).toBe(200);
+  });
+
+  it('does not rewind a newer durable epoch from a stale selected client', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 1, uidValidity: 100, highestModseq: null },
+      status: vi.fn().mockResolvedValue({ uidValidity: 200 }),
+      fetch: vi.fn(async function* () {}),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 200, highest_modseq: null }] });
+      }
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    const ctx = {
+      pluginFacade: {},
+      _bgConnSem: { acquire: vi.fn(), release: vi.fn() },
+      backfillMessages: vi.fn(),
+    };
+
+    await expect(ImapManager.prototype.syncMessages.call(
+      ctx, account, client, 'Watch', 50, false, true
+    )).rejects.toThrow(/UIDVALIDITY/i);
+
+    expect(client.status).toHaveBeenCalledWith('Watch', { uidValidity: true });
+    expect(query.mock.calls.some(([sql, params]) =>
+      sql.includes('SET uid_validity = $1') && params?.[0] === 100)).toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('DELETE FROM messages'))).toBe(false);
+  });
+
+  it('does not insert old-epoch metadata when another sync transitions after the initial read', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    let durableValidity = 100;
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 1, uidValidity: 100, highestModseq: null },
+      fetch: vi.fn(async function* () { yield { uid: 501, envelope: { subject: 'Old epoch' } }; }),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: durableValidity, highest_modseq: null }] });
+      }
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false)') && !sql.includes('UPDATE folders')) {
+        return Promise.resolve({ rows: [{ n: 0 }] });
+      }
+      if (sql.includes('UPDATE folders') && sql.includes('SET total_count = $3')) {
+        durableValidity = 200; // concurrent connection publishes the new epoch here
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('COALESCE(MAX(uid), 0)')) return Promise.resolve({ rows: [{ max_uid: 0 }] });
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'stale', is_new: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockResolvedValue({
+      uid: 501, messageId: '<old@example.com>', subject: 'Old epoch',
+      fromName: 'Sender', fromEmail: 'sender@example.com', to: [], cc: [], replyTo: [],
+      inReplyTo: null, references: null, date: new Date('2026-08-25T10:00:00Z'),
+      snippet: '', isRead: true, isStarred: false, hasAttachments: false, flags: [],
+      isBulk: false, parsedHeaders: {},
+    });
+
+    await expect(ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'Watch', 50, false, true, 0
+    )).rejects.toThrow(/UIDVALIDITY/i);
+    expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+  });
+
+  it('empty cache forces the full metadata scan and accepts an envelope without Message-ID', async () => {
     const account = {
       id: 'acct-sync-empty-cache',
       user_id: 'user-1',
@@ -980,7 +3064,7 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
     const client = {
       getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
       mailbox: { exists: 1, uidValidity: 100, highestModseq: 500n },
-      fetch: vi.fn(async function* () { yield { uid: 501 }; }),
+      fetch: vi.fn(async function* () { yield { uid: 501, envelope: { subject: 'Watch first message' } }; }),
     };
     query.mockImplementation((sql) => {
       if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
@@ -1022,7 +3106,7 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
     const result = await ImapManager.prototype.syncMessages.call({}, account, client, 'Watch', 50, false, true);
 
     expect(client.fetch).toHaveBeenCalledTimes(1);
-    expect(client.fetch.mock.calls[0][0]).toBe('1:*');
+    expect(client.fetch.mock.calls[0][0]).toBe('1:1');
     expect(client.fetch.mock.calls[0][1]).toEqual(expect.objectContaining({
       envelope: true,
       bodyStructure: true,
@@ -1037,7 +3121,7 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
     expect(result).toEqual(expect.objectContaining({ insertedCount: 1 }));
   });
 
-  it('populated cache keeps the old UID-watermark behavior', async () => {
+  it('skips the UID fetch when SEARCH finds no UID above the watermark', async () => {
     const account = {
       id: 'acct-sync-watermark',
       user_id: 'user-1',
@@ -1048,7 +3132,8 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
     };
     const client = {
       getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
-      mailbox: { exists: 50, uidValidity: 100, highestModseq: 500n },
+      mailbox: { exists: 50, uidNext: 51, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue([]),
       fetch: vi.fn(async function* () {}),
     };
     query.mockImplementation((sql) => {
@@ -1067,13 +3152,716 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
 
     await ImapManager.prototype.syncMessages.call({}, account, client, 'Watch', 50, false, true);
 
-    expect(client.fetch).toHaveBeenCalledTimes(1);
-    expect(client.fetch).toHaveBeenCalledWith(
-      '51:*',
-      expect.objectContaining({ envelope: true, bodyStructure: true }),
-      { uid: true }
-    );
+    expect(client.search).toHaveBeenCalledWith({ uid: '51:*' }, { uid: true });
+    expect(client.fetch).not.toHaveBeenCalled();
     expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+  });
+
+  it('defers later phases when the primary UID SEARCH fails', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 600, uidValidity: 100, highestModseq: 501n },
+      search: vi.fn().mockResolvedValue(false),
+      fetch: vi.fn(async function* () {
+        yield { uid: 600, envelope: { subject: 'Later message' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500, storedModseq: null });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(client.fetch).not.toHaveBeenCalled();
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not issue a reversed UID range after expunge moves the mailbox below the watermark', async () => {
+    const account = {
+      id: 'acct-sync-watermark',
+      user_id: 'user-1',
+      email_address: 'me@example.com',
+      gtd_enabled: false,
+      categorization_enabled: false,
+      imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 40, uidNext: 501, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue([498, 500]),
+      fetch: vi.fn(async function* () {}),
+    };
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: '500' }] });
+      }
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false)')) return Promise.resolve({ rows: [{ n: 0 }] });
+      if (sql.includes('COALESCE(MAX(uid), 0)')) return Promise.resolve({ rows: [{ max_uid: 500 }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'ghost', is_new: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockImplementation(async msg => ({
+      uid: msg.uid,
+      messageId: null,
+      subject: '(no subject)',
+      fromName: '',
+      fromEmail: '',
+      to: [],
+      cc: [],
+      replyTo: [],
+      inReplyTo: null,
+      references: null,
+      date: new Date(),
+      snippet: '',
+      isRead: true,
+      isStarred: false,
+      hasAttachments: false,
+      flags: [],
+      isBulk: false,
+      parsedHeaders: {},
+    }));
+
+    const result = await ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+    );
+
+    expect(client.fetch).not.toHaveBeenCalled();
+    expect(client.search).toHaveBeenCalledWith({ uid: '501:*' }, { uid: true });
+    expect(parseMessage).not.toHaveBeenCalled();
+    expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+    expect(result.insertedCount).toBe(0);
+  });
+
+  it('does not let later UIDs leapfrog incomplete metadata', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    let fetchRound = 0;
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 502, uidNext: 504, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue([501, 502, 503]),
+      fetch: vi.fn(async function* () {
+        fetchRound++;
+        if (fetchRound === 1) {
+          yield { uid: 501 };
+          yield { uid: 502, envelope: {}, flags: new Set() };
+          yield { uid: 503, envelope: { subject: 'secret-subject' }, flags: new Set() };
+          return;
+        }
+        yield { uid: 501, envelope: { subject: 'first' }, flags: new Set() };
+        yield { uid: 502, envelope: { subject: 'second' }, flags: new Set() };
+        yield { uid: 503, envelope: { subject: 'third' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const first = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(first.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(client.fetch.mock.calls[0][0]).toBe('501,502,503');
+      const warning = warn.mock.calls[0].join(' ');
+      expect(warning).not.toMatch(/501|502|503|secret-subject|them@example\.com/);
+
+      parseMessage.mockClear();
+      query.mockClear();
+      const second = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(parseMessage).toHaveBeenCalledTimes(3);
+      expect(query.mock.calls.filter(([sql]) => sql.includes('INSERT INTO messages'))).toHaveLength(3);
+      expect(second.insertedCount).toBe(3);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not let a later UID leapfrog when parsing or persistence fails', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 502, uidNext: 503, uidValidity: 100, highestModseq: 501n },
+      search: vi.fn().mockResolvedValue([501, 502]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 501, envelope: { subject: 'First' }, flags: new Set() };
+        yield { uid: 502, envelope: { subject: 'Second' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500, storedModseq: '500' });
+    parseMessage.mockImplementation(async msg => {
+      if (msg.uid === 501) throw new Error('parser failed');
+      return parsedFetch(msg.uid);
+    });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(parseMessage.mock.calls.map(([msg]) => msg.uid)).toEqual([501]);
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      error.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
+  it('accepts an explicitly returned all-NIL envelope', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 501, uidNext: 502, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue([501]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 501, envelope: {}, internalDate: new Date('2026-08-25T10:00:00Z') };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(parseMessage).toHaveBeenCalledOnce();
+      expect(query.mock.calls.filter(([sql]) => sql.includes('INSERT INTO messages'))).toHaveLength(1);
+      expect(result.insertedCount).toBe(1);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('processes a large new-mail range in bounded metadata batches', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    let yielded = 0;
+    let yieldedAtFirstParse = null;
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 705, uidNext: 706, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue(Array.from({ length: 205 }, (_, index) => index + 501)),
+      fetch: vi.fn(async function* (uidSet) {
+        for (const uid of uidSet.split(',').map(Number)) {
+          yielded++;
+          yield { uid, envelope: { subject: `Message ${uid}` }, flags: new Set() };
+        }
+      }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => {
+      if (yieldedAtFirstParse === null) yieldedAtFirstParse = yielded;
+      return parsedFetch(msg.uid);
+    });
+
+    const result = await ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+    );
+
+    expect(client.fetch.mock.calls.map(([uidSet]) => uidSet.split(',').map(Number))).toEqual([
+      Array.from({ length: 100 }, (_, index) => index + 501),
+      Array.from({ length: 100 }, (_, index) => index + 601),
+      Array.from({ length: 5 }, (_, index) => index + 701),
+    ]);
+    expect(yieldedAtFirstParse).toBe(100);
+    expect(parseMessage).toHaveBeenCalledTimes(205);
+    expect(result.insertedCount).toBe(205);
+  });
+
+  it('persists a growing live EXISTS count after bounded initial sync so backfill runs the exact UID diff', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+      imap_port: 993, imap_tls: true, auth_user: 'me@example.com', auth_pass: 'encrypted',
+    };
+    const localUids = new Set();
+    let folderTotal = 0;
+    let backfillIncomplete = false;
+    const syncClient = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 20, uidValidity: 100, highestModseq: 500n },
+      fetch: vi.fn(async function* () {
+        for (let uid = 2; uid <= 21; uid++) {
+          yield { uid, envelope: { subject: `Message ${uid}` }, flags: new Set() };
+        }
+      }),
+    };
+    const exactDiffReached = new Error('exact UID diff reached');
+    const backfillClient = {
+      mailbox: { exists: 21, uidValidity: 100 },
+      on: vi.fn(),
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      search: vi.fn().mockRejectedValue(exactDiffReached),
+    };
+    ImapFlow.mockImplementation(function () { return backfillClient; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql, params = []) => {
+      if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: '500' }] });
+      }
+      if (sql.includes('COUNT(*) FILTER (WHERE is_read = false) AS n')) {
+        return Promise.resolve({ rows: [{ n: 0 }] });
+      }
+      if (sql.includes('UPDATE folders') && sql.includes('SET total_count = $3')) {
+        folderTotal = Number(params[2]);
+        syncClient.mailbox.exists = 21;
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('COALESCE(MAX(uid), 0) as max_uid')) {
+        return Promise.resolve({ rows: [{ max_uid: 0 }] });
+      }
+      if (sql.includes('INSERT INTO messages')) {
+        localUids.add(Number(params[1]));
+        return Promise.resolve({ rows: [{ id: `row-${params[1]}`, is_new: true }] });
+      }
+      if (sql.includes('UPDATE folders') && sql.includes('SET total_count = (SELECT COUNT(*)')) {
+        folderTotal = localUids.size;
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('UPDATE folders') && sql.includes('SET total_count = $3')) {
+        folderTotal = Number(params[2]);
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('SELECT uid_validity, total_count, backfill_incomplete FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: folderTotal, backfill_incomplete: backfillIncomplete }] });
+      }
+      if (sql.includes('SELECT COUNT(*) AS n FROM messages')) {
+        return Promise.resolve({ rows: [{ n: localUids.size }] });
+      }
+      if (sql.includes('UPDATE folders SET backfill_incomplete = true')) {
+        backfillIncomplete = true;
+        return Promise.resolve({ rows: [] });
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) {
+        return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      }
+      if (sql.includes('SELECT gtd_enabled, gtd_folders FROM email_accounts')) {
+        return Promise.resolve({ rows: [{ gtd_enabled: false, gtd_folders: {} }] });
+      }
+      if (sql.includes("preferences->>'categorizationEnabled'")) {
+        return Promise.resolve({ rows: [{ val: false }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(ImapManager.prototype.syncMessages.call(
+        ctx, account, syncClient, 'INBOX', 20, false, true
+      )).resolves.toMatchObject({ insertedCount: 20 });
+      expect(localUids.size).toBe(20);
+
+      await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX'))
+        .resolves.toBe(false);
+      expect(syncClient.fetch).toHaveBeenCalledWith('2:21', expect.any(Object));
+      expect(folderTotal).toBe(21);
+      expect(backfillClient.search).toHaveBeenCalledWith({ all: true }, { uid: true });
+    } finally {
+      log.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it('fetches sparse UIDs by candidate count rather than numeric distance', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 501, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue([1_000_000]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 1_000_000, envelope: { subject: 'Sparse message' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+
+    const result = await ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+    );
+
+    expect(client.search).toHaveBeenCalledWith({ uid: '501:*' }, { uid: true });
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+    expect(client.fetch.mock.calls[0][0]).toBe('1000000');
+    expect(parseMessage).toHaveBeenCalledOnce();
+    expect(result.insertedCount).toBe(1);
+  });
+
+  it('defers a UID batch when FETCH omits a SEARCH candidate', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 502, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn()
+        .mockResolvedValueOnce([501, 502])
+        .mockResolvedValueOnce([10]),
+      fetch: vi.fn()
+        .mockImplementationOnce(async function* () {
+          yield { uid: 502, envelope: { subject: 'Later message' }, flags: new Set() };
+        })
+        .mockImplementationOnce(async function* () {
+          yield { seq: 10, uid: 501 };
+        }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(client.fetch.mock.calls[0][0]).toBe('501,502');
+      expect(client.search).toHaveBeenNthCalledWith(2, { uid: '501' }, { uid: false });
+      expect(client.fetch.mock.calls[1][0]).toBe('10');
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not let a sequence-unmapped phantom UID block valid new mail', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 502, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn()
+        .mockResolvedValueOnce([501, 502])
+        .mockResolvedValueOnce([]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 502, envelope: { subject: 'Valid message' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+
+    const result = await ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+    );
+
+    expect(client.search).toHaveBeenNthCalledWith(2, { uid: '501' }, { uid: false });
+    expect(client.fetch).toHaveBeenCalledTimes(1);
+    expect(parseMessage).toHaveBeenCalledOnce();
+    expect(parseMessage).toHaveBeenCalledWith(expect.objectContaining({ uid: 502 }));
+    expect(result.insertedCount).toBe(1);
+  });
+
+  it('recovers an omitted UID through sequence addressing before committing the batch', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 502, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn()
+        .mockResolvedValueOnce([501, 502])
+        .mockResolvedValueOnce([10]),
+      fetch: vi.fn()
+        .mockImplementationOnce(async function* () {
+          yield { uid: 502, envelope: { subject: 'Second message' }, flags: new Set() };
+        })
+        .mockImplementationOnce(async function* () {
+          yield { seq: 10, uid: 501, envelope: { subject: 'First message' }, flags: new Set() };
+        }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+
+    const result = await ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+    );
+
+    expect(client.fetch.mock.calls.map(([set]) => set)).toEqual(['501,502', '10']);
+    expect(parseMessage.mock.calls.map(([msg]) => msg.uid)).toEqual([501, 502]);
+    expect(result.insertedCount).toBe(2);
+  });
+
+  it('defers when sequence revalidation fails instead of assuming a phantom', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 502, uidValidity: 100, highestModseq: 501n },
+      search: vi.fn()
+        .mockResolvedValueOnce([501, 502])
+        .mockResolvedValueOnce(false),
+      fetch: vi.fn(async function* () {
+        yield { uid: 502, envelope: { subject: 'Later message' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500, storedModseq: '500' });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('cannot commit a later UID range before an incomplete earlier range', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 705, uidNext: 706, uidValidity: 100, highestModseq: 500n },
+      search: vi.fn().mockResolvedValue(Array.from({ length: 205 }, (_, index) => index + 501)),
+      fetch: vi.fn(async function* (uidSet) {
+        const uids = uidSet.split(',').map(Number);
+        for (let index = uids.length - 1; index > 0; index--) {
+          const uid = uids[index];
+          yield { uid, envelope: { subject: `Message ${uid}` }, flags: new Set() };
+        }
+        yield { uid: uids[0] };
+      }),
+    };
+    stubSyncQueries({ maxUid: 500 });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(client.fetch).toHaveBeenCalledTimes(1);
+      expect(client.fetch.mock.calls[0][0].split(',').map(Number)).toEqual(
+        Array.from({ length: 100 }, (_, index) => index + 501)
+      );
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('rejects an incomplete full metadata batch without advancing modseq', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 2, uidValidity: 100, highestModseq: 501n },
+      fetch: vi.fn(async function* () {
+        yield { uid: 1 };
+        yield { uid: 2, envelope: { subject: 'complete' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 0, storedModseq: '500' });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('rejects a full metadata scan that omits an expected message', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 2, uidValidity: 100, highestModseq: 501n },
+      fetch: vi.fn(async function* () {
+        yield { uid: 2, envelope: { subject: 'Later message' }, flags: new Set() };
+      }),
+    };
+    stubSyncQueries({ maxUid: 0, storedModseq: '500' });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(client.fetch.mock.calls[0][0]).toBe('1:2');
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('bounds a full scan to the mailbox snapshot when new mail arrives', async () => {
+    const account = {
+      id: 'acct-sync-empty-cache', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 2, uidValidity: 100, highestModseq: 501n },
+      fetch: vi.fn(async function* (range) {
+        yield { uid: 1, envelope: { subject: 'First message' }, flags: new Set() };
+        yield { uid: 2, envelope: { subject: 'Second message' }, flags: new Set() };
+        if (range === '1:*') {
+          yield { uid: 3, envelope: { subject: 'Post-snapshot arrival' }, flags: new Set() };
+        }
+      }),
+    };
+    stubSyncQueries({ maxUid: 0, storedModseq: '500' });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+
+    const result = await ImapManager.prototype.syncMessages.call(
+      { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+    );
+
+    expect(client.fetch.mock.calls[0][0]).toBe('1:2');
+    expect(parseMessage).toHaveBeenCalledTimes(2);
+    expect(result.insertedCount).toBe(2);
+    expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(true);
+  });
+
+  it('keeps the retry barrier across UID and full metadata phases', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 600, uidNext: 503, uidValidity: 100, highestModseq: 501n },
+      search: vi.fn().mockResolvedValue([501, 502]),
+      fetch: vi.fn()
+        .mockImplementationOnce(async function* () {
+          yield { uid: 501 };
+          yield { uid: 502, envelope: { subject: 'later' }, flags: new Set() };
+        })
+        .mockImplementationOnce(async function* () {
+          yield { uid: 600, envelope: { subject: 'much later' }, flags: new Set() };
+        }),
+    };
+    stubSyncQueries({ maxUid: 500, storedModseq: null });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(client.fetch).toHaveBeenCalledTimes(1);
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('keeps the retry barrier when an exact UID FETCH becomes stale', async () => {
+    const account = {
+      id: 'acct-sync-watermark', user_id: 'user-1', email_address: 'me@example.com',
+      gtd_enabled: false, categorization_enabled: false, imap_host: 'imap.example.com',
+    };
+    const client = {
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      mailbox: { exists: 600, uidValidity: 100, highestModseq: 501n },
+      search: vi.fn().mockResolvedValue([501, 502]),
+      fetch: vi.fn()
+        .mockImplementationOnce(async function* (uidSet) {
+          if (!uidSet) yield null;
+          throw new Error('Invalid messageset after concurrent expunge');
+        })
+        .mockImplementationOnce(async function* () {
+          yield { uid: 600, envelope: { subject: 'much later' }, flags: new Set() };
+        }),
+    };
+    stubSyncQueries({ maxUid: 500, storedModseq: null });
+    parseMessage.mockImplementation(async msg => parsedFetch(msg.uid));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await ImapManager.prototype.syncMessages.call(
+        { pluginFacade: {} }, account, client, 'Watch', 20, false, true
+      );
+
+      expect(client.fetch).toHaveBeenCalledTimes(1);
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('UPDATE folders SET highest_modseq'))).toBe(false);
+      expect(result.insertedCount).toBe(0);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('hands a newly-inserted INBOX row to the inboxIngest hook when a plugin is active', async () => {
@@ -1090,7 +3878,7 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
       const client = {
         getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
         mailbox: { exists: 1, uidValidity: 100, highestModseq: 500n },
-        fetch: vi.fn(async function* () { yield { uid: 501 }; }),
+        fetch: vi.fn(async function* () { yield { uid: 501, envelope: { messageId: '<in1@x>' } }; }),
       };
       query.mockImplementation((sql) => {
         if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) {
@@ -1140,7 +3928,7 @@ describe('syncMessages — empty local cache vs nonempty server (wiring)', () =>
       const client = {
         getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
         mailbox: { exists: 1, uidValidity: 100, highestModseq: 500n },
-        fetch: vi.fn(async function* () { yield { uid: 501 }; }),
+        fetch: vi.fn(async function* () { yield { uid: 501, envelope: { messageId: '<in2@x>' } }; }),
       };
       query.mockImplementation((sql) => {
         if (sql.includes('SELECT uid_validity, highest_modseq FROM folders')) return Promise.resolve({ rows: [{ uid_validity: 100, highest_modseq: '500' }] });
@@ -1179,7 +3967,7 @@ describe('syncMessages — unread_count recompute ordering (folder badge fix)', 
       const client = {
         getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
         mailbox: { exists: 1, uidValidity: 100, highestModseq: 500n },
-        fetch: vi.fn(async function* () { yield { uid: 501 }; }),
+        fetch: vi.fn(async function* () { yield { uid: 501, envelope: { messageId: '<n1@x>' } }; }),
       };
       query.mockReset();
       query.mockImplementation((sql) => {
@@ -1193,7 +3981,7 @@ describe('syncMessages — unread_count recompute ordering (folder badge fix)', 
       // Already-\Seen so the message doesn't enter the new-mail notification path (which needs a
       // broadcast stub); it is still INSERTed, which is all the ordering assertion needs.
       parseMessage.mockResolvedValue({
-        uid: 501, messageId: '<n1@x>', subject: 'Spam', fromName: 'Sketchy', fromEmail: 's@x.com',
+        uid: 501, messageId: '<n1@x>', subject: 'Spam', fromName: 'Sketchy', fromEmail: 's@example.com',
         to: [], cc: [], replyTo: [], inReplyTo: null, references: null, date: new Date('2026-08-20T10:00:00Z'),
         snippet: 'hi', isRead: true, isStarred: false, hasAttachments: false, flags: ['\\Seen'], isBulk: false, parsedHeaders: {},
       });
@@ -1204,14 +3992,646 @@ describe('syncMessages — unread_count recompute ordering (folder badge fix)', 
       const insertIdx = calls.findIndex(sql => sql.includes('INSERT INTO messages'));
       const recomputeIdx = calls.findIndex(sql =>
         sql.includes('UPDATE folders') && sql.includes('unread_count = (SELECT COUNT(*) FILTER (WHERE m.is_read = false)'));
+      const recomputeLockIdx = calls.findIndex((sql, index) =>
+        index > insertIdx && sql.includes('SELECT uid_validity, highest_modseq FROM folders') && sql.includes('FOR UPDATE'));
       expect(insertIdx).toBeGreaterThanOrEqual(0);
+      expect(recomputeLockIdx).toBeGreaterThan(insertIdx);
       expect(recomputeIdx).toBeGreaterThanOrEqual(0);
+      expect(recomputeIdx).toBeGreaterThan(recomputeLockIdx);
       expect(recomputeIdx).toBeGreaterThan(insertIdx);            // recompute strictly after insert
-      expect(query.mock.calls[recomputeIdx][1]).toEqual(['acct-junk', 'Junk']); // scoped to this folder
+      expect(query.mock.calls[recomputeIdx][1]).toEqual(['acct-junk', 'Junk', 1]); // scoped to this folder + live EXISTS
     } finally {
       hasActive.mockRestore();
       runHook.mockRestore();
     }
+  });
+});
+
+describe('backfillMessages — incomplete metadata', () => {
+  beforeEach(() => {
+    query.mockReset();
+    parseMessage.mockReset();
+    ImapFlow.mockReset();
+  });
+
+  it('keeps an incomplete UID eligible and does not announce completion', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    const lock = { release: vi.fn() };
+    const client = {
+      mailbox: { exists: 2, uidValidity: 100 },
+      on: vi.fn(),
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue(lock),
+      search: vi.fn().mockResolvedValue([501, 502]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 501 };
+        yield { uid: 502, envelope: { subject: 'complete' }, flags: new Set() };
+      }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 2, backfill_incomplete: false }] });
+      }
+      if (sql.includes('SELECT COUNT(*) AS n FROM messages')) return Promise.resolve({ rows: [{ n: 0 }] });
+      if (sql.includes('SELECT uid_validity FROM folders')) return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      if (sql.includes('SELECT COUNT(*) as count, COALESCE(MAX(uid), 0)')) {
+        return Promise.resolve({ rows: [{ count: 0, max_uid: 0 }] });
+      }
+      if (sql.includes('SELECT uid FROM messages')) return Promise.resolve({ rows: [] });
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SELECT id FROM email_accounts')) return Promise.resolve({ rows: [{ id: account.id }] });
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'stored', is_new: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockImplementation(async msg => ({
+      uid: msg.uid, messageId: `<${msg.uid}@example.com>`, subject: 'Message',
+      fromName: 'Sender', fromEmail: 'sender@example.com', to: [], cc: [], replyTo: [],
+      inReplyTo: null, references: null, date: new Date('2026-08-25T10:00:00Z'),
+      snippet: '', isRead: true, isStarred: false, hasAttachments: false, flags: [],
+      isBulk: false, parsedHeaders: {},
+    }));
+    const ctx = {
+      backfillRunning: new Set(),
+      pluginFacade: {},
+      broadcast: vi.fn(),
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      await ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX');
+
+      expect(parseMessage).not.toHaveBeenCalled();
+      expect(query.mock.calls.filter(([sql]) => sql.includes('INSERT INTO messages'))).toHaveLength(0);
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining('SET total_count = $3'),
+        [account.id, 'INBOX', 2]
+      );
+      const deferredCountUpdate = query.mock.calls.find(([sql]) => sql.includes('SET total_count = $3'));
+      expect(deferredCountUpdate[0]).toContain('unread_count');
+      expect(deferredCountUpdate[0]).toContain('COUNT(*) FILTER (WHERE is_read = false)');
+      expect(deferredCountUpdate[0]).toContain('m.is_deleted = false');
+      expect(deferredCountUpdate[0]).toContain('backfill_incomplete = true');
+      expect(ctx.broadcast).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'backfill_complete' }), account.user_id
+      );
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0].join(' ')).not.toMatch(/501|502|sender@example\.com|Message/);
+    } finally {
+      warn.mockRestore();
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('keeps the durable marker when UIDVALIDITY changes after the UID snapshot', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    let validityReads = 0;
+    const client = {
+      mailbox: { exists: 1, uidValidity: 100 },
+      on: vi.fn(), connect: vi.fn().mockResolvedValue(undefined), close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      search: vi.fn().mockResolvedValue([501]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 501, envelope: { subject: 'Wrong epoch' }, flags: new Set() };
+      }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 1, backfill_incomplete: false }] });
+      }
+      if (sql.includes('SELECT COUNT(*) AS n FROM messages')) return Promise.resolve({ rows: [{ n: 0 }] });
+      if (sql.includes('SELECT uid_validity FROM folders')) {
+        validityReads++;
+        return Promise.resolve({ rows: [{ uid_validity: validityReads <= 2 ? 100 : 200 }] });
+      }
+      if (sql.includes('SELECT COUNT(*) as count, COALESCE(MAX(uid), 0)')) {
+        return Promise.resolve({ rows: [{ count: 0, max_uid: 0 }] });
+      }
+      if (sql.includes('SELECT uid FROM messages')) return Promise.resolve({ rows: [] });
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SELECT id FROM email_accounts')) return Promise.resolve({ rows: [{ id: account.id }] });
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'wrong-epoch', is_new: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockImplementation(async msg => ({
+      uid: msg.uid, messageId: `<${msg.uid}@example.com>`, subject: 'Wrong epoch',
+      fromName: 'Sender', fromEmail: 'sender@example.com', to: [], cc: [], replyTo: [],
+      inReplyTo: null, references: null, date: new Date('2026-08-25T10:00:00Z'),
+      snippet: '', isRead: true, isStarred: false, hasAttachments: false, flags: [],
+      isBulk: false, parsedHeaders: {},
+    }));
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX'))
+        .resolves.toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(false);
+      expect(query.mock.calls.some(([sql]) => sql.includes('backfill_incomplete = false'))).toBe(false);
+      expect(ctx.broadcast).not.toHaveBeenCalledWith(
+        { type: 'backfill_complete', accountId: account.id }, account.user_id
+      );
+    } finally {
+      log.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it('does not clear completion when UIDVALIDITY changes after final verification', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    let validityReads = 0;
+    const client = {
+      mailbox: { exists: 1, uidValidity: 100 },
+      on: vi.fn(), connect: vi.fn().mockResolvedValue(undefined), close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      search: vi.fn().mockResolvedValue([501]),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 2, backfill_incomplete: false }] });
+      }
+      if (sql.includes('SELECT COUNT(*) AS n FROM messages')) return Promise.resolve({ rows: [{ n: 1 }] });
+      if (sql.includes('SELECT uid_validity FROM folders')) {
+        validityReads++;
+        return Promise.resolve({ rows: [{ uid_validity: validityReads <= 2 ? 100 : 200 }] });
+      }
+      if (sql.includes('SELECT COUNT(*) as count, COALESCE(MAX(uid), 0)')) {
+        return Promise.resolve({ rows: [{ count: 1, max_uid: 501 }] });
+      }
+      if (sql.includes('SELECT uid FROM messages')) return Promise.resolve({ rows: [{ uid: 501 }] });
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX')).resolves.toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('backfill_incomplete = false'))).toBe(false);
+    expect(ctx.broadcast).not.toHaveBeenCalledWith(
+      { type: 'backfill_complete', accountId: account.id }, account.user_id
+    );
+  });
+
+  it('does not clear an empty mailbox when the durable epoch changes under the completion fence', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    let validityReads = 0;
+    const client = {
+      mailbox: { exists: 0, uidValidity: 100 },
+      on: vi.fn(), connect: vi.fn().mockResolvedValue(undefined), close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 0, backfill_incomplete: true }] });
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SELECT uid_validity FROM folders')) {
+        validityReads++;
+        return Promise.resolve({ rows: [{ uid_validity: validityReads === 1 ? 100 : 200 }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX')).resolves.toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('backfill_incomplete = false'))).toBe(false);
+  });
+
+  it('does not publish zero/complete from an empty backfill snapshot superseded by a fresh row', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    const client = {
+      mailbox: { exists: 0, uidValidity: 100 },
+      on: vi.fn(), connect: vi.fn().mockResolvedValue(undefined), close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 0, backfill_incomplete: true }] });
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SELECT uid_validity FROM folders')) return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      if (sql.includes('synced_at >=') && sql.includes('SELECT 1 FROM messages')) {
+        return Promise.resolve({ rows: [{ '?column?': 1 }] });
+      }
+      return Promise.resolve({ rowCount: 1, rows: [] });
+    });
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX')).resolves.toBe(false);
+
+    expect(query.mock.calls.some(([sql]) => sql.includes('synced_at >='))).toBe(true);
+    expect(query.mock.calls.some(([sql]) => sql.includes('SET total_count = 0'))).toBe(false);
+  });
+
+  it('retries exact-diff work when atomic thread repair rolls back its insert', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    const client = {
+      mailbox: { exists: 2, uidValidity: 100 },
+      on: vi.fn(), connect: vi.fn().mockResolvedValue(undefined), close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      search: vi.fn().mockResolvedValue([501, 502]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 502, envelope: { subject: 'Recovered gap' }, flags: new Set() };
+      }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count')) {
+        // Cached total is higher, so the cheap DB precheck correctly opens IMAP. The live server
+        // total/max then match the two DB rows only because one DB UID is stale.
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 3, backfill_incomplete: false }] });
+      }
+      if (sql.includes('SELECT COUNT(*) AS n FROM messages')) return Promise.resolve({ rows: [{ n: 2 }] });
+      if (sql.includes('SELECT uid_validity FROM folders')) return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      if (sql.includes('SELECT COUNT(*) as count, COALESCE(MAX(uid), 0)')) {
+        return Promise.resolve({ rows: [{ count: 2, max_uid: 502 }] });
+      }
+      if (sql.includes('SELECT uid FROM messages')) return Promise.resolve({ rows: [{ uid: 501 }, { uid: 999 }] });
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SELECT id FROM email_accounts')) return Promise.resolve({ rows: [{ id: account.id }] });
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'stored', is_new: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockImplementation(async msg => ({
+      uid: msg.uid, messageId: `<${msg.uid}@example.com>`, subject: 'Recovered gap',
+      fromName: 'Sender', fromEmail: 'sender@example.com', to: [], cc: [], replyTo: [],
+      inReplyTo: '<root@example.com>', references: '<root@example.com>',
+      date: new Date('2026-08-25T10:00:00Z'), snippet: '', isRead: true, isStarred: false,
+      hasAttachments: false, flags: [], isBulk: false, parsedHeaders: {},
+    }));
+    let threadRepairFailed = false;
+    let committedUid502 = false;
+    withTransaction.mockImplementation(async callback => {
+      let stagedInsert = false;
+      const tx = {
+        query: vi.fn(async (sql, params) => {
+          const result = await query(sql, params);
+          if (sql.includes('INSERT INTO messages')) stagedInsert = true;
+          if (sql.includes('UPDATE messages SET thread_id') && !threadRepairFailed) {
+            threadRepairFailed = true;
+            throw new Error('thread propagation failed');
+          }
+          return result;
+        }),
+      };
+      const result = await callback(tx);
+      if (stagedInsert) committedUid502 = true;
+      return result;
+    });
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX')).resolves.toBe(false);
+      expect(committedUid502).toBe(false);
+      expect(ctx.broadcast).not.toHaveBeenCalledWith(
+        { type: 'backfill_complete', accountId: account.id }, account.user_id
+      );
+      const retainedMarker = query.mock.calls.find(([sql]) =>
+        sql.includes('backfill_incomplete = true') && sql.includes('total_count = $3'));
+      expect(retainedMarker).toBeTruthy();
+
+      await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX')).resolves.toBe(true);
+      expect(client.connect).toHaveBeenCalledTimes(2);
+      expect(client.search).toHaveBeenCalledWith({ all: true }, { uid: true });
+      expect(client.fetch).toHaveBeenCalled();
+      expect(parseMessage).toHaveBeenCalledWith(expect.objectContaining({ uid: 502 }));
+      expect(committedUid502).toBe(true);
+      const uidDiffQuery = query.mock.calls.find(([sql]) => sql.includes('SELECT uid FROM messages'));
+      expect(uidDiffQuery[0]).toContain('metadata_complete = true');
+      const repairedInsert = query.mock.calls.find(([sql]) => sql.includes('INSERT INTO messages'));
+      expect(repairedInsert[0]).toContain('metadata_complete = true');
+      expect(query.mock.calls.some(([sql]) =>
+        sql.includes('UPDATE messages SET') && sql.includes('message_id = $4'))).toBe(false);
+      const completedCountUpdate = query.mock.calls.find(([sql]) => sql.includes('backfill_incomplete = false'));
+      expect(completedCountUpdate).toBeTruthy();
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('inserts an external destination copy independently instead of relocating by Message-ID', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    const client = {
+      mailbox: { exists: 1, uidValidity: 100 },
+      on: vi.fn(), connect: vi.fn().mockResolvedValue(undefined), close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      search: vi.fn().mockResolvedValue([700]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 700, envelope: { subject: 'External copy' }, flags: new Set() };
+      }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 1, backfill_incomplete: true }] });
+      }
+      if (sql.includes('SELECT uid_validity FROM folders')) return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      if (sql.includes('SELECT COUNT(*) as count')) return Promise.resolve({ rows: [{ count: 0, max_uid: 0 }] });
+      if (sql.includes('SELECT uid FROM messages')) return Promise.resolve({ rows: [] });
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SELECT id FROM email_accounts')) return Promise.resolve({ rows: [{ id: account.id }] });
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'destination-copy', is_new: true }] });
+      return Promise.resolve({ rowCount: 1, rows: [{ path: 'Archive' }] });
+    });
+    parseMessage.mockResolvedValue({
+      uid: 700, messageId: '<shared@example.com>', subject: 'External copy',
+      fromName: 'Sender', fromEmail: 'sender@example.com', to: [], cc: [], replyTo: [],
+      inReplyTo: null, references: null, date: new Date('2026-08-25T10:00:00Z'),
+      snippet: '', isRead: true, isStarred: false, hasAttachments: false, flags: [],
+      isBulk: false, parsedHeaders: {},
+    });
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'Archive')).resolves.toBe(true);
+
+    expect(query.mock.calls.some(([sql]) =>
+      sql.includes('UPDATE messages SET') && sql.includes('message_id = $4'))).toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes('INSERT INTO messages'))).toBe(true);
+  });
+
+  it('confirms a sequence-unmapped phantom without blocking backfill completion', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    const client = {
+      mailbox: { exists: 2, uidValidity: 100 },
+      on: vi.fn(),
+      connect: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+      search: vi.fn()
+        .mockResolvedValueOnce([501, 502])
+        .mockResolvedValueOnce([]),
+      fetch: vi.fn(async function* () {
+        yield { uid: 502, envelope: { subject: 'Later message' }, flags: new Set() };
+      }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count FROM folders')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 2 }] });
+      }
+      if (sql.includes('SELECT COUNT(*) AS n FROM messages')) return Promise.resolve({ rows: [{ n: 0 }] });
+      if (sql.includes('SELECT uid_validity FROM folders')) return Promise.resolve({ rows: [{ uid_validity: 100 }] });
+      if (sql.includes('SELECT COUNT(*) as count, COALESCE(MAX(uid), 0)')) {
+        return Promise.resolve({ rows: [{ count: 0, max_uid: 0 }] });
+      }
+      if (sql.includes('SELECT uid FROM messages')) return Promise.resolve({ rows: [] });
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SELECT id FROM email_accounts')) return Promise.resolve({ rows: [{ id: account.id }] });
+      if (sql.includes("preferences->>'categorizationEnabled'")) return Promise.resolve({ rows: [{ val: false }] });
+      if (sql.includes('INSERT INTO messages')) return Promise.resolve({ rows: [{ id: 'stored', is_new: true }] });
+      return Promise.resolve({ rows: [] });
+    });
+    parseMessage.mockImplementation(async msg => ({
+      uid: msg.uid, messageId: `<${msg.uid}@example.com>`, subject: 'Message',
+      fromName: 'Sender', fromEmail: 'sender@example.com', to: [], cc: [], replyTo: [],
+      inReplyTo: null, references: null, date: new Date('2026-08-25T10:00:00Z'),
+      snippet: '', isRead: true, isStarred: false, hasAttachments: false, flags: [],
+      isBulk: false, parsedHeaders: {},
+    }));
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const complete = await ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX');
+
+      expect(complete).toBe(true);
+      expect(parseMessage).toHaveBeenCalledOnce();
+      expect(client.search).toHaveBeenNthCalledWith(2, { uid: '501' }, { uid: false });
+      expect(ctx.broadcast).toHaveBeenCalledWith(
+        { type: 'backfill_complete', accountId: account.id }, account.user_id
+      );
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it('does not report an empty mailbox complete when clearing the durable marker fails', async () => {
+    const account = {
+      id: 'acct-backfill', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com', imap_port: 993, imap_tls: true,
+      auth_user: 'me@example.com', auth_pass: 'encrypted', categorization_enabled: false,
+    };
+    const client = {
+      mailbox: { exists: 0, uidValidity: 100 },
+      on: vi.fn(), connect: vi.fn().mockResolvedValue(undefined), close: vi.fn(),
+      logout: vi.fn().mockResolvedValue(undefined),
+      getMailboxLock: vi.fn().mockResolvedValue({ release: vi.fn() }),
+    };
+    ImapFlow.mockImplementation(function () { return client; });
+    getConnectionPolicy.mockResolvedValue({ allowPrivateHosts: true, allowInsecureTls: true });
+    resolveForConnection.mockResolvedValue({ host: '127.0.0.1', addresses: ['127.0.0.1'], servername: null });
+    query.mockImplementation((sql) => {
+      if (sql.includes('SELECT uid_validity, total_count')) {
+        return Promise.resolve({ rows: [{ uid_validity: 100, total_count: 0, backfill_incomplete: true }] });
+      }
+      if (sql.includes('SELECT * FROM email_accounts')) return Promise.resolve({ rows: [{ ...account, enabled: true }] });
+      if (sql.includes('SET total_count = 0')) return Promise.reject(new Error('marker write failed'));
+      return Promise.resolve({ rows: [] });
+    });
+    const ctx = { backfillRunning: new Set(), pluginFacade: {}, broadcast: vi.fn() };
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(ImapManager.prototype.backfillMessages.call(ctx, account, 'INBOX')).resolves.toBe(false);
+      expect(ctx.broadcast).not.toHaveBeenCalledWith(
+        { type: 'backfill_complete', accountId: account.id }, account.user_id
+      );
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});
+
+describe('backfillAllFolders — incomplete metadata', () => {
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  it('does not announce all-folder completion when any folder defers metadata', async () => {
+    const account = {
+      id: 'acct-backfill-all', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com',
+    };
+    const ctx = {
+      backfillAllRunning: new Set(),
+      _bgConnSem: { acquire: vi.fn().mockResolvedValue(undefined), release: vi.fn() },
+      backfillMessages: vi.fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true),
+      broadcast: vi.fn(),
+      refreshBulkFlags: vi.fn().mockResolvedValue(undefined),
+      startSnippetIndexer: vi.fn().mockResolvedValue(undefined),
+    };
+    query.mockResolvedValue({ rows: [{ path: 'Archive' }] });
+
+    const complete = await ImapManager.prototype.backfillAllFolders.call(ctx, account);
+
+    expect(complete).toBe(false);
+    expect(ctx.backfillMessages).toHaveBeenCalledTimes(2);
+    expect(ctx.broadcast).toHaveBeenCalledWith(
+      { type: 'backfill_all_start', accountId: account.id }, account.user_id
+    );
+    expect(ctx.broadcast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'backfill_all_complete' }), account.user_id
+    );
+    expect(ctx.broadcast).toHaveBeenCalledWith(
+      { type: 'backfill_all_deferred', accountId: account.id }, account.user_id
+    );
+    expect(ctx._bgConnSem.release).toHaveBeenCalledWith(account.imap_host);
+  });
+
+  it('announces completion and starts follow-up jobs after every folder completes', async () => {
+    const account = {
+      id: 'acct-backfill-all', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.fastmail.com',
+    };
+    const ctx = {
+      backfillAllRunning: new Set(),
+      _bgConnSem: { acquire: vi.fn().mockResolvedValue(undefined), release: vi.fn() },
+      backfillMessages: vi.fn().mockResolvedValue(true),
+      broadcast: vi.fn(),
+      refreshBulkFlags: vi.fn().mockResolvedValue(undefined),
+      startSnippetIndexer: vi.fn().mockResolvedValue(undefined),
+    };
+    query.mockResolvedValue({ rows: [{ path: 'Archive' }] });
+
+    const complete = await ImapManager.prototype.backfillAllFolders.call(ctx, account);
+
+    expect(complete).toBe(true);
+    expect(ctx.broadcast).toHaveBeenCalledWith(
+      { type: 'backfill_all_complete', accountId: account.id }, account.user_id
+    );
+    expect(ctx.refreshBulkFlags).toHaveBeenCalledWith(account);
+    expect(ctx.startSnippetIndexer).toHaveBeenCalledWith(account);
+  });
+
+  it('clears durable backfill markers for deliberately skipped provider folders', async () => {
+    const account = {
+      id: 'acct-backfill-all', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.gmail.com',
+    };
+    const ctx = {
+      backfillAllRunning: new Set(),
+      _bgConnSem: { acquire: vi.fn().mockResolvedValue(undefined), release: vi.fn() },
+      backfillMessages: vi.fn().mockResolvedValue(true),
+      broadcast: vi.fn(),
+      refreshBulkFlags: vi.fn().mockResolvedValue(undefined),
+      startSnippetIndexer: vi.fn().mockResolvedValue(undefined),
+    };
+    query.mockImplementation(async (sql) => {
+      if (sql.includes('SELECT path FROM folders')) {
+        return { rows: [{ path: '[Gmail]' }, { path: '[Gmail]/All Mail' }, { path: 'Archive' }] };
+      }
+      return { rowCount: 1, rows: [] };
+    });
+
+    await expect(ImapManager.prototype.backfillAllFolders.call(ctx, account)).resolves.toBe(true);
+
+    expect(ctx.backfillMessages.mock.calls.map(([, folder]) => folder)).toEqual(['INBOX', 'Archive']);
+    const markerClears = query.mock.calls.filter(([sql]) => sql.includes('backfill_incomplete = false'));
+    expect(markerClears.map(([, params]) => params)).toEqual([
+      [account.id, '[Gmail]'],
+      [account.id, '[Gmail]/All Mail'],
+    ]);
+  });
+
+  it('defers all-folder completion when a skipped-folder marker cannot be cleared', async () => {
+    const account = {
+      id: 'acct-backfill-all', user_id: 'user-1', email_address: 'me@example.com',
+      imap_host: 'imap.gmail.com',
+    };
+    const ctx = {
+      backfillAllRunning: new Set(),
+      _bgConnSem: { acquire: vi.fn().mockResolvedValue(undefined), release: vi.fn() },
+      backfillMessages: vi.fn().mockResolvedValue(true),
+      broadcast: vi.fn(),
+      refreshBulkFlags: vi.fn().mockResolvedValue(undefined),
+      startSnippetIndexer: vi.fn().mockResolvedValue(undefined),
+    };
+    query.mockImplementation(async (sql) => {
+      if (sql.includes('SELECT path FROM folders')) return { rows: [{ path: '[Gmail]/All Mail' }] };
+      if (sql.includes('backfill_incomplete = false')) throw new Error('marker write failed');
+      return { rows: [] };
+    });
+
+    await expect(ImapManager.prototype.backfillAllFolders.call(ctx, account)).resolves.toBe(false);
+    expect(ctx.broadcast).toHaveBeenCalledWith(
+      { type: 'backfill_all_deferred', accountId: account.id }, account.user_id
+    );
+    expect(ctx.broadcast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'backfill_all_complete' }), account.user_id
+    );
   });
 });
 
@@ -1322,8 +4742,8 @@ describe('walkStructure attachment classification', () => {
 // ── _shouldAutoBackfillOnConnect — auto-backfill gate (#354) ──────────────────
 // The gate itself was always correct; #354 was the connect flow evaluating it
 // AFTER the initial INBOX sync inserted rows. These lock the gate contract:
-// providers without the flag always backfill; PurelyMail backfills only when the
-// account is genuinely empty (which connectAccount now captures pre-sync).
+// providers without the flag always backfill; PurelyMail backfills when the account
+// is empty or any folder still owes a durable exact-diff retry.
 
 describe('_shouldAutoBackfillOnConnect (#354)', () => {
   const gate = acct => ImapManager.prototype._shouldAutoBackfillOnConnect.call({}, acct);
@@ -1335,13 +4755,19 @@ describe('_shouldAutoBackfillOnConnect (#354)', () => {
   });
 
   it('backfills a fresh PurelyMail account with no cached messages', async () => {
-    query.mockResolvedValueOnce({ rows: [] });
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] });
     await expect(gate({ imap_host: 'imap.purelymail.com', id: 'a1' })).resolves.toBe(true);
   });
 
   it('skips backfill for a PurelyMail account that already has cached messages', async () => {
-    query.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [{ exists: 1 }] });
     await expect(gate({ imap_host: 'imap.purelymail.com', id: 'a1' })).resolves.toBe(false);
+  });
+
+  it('retries a deferred PurelyMail folder even when the account already has messages', async () => {
+    query.mockResolvedValueOnce({ rows: [{ exists: 1 }] });
+    await expect(gate({ imap_host: 'imap.purelymail.com', id: 'a1' })).resolves.toBe(true);
+    expect(query.mock.calls[0][0]).toContain('backfill_incomplete = true');
   });
 });
 
@@ -1412,11 +4838,13 @@ describe('syncFolders pruning', () => {
   beforeEach(() => {
     query.mockReset();
     query.mockResolvedValue({ rows: [] });
+    claimMailboxTopology.mockClear();
+    commitMailboxTopology.mockClear();
   });
 
   const account = { id: 'acct-1', email_address: 'a@example.com' };
 
-  it('deletes DB rows for folders missing from LIST (ghosts after external rename)', async () => {
+  it('claims topology before LIST and commits the complete buffered result atomically', async () => {
     const client = {
       list: vi.fn().mockResolvedValue([
         { path: 'INBOX', name: 'INBOX', delimiter: '/' },
@@ -1426,138 +4854,257 @@ describe('syncFolders pruning', () => {
     };
     await ImapManager.prototype.syncFolders.call({}, account, client);
 
-    const del = query.mock.calls.find(([sql]) => sql.includes('DELETE FROM folders'));
-    expect(del).toBeTruthy();
-    expect(del[0]).toContain("path != 'INBOX'");
-    expect(del[1]).toEqual(['acct-1', ['INBOX', 'Projects-Renamed', 'Projects-Renamed/Sub']]);
+    expect(claimMailboxTopology).toHaveBeenCalledWith('acct-1');
+    expect(client.list).toHaveBeenCalledOnce();
+    expect(commitMailboxTopology).toHaveBeenCalledWith(
+      'acct-1',
+      { accountId: 'acct-1', generation: '1' },
+      [
+        expect.objectContaining({ path: 'INBOX' }),
+        expect.objectContaining({ path: 'Projects-Renamed' }),
+        expect.objectContaining({ path: 'Projects-Renamed/Sub' }),
+      ],
+    );
+    expect(query).not.toHaveBeenCalled();
   });
 
-  it('never prunes on an empty LIST response', async () => {
+  it('fails closed without a topology commit when LIST fails', async () => {
+    const client = { list: vi.fn().mockRejectedValue(new Error('LIST interrupted')) };
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.syncFolders.call({}, account, client))
+      .rejects.toThrow('LIST interrupted');
+
+    expect(claimMailboxTopology).toHaveBeenCalledWith('acct-1');
+    expect(commitMailboxTopology).not.toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty LIST before synthesizing INBOX or committing topology', async () => {
     const client = { list: vi.fn().mockResolvedValue([]) };
-    await ImapManager.prototype.syncFolders.call({}, account, client);
-    expect(query.mock.calls.some(([sql]) => sql.includes('DELETE FROM folders'))).toBe(false);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.syncFolders.call({}, account, client))
+      .rejects.toThrow(/empty LIST/i);
+
+    expect(claimMailboxTopology).toHaveBeenCalledWith('acct-1');
+    expect(commitMailboxTopology).not.toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
   });
 
-  it('still upserts every listed folder before pruning', async () => {
+  it('rejects a malformed partial LIST before committing any folder state', async () => {
     const client = {
       list: vi.fn().mockResolvedValue([
         { path: 'Archive', name: 'Archive', delimiter: '/', specialUse: '\\Archive' },
+        { name: 'truncated-entry', delimiter: '/' },
       ]),
     };
-    await ImapManager.prototype.syncFolders.call({}, account, client);
-    const inserts = query.mock.calls.filter(([sql]) => sql.includes('INSERT INTO folders'));
-    // The listed folder + the implicit INBOX row.
-    expect(inserts.length).toBe(2);
-    const del = query.mock.calls.find(([sql]) => sql.includes('DELETE FROM folders'));
-    expect(del[1][1]).toEqual(['Archive']);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.syncFolders.call({}, account, client))
+      .rejects.toThrow(/invalid mailbox entry/i);
+
+    expect(commitMailboxTopology).not.toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a nonempty partial LIST that omits mandatory INBOX', async () => {
+    const client = { list: vi.fn().mockResolvedValue([
+      { path: 'Archive', name: 'Archive', delimiter: '/', specialUse: '\\Archive' },
+    ]) };
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(ImapManager.prototype.syncFolders.call({}, account, client))
+      .rejects.toThrow(/missing mandatory INBOX/i);
+
+    expect(commitMailboxTopology).not.toHaveBeenCalled();
+  });
+});
+
+describe('background body prefetch exact publication', () => {
+  it('carries the captured row and folder epoch through the post-fetch cache CAS', async () => {
+    query.mockReset();
+    query
+      .mockResolvedValueOnce({ rows: [{
+        id: '11111111-1111-4111-8111-111111111111', account_id: 'acct-1',
+        uid: '7', folder: 'INBOX', read_revision: '2', star_revision: '3',
+        folder_uid_validity: '101', folder_observation_generation: '9', cached: false,
+      }] })
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const manager = {
+      fetchMessageBody: vi.fn().mockResolvedValue({ html: null, text: 'body', attachments: [] }),
+    };
+
+    await ImapManager.prototype.prefetchNewMessageBodies.call(
+      manager,
+      { id: 'acct-1' },
+      [{ id: '11111111-1111-4111-8111-111111111111', uid: 7 }],
+    );
+
+    expect(manager.fetchMessageBody).toHaveBeenCalledWith(
+      { id: 'acct-1' }, '7', 'INBOX',
+      { snapshot: expect.objectContaining({ uidValidity: '101', folderGeneration: '9' }) },
+    );
+    const [publishSql, publishParams] = query.mock.calls[1];
+    expect(publishSql).toMatch(/f\.uid_validity = \$9/);
+    expect(publishSql).toMatch(/f\.observation_generation = \$10/);
+    expect(publishParams.slice(-2)).toEqual(['101', '9']);
+  });
+});
+
+describe('mailbox topology mutations', () => {
+  beforeEach(() => {
+    claimMailboxTopology.mockClear();
+    commitMailboxTopology.mockClear();
+    claimFolderObservation.mockClear();
+    readFolderObservation.mockClear();
+    seedFolderUidValidity.mockClear();
+  });
+
+  it('claims topology before a provider mutation and commits a fresh complete LIST afterward', async () => {
+    const account = { id: 'acct-1' };
+    const providerMutation = vi.fn().mockResolvedValue({ path: 'Archive', created: true });
+    const client = {
+      list: vi.fn().mockResolvedValue([
+        { path: 'INBOX', name: 'INBOX', delimiter: '/' },
+        { path: 'Archive', name: 'Archive', delimiter: '/', specialUse: '\\Archive' },
+      ]),
+    };
+
+    const result = await imapModule.mutateMailboxTopology?.(account, client, providerMutation);
+
+    expect(result).toEqual({ path: 'Archive', created: true });
+    expect(claimMailboxTopology).toHaveBeenCalledWith('acct-1');
+    expect(providerMutation).toHaveBeenCalledWith(client);
+    expect(commitMailboxTopology).toHaveBeenCalledWith(
+      'acct-1',
+      { accountId: 'acct-1', generation: '1' },
+      [
+        expect.objectContaining({ path: 'INBOX' }),
+        expect.objectContaining({ path: 'Archive', specialUse: '\\Archive' }),
+      ],
+    );
+    expect(claimMailboxTopology.mock.invocationCallOrder[0])
+      .toBeLessThan(providerMutation.mock.invocationCallOrder[0]);
+    expect(providerMutation.mock.invocationCallOrder[0])
+      .toBeLessThan(client.list.mock.invocationCallOrder[0]);
+  });
+
+  it('routes create, delete, and rename through topology-fenced provider mutations', async () => {
+    const account = { id: 'acct-1' };
+    const listed = [{ path: 'INBOX', name: 'INBOX', delimiter: '/' }];
+    const client = {
+      mailboxCreate: vi.fn().mockResolvedValue({ path: 'New', created: true }),
+      mailboxDelete: vi.fn().mockResolvedValue(true),
+      mailboxRename: vi.fn().mockResolvedValue(true),
+      list: vi.fn().mockResolvedValue(listed),
+    };
+
+    await imapModule.createMailboxTopology?.(account, client, 'New');
+    await imapModule.deleteMailboxTopology?.(account, client, 'Old');
+    await imapModule.renameMailboxTopology?.(account, client, 'Old', 'New');
+
+    expect(client.mailboxCreate).toHaveBeenCalledWith('New');
+    expect(client.mailboxDelete).toHaveBeenCalledWith('Old');
+    expect(client.mailboxRename).toHaveBeenCalledWith('Old', 'New');
+    expect(claimMailboxTopology).toHaveBeenCalledTimes(3);
+    expect(commitMailboxTopology).toHaveBeenCalledTimes(3);
+  });
+
+  it('establishes the UIDVALIDITY observation before a newly ensured folder can be used', async () => {
+    const account = { id: 'acct-1' };
+    const release = vi.fn();
+    readFolderObservation.mockResolvedValueOnce({
+      folder: 'Todo', uidValidity: null, generation: '1', isPresent: true,
+    });
+    claimFolderObservation.mockResolvedValueOnce({
+      folder: 'Todo', uidValidity: null, generation: '2', isPresent: true,
+    });
+    const client = {
+      mailbox: null,
+      mailboxCreate: vi.fn().mockResolvedValue({ path: 'Todo', created: true }),
+      list: vi.fn().mockResolvedValue([
+        { path: 'INBOX', name: 'INBOX', delimiter: '/' },
+        { path: 'Todo', name: 'Todo', delimiter: '/' },
+      ]),
+      getMailboxLock: vi.fn(async folder => {
+        client.mailbox = { path: folder, uidValidity: 303 };
+        return { release };
+      }),
+    };
+
+    await expect(imapModule.ensureMailboxTopology(account, client, 'Todo'))
+      .resolves.toEqual({ path: 'Todo', created: true });
+
+    expect(readFolderObservation).toHaveBeenCalledWith('acct-1', 'Todo');
+    expect(claimFolderObservation).toHaveBeenCalledWith('acct-1', 'Todo');
+    expect(client.getMailboxLock).toHaveBeenCalledWith('Todo');
+    expect(seedFolderUidValidity).toHaveBeenCalledWith(
+      expect.anything(),
+      'acct-1',
+      expect.objectContaining({ folder: 'Todo' }),
+      303,
+    );
+    expect(seedFolderUidValidity.mock.invocationCallOrder[0])
+      .toBeLessThan(release.mock.invocationCallOrder[0]);
   });
 });
 
 // ── _deleteAllInFolder — chunked, throttle-tolerant empty ─────────────────────
-describe('_deleteAllInFolder — chunked delete', () => {
-  const run = (client, opts) =>
-    ImapManager.prototype._deleteAllInFolder.call(ImapManager.prototype, client, 'Trash', { retryBackoffMs: 0, ...opts });
-
-  it('deletes in UID-addressed chunks of chunkSize and returns the total', async () => {
-    const uids = Array.from({ length: 1200 }, (_, i) => i + 1);
-    const client = {
-      search: vi.fn().mockResolvedValue(uids),
-      messageDelete: vi.fn().mockResolvedValue(true),
+describe('setDesiredFlag — structured local acceptance', () => {
+  it('fences provider STORE with the accepted flag revision, not revision zero', () => {
+    const delivery = {
+      messageId: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+      uidValidity: '101', folderGeneration: '4', revision: 9,
     };
-    const deleted = await run(client, { chunkSize: 500 });
-
-    expect(deleted).toBe(1200);
-    expect(client.search).toHaveBeenCalledWith({ all: true }, { uid: true });
-    expect(client.messageDelete).toHaveBeenCalledTimes(3); // 500 + 500 + 200
-    // Every call is UID-addressed, and the chunks together cover exactly all UIDs, in order.
-    const seen = [];
-    for (const [range, options] of client.messageDelete.mock.calls) {
-      expect(options).toEqual({ uid: true });
-      seen.push(...range.split(',').map(Number));
-    }
-    expect(seen).toEqual(uids);
+    expect(desiredFlagDeliverySnapshot({ ...delivery, flag: 'read' })).toMatchObject({
+      readRevision: 9, starRevision: null,
+    });
+    expect(desiredFlagDeliverySnapshot({ ...delivery, flag: 'star' })).toMatchObject({
+      readRevision: null, starRevision: 9,
+    });
   });
 
-  it('is a no-op when the folder is already empty', async () => {
-    const client = {
-      search: vi.fn().mockResolvedValue([]),
-      messageDelete: vi.fn(),
+  it('attaches committed acceptance when provider delivery rejects', async () => {
+    const accepted = {
+      changed: true,
+      delivery: { messageId: 'row-1', flag: 'read', desiredValue: true, state: 'pending' },
     };
-    const deleted = await run(client);
-    expect(deleted).toBe(0);
-    expect(client.messageDelete).not.toHaveBeenCalled();
-  });
+    const deliveryError = new Error('provider unavailable');
+    const accept = vi.spyOn(desiredFlagExecutor, 'accept').mockResolvedValue(accepted);
+    const deliver = vi.spyOn(desiredFlagExecutor, 'deliver').mockRejectedValue(deliveryError);
+    const manager = Object.create(ImapManager.prototype);
+    manager._desiredFlagProvider = vi.fn().mockReturnValue({ withSession: vi.fn() });
 
-  it('retries a chunk once after the server declines it, then succeeds', async () => {
-    const client = {
-      search: vi.fn().mockResolvedValue([1, 2, 3]),
-      messageDelete: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
-    };
-    const deleted = await run(client);
-    expect(deleted).toBe(3);
-    expect(client.messageDelete).toHaveBeenCalledTimes(2); // one decline, one retry
-  });
-
-  it('throws with progress when a chunk keeps failing after the retry', async () => {
-    const client = {
-      search: vi.fn().mockResolvedValue([1, 2, 3]),
-      messageDelete: vi.fn().mockResolvedValue(false),
-    };
-    await expect(run(client)).rejects.toThrow(/messageDelete could not be confirmed/);
-    expect(client.messageDelete).toHaveBeenCalledTimes(2); // initial attempt + one retry
-  });
-
-  it('surfaces the underlying error if the retry attempt throws', async () => {
-    const client = {
-      search: vi.fn().mockResolvedValue([1, 2, 3]),
-      messageDelete: vi.fn()
-        .mockResolvedValueOnce(false)
-        .mockRejectedValueOnce(new Error('Socket timeout')),
-    };
-    await expect(run(client)).rejects.toThrow(/Socket timeout/);
-    expect(client.messageDelete).toHaveBeenCalledTimes(2);
-  });
-});
-
-// ── _markSeenInFolder — chunked mark-all-read ────────────────────────────────
-describe('_markSeenInFolder — chunked mark-all-read', () => {
-  const run = (client, opts) =>
-    ImapManager.prototype._markSeenInFolder.call(ImapManager.prototype, client, 'INBOX', { retryBackoffMs: 0, ...opts });
-
-  it('adds \\Seen to UNSEEN messages in UID-addressed chunks', async () => {
-    const uids = Array.from({ length: 1100 }, (_, i) => i + 1);
-    const client = {
-      search: vi.fn().mockResolvedValue(uids),
-      messageFlagsAdd: vi.fn().mockResolvedValue(true),
-    };
-    const flagged = await run(client, { chunkSize: 500 });
-
-    expect(flagged).toBe(1100);
-    // Only unread messages are targeted, and the return is UID-addressed.
-    expect(client.search).toHaveBeenCalledWith({ seen: false }, { uid: true });
-    expect(client.messageFlagsAdd).toHaveBeenCalledTimes(3); // 500 + 500 + 100
-    for (const [range, flags, options] of client.messageFlagsAdd.mock.calls) {
-      expect(flags).toEqual(['\\Seen']);
-      expect(options).toEqual({ uid: true });
-      expect(range.split(',').length).toBeLessThanOrEqual(500);
+    try {
+      await expect(manager.setDesiredFlag(
+        { id: 'acct-1' }, 'row-1', '\\Seen', true,
+      )).rejects.toBe(deliveryError);
+      expect(deliveryError.desiredFlagAcceptance).toBe(accepted);
+    } finally {
+      accept.mockRestore();
+      deliver.mockRestore();
     }
   });
 
-  it('is a no-op when nothing is unread', async () => {
-    const client = {
-      search: vi.fn().mockResolvedValue([]),
-      messageFlagsAdd: vi.fn(),
+  it('returns acceptance separately from confirmed provider delivery', async () => {
+    const accepted = {
+      changed: true,
+      delivery: { messageId: 'row-1', flag: 'read', desiredValue: true, state: 'pending' },
     };
-    expect(await run(client)).toBe(0);
-    expect(client.messageFlagsAdd).not.toHaveBeenCalled();
-  });
+    const confirmed = { ...accepted.delivery, state: 'confirmed' };
+    const accept = vi.spyOn(desiredFlagExecutor, 'accept').mockResolvedValue(accepted);
+    const deliver = vi.spyOn(desiredFlagExecutor, 'deliver').mockResolvedValue(confirmed);
+    const manager = Object.create(ImapManager.prototype);
+    manager._desiredFlagProvider = vi.fn().mockReturnValue({ withSession: vi.fn() });
 
-  it('retries a chunk once, then throws with progress if it keeps failing', async () => {
-    const client = {
-      search: vi.fn().mockResolvedValue([1, 2, 3]),
-      messageFlagsAdd: vi.fn().mockResolvedValue(false),
-    };
-    await expect(run(client)).rejects.toThrow(/messageFlagsAdd could not be confirmed/);
-    expect(client.messageFlagsAdd).toHaveBeenCalledTimes(2);
+    try {
+      await expect(manager.setDesiredFlag(
+        { id: 'acct-1' }, 'row-1', '\\Seen', true,
+      )).resolves.toMatchObject({ acceptance: accepted, delivery: confirmed });
+    } finally {
+      accept.mockRestore();
+      deliver.mockRestore();
+    }
   });
 });

--- a/backend/src/services/inboxRules.js
+++ b/backend/src/services/inboxRules.js
@@ -1,5 +1,97 @@
 import { query } from './db.js';
-import { resolveArchiveFolder, isAllMailFolder, resolveTrashFolder, resolveAllTrashPaths, getDeleteStrategy, adjustFolderCounts } from '../utils/mailUtils.js';
+import { resolveArchiveFolder, isAllMailFolder, resolveTrashFolder, resolveAllTrashPaths, getDeleteStrategy } from '../utils/mailUtils.js';
+import { materializeArchiveReceipt } from './archiveInbox.js';
+
+function bulkMoveObserved(
+  imapManager, account, uids, fromFolder, toFolder, observationContext, operationKey,
+  sourceMessages = [], allMail = false,
+) {
+  const rows = new Map(sourceMessages.map(msg => {
+    const token = observationContext?.tokens?.find(candidate => candidate.folder === msg.folder);
+    return [Number(msg.uid), {
+      ...msg, account_id: msg.account_id || account.id,
+      folder_uid_validity: token?.uidValidity ?? msg.folder_uid_validity,
+      folder_observation_generation: token?.generation ?? msg.folder_observation_generation,
+    }];
+  }));
+  return imapManager.bulkMoveMessages(account, uids, fromFolder, toFolder, {
+    ...(observationContext ? { observationContext } : {}),
+    operationKey,
+    sourceRows: rows,
+    sourceSnapshots: new Map([...rows].map(([uid, row]) => [uid, desiredSnapshot(row, account, observationContext)])),
+    materialize: (row, receipt, operation, tx, providerResource) => materializeArchiveReceipt(tx, {
+      accountId: account.id, sourceSnapshot: row, destinationFolder: toFolder,
+      receipt, operation, allMail,
+      providerResource,
+    }),
+  });
+}
+
+function applyMoveReceipt(msg, result, sourceUid, destinationFolder) {
+  const receipt = result.receiptMap?.get(Number(sourceUid));
+  msg.uid = receipt?.uid ?? result.uidMap?.get(Number(sourceUid)) ?? msg.uid;
+  msg.folder = destinationFolder;
+  if (receipt?.uidValidity != null) msg.folder_uid_validity = receipt.uidValidity;
+  if (receipt?.destinationToken?.generation != null) {
+    msg.folder_observation_generation = receipt.destinationToken.generation;
+  }
+}
+
+function desiredSnapshot(msg, account, observationContext) {
+  const token = observationContext?.tokens?.find(candidate => candidate.folder === msg.folder);
+  const uidValidity = token?.uidValidity ?? msg.folder_uid_validity;
+  const generation = token?.generation ?? msg.folder_observation_generation;
+  if (uidValidity == null || generation == null || !msg.id) return null;
+  return {
+    id: msg.id,
+    accountId: account.id,
+    uid: Number(msg.uid),
+    folder: msg.folder,
+    uidValidity: String(uidValidity),
+    folderGeneration: String(generation),
+    readRevision: Number(msg.read_revision || 0),
+    starRevision: Number(msg.star_revision || 0),
+  };
+}
+
+async function setDesiredFlagObserved(
+  imapManager, account, msg, flag, value, observationContext,
+) {
+  if (typeof imapManager.setDesiredFlag !== 'function') {
+    const err = new Error('Durable desired-flag capability is unavailable');
+    err.code = 'INBOX_RULE_DESIRED_FLAG_UNAVAILABLE';
+    throw err;
+  }
+  const snapshot = desiredSnapshot(msg, account, observationContext);
+  const outcome = await imapManager.setDesiredFlag(
+    account, msg.id, flag, value, snapshot ? { snapshot } : {},
+  );
+  if (outcome?.delivery?.state !== 'confirmed') {
+    const err = new Error(`Desired ${flag} delivery is not confirmed`);
+    err.code = 'INBOX_RULE_DESIRED_FLAG_NOT_CONFIRMED';
+    err.retryable = true;
+    err.uncertain = true;
+    err.desiredFlagAcceptance = outcome?.acceptance;
+    throw err;
+  }
+  return outcome;
+}
+
+function applyAcceptedDesiredFlagToMessage(err, action, msg) {
+  const accepted = err?.desiredFlagAcceptance?.delivery;
+  if (!accepted || accepted.desiredValue !== true) return false;
+  if (action.type === 'mark_read' && accepted.flag === 'read') {
+    msg.isRead = true;
+    msg.is_read = true;
+    return true;
+  }
+  if (action.type === 'star' && accepted.flag === 'star') {
+    msg.isStarred = true;
+    msg.is_starred = true;
+    return true;
+  }
+  return false;
+}
 
 async function getRulesForAccount(userId, accountId) {
   const result = await query(
@@ -145,7 +237,7 @@ function evaluateRule(rule, msg) {
 //   remaining — messages still in INBOX after rules ran (moved/archived/deleted excluded)
 //   mutedIds  — IDs of remaining messages that had mark_read applied by a rule;
 //               the caller uses this to suppress sound/toast/push for silenced mail
-export async function applyInboxRules(messages, account, imapManager) {
+export async function applyInboxRules(messages, account, imapManager, observationContext = null) {
   if (!messages.length) return { remaining: messages, mutedIds: new Set() };
 
   let rules;
@@ -197,6 +289,7 @@ export async function applyInboxRules(messages, account, imapManager) {
   // manual recovery. Keep every destination action blocked so nothing moves,
   // archives, or deletes that source out from under recovery.
   const destinationBlockedIds = new Set();
+  const actionBlockedIds = new Set();
   // IDs of remaining-in-INBOX messages that had mark_read applied by a rule.
   // Used by the caller to skip sound/toast/push for mail the user chose to silence.
   const mutedIds = new Set();
@@ -221,13 +314,21 @@ export async function applyInboxRules(messages, account, imapManager) {
           account,
           imapManager,
           ruleId,
-          resolverCache
+          resolverCache,
+          observationContext
         );
         if (isDest && acted) removedIds.add(msg.id);
         // mark_read: add to mutedIds so caller suppresses sound/push.
         // star: intentionally NOT muted — a star-only rule should still alert.
         if (action.type === 'mark_read') mutedIds.add(msg.id);
       } catch (err) {
+        if (err?.code === 'INBOX_RULE_DESIRED_FLAG_NOT_CONFIRMED' ||
+            err?.code === 'INBOX_RULE_DESIRED_FLAG_UNAVAILABLE' ||
+            err?.code === 'INBOX_RULE_DESIRED_FLAG_FAILED') {
+          actionBlockedIds.add(msg.id);
+          const accepted = applyAcceptedDesiredFlagToMessage(err, action, msg);
+          if (accepted && action.type === 'mark_read') mutedIds.add(msg.id);
+        }
         console.error(`inboxRules: action ${action.type} failed for msg ${msg.id}:`, err.message);
       }
     };
@@ -235,12 +336,14 @@ export async function applyInboxRules(messages, account, imapManager) {
     const flushDeferredDestinations = async () => {
       while (deferredDestinations.length) {
         const { action, ruleId } = deferredDestinations.shift();
-        if (removedIds.has(msg.id) || destinationBlockedIds.has(msg.id)) continue;
+        if (removedIds.has(msg.id) || destinationBlockedIds.has(msg.id) ||
+            actionBlockedIds.has(msg.id)) continue;
         await executeNonForwardAction(action, ruleId, true);
       }
     };
 
     for (let ruleIndex = 0; ruleIndex < rules.length; ruleIndex++) {
+      if (actionBlockedIds.has(msg.id)) break;
       const rule = rules[ruleIndex];
       let matches;
       try {
@@ -274,7 +377,8 @@ export async function applyInboxRules(messages, account, imapManager) {
             account,
             imapManager,
             rule.id,
-            resolverCache
+            resolverCache,
+            observationContext
           );
         } catch {
           destinationBlockedIds.add(msg.id);
@@ -295,6 +399,7 @@ export async function applyInboxRules(messages, account, imapManager) {
 
       let destSeen = false;
       for (const action of actions.filter(action => action.type !== 'forward')) {
+        if (actionBlockedIds.has(msg.id)) break;
         const isDest = action.type === 'move' || action.type === 'archive' || action.type === 'delete';
         if (isDest && destSeen) continue;
         // Skip destination actions for already-relocated messages — the source UID no
@@ -325,7 +430,7 @@ export async function applyInboxRules(messages, account, imapManager) {
 }
 
 // Moves messages from blocked senders to trash before inbox rules run.
-export async function applyBlockList(messages, account, imapManager) {
+export async function applyBlockList(messages, account, imapManager, observationContext = null) {
   if (!messages.length) return messages;
 
   let blockedRows;
@@ -365,32 +470,30 @@ export async function applyBlockList(messages, account, imapManager) {
     try {
       const strategy = getDeleteStrategy(msg.folder, trashFolder, allTrashPaths);
       if (strategy.action === 'move') {
+        const sourceFolder = msg.folder;
+        const sourceUid = msg.uid;
         imapManager._guardMoveUid(account.id, msg.folder, msg.uid);
         try {
-          const result = await imapManager.bulkMoveMessages(account, [msg.uid], msg.folder, strategy.destination);
+          const result = await bulkMoveObserved(
+            imapManager, account, [msg.uid], msg.folder, strategy.destination,
+            observationContext, `block-list:${msg.id}:${strategy.destination}`,
+            [msg],
+          );
           if (!result.failed?.length) {
-            const newUid = result.uidMap?.get(Number(msg.uid));
-            if (newUid) {
-              await query('UPDATE messages SET folder = $1, uid = $2 WHERE id = $3', [strategy.destination, newUid, msg.id]);
-            } else {
-              imapManager._guardMoveUid(account.id, strategy.destination, msg.uid);
-              await query('UPDATE messages SET folder = $1 WHERE id = $2', [strategy.destination, msg.id]);
-              setTimeout(() => imapManager._unguardMoveUid(account.id, strategy.destination, msg.uid), 10_000);
-            }
-            const wasUnread = !(msg.isRead ?? msg.is_read);
-            adjustFolderCounts(account.id, msg.folder, -1, wasUnread ? -1 : 0);
-            adjustFolderCounts(account.id, strategy.destination, 1, wasUnread ? 1 : 0);
+            applyMoveReceipt(msg, result, sourceUid, strategy.destination);
           } else {
             remaining.push(msg);
           }
         } finally {
-          imapManager._unguardMoveUid(account.id, msg.folder, msg.uid);
+          imapManager._unguardMoveUid(account.id, sourceFolder, sourceUid);
         }
       } else if (strategy.action === 'expunge') {
-        await imapManager.setFlag(account, msg.uid, msg.folder, '\\Deleted', true);
-        await query('UPDATE messages SET is_deleted = true WHERE id = $1', [msg.id]);
-        const wasUnread = !(msg.isRead ?? msg.is_read);
-        adjustFolderCounts(account.id, msg.folder, -1, wasUnread ? -1 : 0);
+        const snapshot = desiredSnapshot(msg, account, observationContext);
+        if (!snapshot) throw new Error('Exact block-list delete snapshot is unavailable');
+        await imapManager.removeMessageCopy(account.id, msg.uid, msg.folder, {
+          expectedId: msg.id, expectedUidValidity: snapshot.uidValidity, snapshot,
+          operationKey: `block-list-expunge:${msg.id}`, notify: false,
+        });
       } else {
         remaining.push(msg);
       }
@@ -402,7 +505,9 @@ export async function applyBlockList(messages, account, imapManager) {
   return remaining;
 }
 
-async function applyAction(action, msg, account, imapManager, ruleId, resolverCache = {}) {
+async function applyAction(
+  action, msg, account, imapManager, ruleId, resolverCache = {}, observationContext = null
+) {
   switch (action.type) {
     case 'forward': {
       // Load this path only when a forward action actually runs. ruleForwarder
@@ -419,19 +524,16 @@ async function applyAction(action, msg, account, imapManager, ruleId, resolverCa
     }
 
     case 'mark_read': {
-      await query(
-        'UPDATE messages SET is_read = true, read_changed_at = NOW() WHERE id = $1',
-        [msg.id]
-      );
-      imapManager.setFlag(account, msg.uid, msg.folder, '\\Seen', true).catch(err => {
-        console.error('inboxRules: setFlag \\Seen failed:', err.message);
-        // Durable retry so a later flag-sync pull can't silently revert the rule's effect.
-        imapManager._enqueueFlagPush(account.id, msg.id, '\\Seen', true);
-      });
-      // msg.isRead (camelCase from parseMessage) and msg.is_read (snake_case in test
-      // fixtures) both represent the pre-action read state; use whichever is present.
-      const wasUnread = !(msg.isRead ?? msg.is_read);
-      if (wasUnread) adjustFolderCounts(account.id, msg.folder, 0, -1);
+      try {
+        await setDesiredFlagObserved(
+          imapManager, account, msg, '\\Seen', true, observationContext,
+        );
+      } catch (err) {
+        if (!err?.code?.startsWith?.('INBOX_RULE_DESIRED_FLAG_')) {
+          err.code = 'INBOX_RULE_DESIRED_FLAG_FAILED';
+        }
+        throw err;
+      }
       // Update in-memory state so subsequent actions in later rules (e.g. a move rule
       // at lower priority) see the correct read state and don't double-decrement the
       // unread count.
@@ -441,15 +543,18 @@ async function applyAction(action, msg, account, imapManager, ruleId, resolverCa
     }
 
     case 'star': {
-      await query(
-        'UPDATE messages SET is_starred = true, star_changed_at = NOW() WHERE id = $1',
-        [msg.id]
-      );
-      imapManager.setFlag(account, msg.uid, msg.folder, '\\Flagged', true).catch(err => {
-        console.error('inboxRules: setFlag \\Flagged failed:', err.message);
-        // Durable retry so a later flag-sync pull can't silently revert the rule's effect.
-        imapManager._enqueueFlagPush(account.id, msg.id, '\\Flagged', true);
-      });
+      try {
+        await setDesiredFlagObserved(
+          imapManager, account, msg, '\\Flagged', true, observationContext,
+        );
+      } catch (err) {
+        if (!err?.code?.startsWith?.('INBOX_RULE_DESIRED_FLAG_')) {
+          err.code = 'INBOX_RULE_DESIRED_FLAG_FAILED';
+        }
+        throw err;
+      }
+      msg.isStarred = true;
+      msg.is_starred = true;
       break;
     }
 
@@ -468,35 +573,16 @@ async function applyAction(action, msg, account, imapManager, ruleId, resolverCa
         // the error propagates to the caller so the DB is never updated. This prevents
         // a DB/IMAP split where the DB shows the message in destFolder but IMAP still
         // has it in INBOX, which caused the next sync to bounce the message back.
-        const moveResult = await imapManager.bulkMoveMessages(account, [srcUid], srcFolder, destFolder);
+        const moveResult = await bulkMoveObserved(
+          imapManager, account, [srcUid], srcFolder, destFolder, observationContext,
+          `rule-move:${msg.id}:${srcFolder}:${destFolder}`,
+          [msg],
+        );
         if (moveResult.failed?.length) throw new Error(`IMAP move to ${destFolder} failed for uid ${srcUid}`);
-        // Update UID alongside folder. The IMAP MOVE assigns the message a new UID in
-        // the destination folder. Without this, reconcileDeletes fires ~1.5 s later
-        // (triggered by the EXPUNGE IDLE event), sees the old source UID absent from
-        // the destination's server UID set, and deletes the DB row — silently losing
-        // the message.
-        const newUid = moveResult.uidMap?.get(Number(srcUid));
-        if (newUid) {
-          await query('UPDATE messages SET folder = $1, uid = $2 WHERE id = $3', [destFolder, newUid, msg.id]);
-        } else {
-          // Non-UIDPLUS server: DB will hold the stale source UID in the destination
-          // folder until the next sync corrects it. Guard the stale UID in the
-          // destination so reconcileDeletes does not treat it as an orphan in the
-          // meantime. The guard auto-expires after 10 s — well beyond the 1.5 s
-          // EXPUNGE debounce; a regular sync (~60 s) will update the UID before the
-          // next periodic reconcile (every 10 sync ticks, ~10 min).
-          imapManager._guardMoveUid(account.id, destFolder, srcUid);
-          await query('UPDATE messages SET folder = $1 WHERE id = $2', [destFolder, msg.id]);
-          setTimeout(() => imapManager._unguardMoveUid(account.id, destFolder, srcUid), 10_000);
-        }
-        const wasUnread = !(msg.isRead ?? msg.is_read);
-        adjustFolderCounts(account.id, srcFolder, -1, wasUnread ? -1 : 0);
-        adjustFolderCounts(account.id, destFolder, 1, wasUnread ? 1 : 0);
         // Update the in-memory msg so subsequent non-destination actions in later rules
         // (e.g. mark_read) target the correct destination folder and uid rather than
         // the now-stale INBOX values.
-        msg.folder = destFolder;
-        msg.uid = newUid || srcUid;
+        applyMoveReceipt(msg, moveResult, srcUid, destFolder);
       } finally {
         imapManager._unguardMoveUid(account.id, srcFolder, srcUid);
       }
@@ -519,25 +605,13 @@ async function applyAction(action, msg, account, imapManager, ruleId, resolverCa
       const srcUid = msg.uid;
       imapManager._guardMoveUid(account.id, srcFolder, srcUid);
       try {
-        const archiveResult = await imapManager.bulkMoveMessages(account, [srcUid], srcFolder, archiveFolder);
+        const archiveResult = await bulkMoveObserved(
+          imapManager, account, [srcUid], srcFolder, archiveFolder, observationContext,
+          `rule-archive:${msg.id}:${srcFolder}:${archiveFolder}`,
+          [msg], resolverCache.archiveIsAllMail,
+        );
         if (archiveResult.failed?.length) throw new Error(`IMAP archive failed for uid ${srcUid}`);
-        const newArchiveUid = archiveResult.uidMap?.get(Number(srcUid));
-        const wasUnread = !(msg.isRead ?? msg.is_read);
-        if (resolverCache.archiveIsAllMail) {
-          // No sync loop maintains a messages row filed under All Mail — the message
-          // vanishes from our view instead of getting re-homed there (see mail.js bulk-archive).
-          await query('DELETE FROM messages WHERE id = $1', [msg.id]);
-        } else if (newArchiveUid) {
-          await query('UPDATE messages SET folder = $1, uid = $2 WHERE id = $3', [archiveFolder, newArchiveUid, msg.id]);
-        } else {
-          imapManager._guardMoveUid(account.id, archiveFolder, srcUid);
-          await query('UPDATE messages SET folder = $1 WHERE id = $2', [archiveFolder, msg.id]);
-          setTimeout(() => imapManager._unguardMoveUid(account.id, archiveFolder, srcUid), 10_000);
-        }
-        adjustFolderCounts(account.id, srcFolder, -1, wasUnread ? -1 : 0);
-        if (!resolverCache.archiveIsAllMail) adjustFolderCounts(account.id, archiveFolder, 1, wasUnread ? 1 : 0);
-        msg.folder = archiveFolder;
-        msg.uid = newArchiveUid || srcUid;
+        applyMoveReceipt(msg, archiveResult, srcUid, archiveFolder);
       } finally {
         imapManager._unguardMoveUid(account.id, srcFolder, srcUid);
       }
@@ -557,29 +631,27 @@ async function applyAction(action, msg, account, imapManager, ruleId, resolverCa
       const strategy = getDeleteStrategy(msg.folder, trashFolder, allTrashPaths);
       if (strategy.action === 'no_trash') return false;
       if (strategy.action === 'move') {
-        imapManager._guardMoveUid(account.id, msg.folder, msg.uid);
+        const sourceFolder = msg.folder;
+        const sourceUid = msg.uid;
+        imapManager._guardMoveUid(account.id, sourceFolder, sourceUid);
         try {
-          const deleteResult = await imapManager.bulkMoveMessages(account, [msg.uid], msg.folder, strategy.destination);
+          const deleteResult = await bulkMoveObserved(
+            imapManager, account, [msg.uid], msg.folder, strategy.destination,
+            observationContext, `rule-delete:${msg.id}:${msg.folder}:${strategy.destination}`,
+            [msg],
+          );
           if (deleteResult.failed?.length) throw new Error(`IMAP delete-move failed for uid ${msg.uid}`);
-          const newDeleteUid = deleteResult.uidMap?.get(Number(msg.uid));
-          if (newDeleteUid) {
-            await query('UPDATE messages SET folder = $1, uid = $2 WHERE id = $3', [strategy.destination, newDeleteUid, msg.id]);
-          } else {
-            imapManager._guardMoveUid(account.id, strategy.destination, msg.uid);
-            await query('UPDATE messages SET folder = $1 WHERE id = $2', [strategy.destination, msg.id]);
-            setTimeout(() => imapManager._unguardMoveUid(account.id, strategy.destination, msg.uid), 10_000);
-          }
-          const wasUnread = !(msg.isRead ?? msg.is_read);
-          adjustFolderCounts(account.id, msg.folder, -1, wasUnread ? -1 : 0);
-          adjustFolderCounts(account.id, strategy.destination, 1, wasUnread ? 1 : 0);
+          applyMoveReceipt(msg, deleteResult, sourceUid, strategy.destination);
         } finally {
-          imapManager._unguardMoveUid(account.id, msg.folder, msg.uid);
+          imapManager._unguardMoveUid(account.id, sourceFolder, sourceUid);
         }
       } else if (strategy.action === 'expunge') {
-        await imapManager.setFlag(account, msg.uid, msg.folder, '\\Deleted', true);
-        await query('UPDATE messages SET is_deleted = true WHERE id = $1', [msg.id]);
-        const wasUnread = !(msg.isRead ?? msg.is_read);
-        adjustFolderCounts(account.id, msg.folder, -1, wasUnread ? -1 : 0);
+        const snapshot = desiredSnapshot(msg, account, observationContext);
+        if (!snapshot) throw new Error('Exact rule delete snapshot is unavailable');
+        await imapManager.removeMessageCopy(account.id, msg.uid, msg.folder, {
+          expectedId: msg.id, expectedUidValidity: snapshot.uidValidity, snapshot,
+          operationKey: `rule-expunge:${msg.id}`, notify: false,
+        });
       }
       return true;
     }

--- a/backend/src/services/inboxRules.test.js
+++ b/backend/src/services/inboxRules.test.js
@@ -27,6 +27,7 @@ const account = { id: 'acc-1', user_id: 'user-1', folder_mappings: {} };
 
 const mkMsg = (overrides = {}) => ({
   id: 'msg-1', uid: 100, folder: 'INBOX', account_id: 'acc-1',
+  folder_uid_validity: '100', folder_observation_generation: '7',
   fromEmail: 'sender@example.com', fromName: 'Sender',
   to: [], subject: 'Test', is_read: false, hasAttachments: false,
   parsedHeaders: {},
@@ -43,13 +44,21 @@ const mkRule = (actions, overrides = {}) => ({
 
 const mockImap = {
   bulkMoveMessages: vi.fn(),
+  setDesiredFlag: vi.fn(),
   setFlag: vi.fn(),
   _guardMoveUid: vi.fn(),
   _unguardMoveUid: vi.fn(),
+  withFolderObservationContext: vi.fn((_accountId, _context, callback) => callback({ query })),
 };
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
+  mockImap.withFolderObservationContext.mockImplementation(
+    (_accountId, _context, callback) => callback({ query })
+  );
+  mockImap.setDesiredFlag.mockResolvedValue({
+    changed: true, delivery: { state: 'confirmed' },
+  });
 });
 
 describe('applyInboxRules — forwarding', () => {
@@ -107,12 +116,8 @@ describe('applyInboxRules — forwarding', () => {
 
       expect(mockImap.bulkMoveMessages).not.toHaveBeenCalled();
       expect(result.remaining).toHaveLength(1);
-      expect(mockImap.setFlag).toHaveBeenCalledWith(
-        account,
-        100,
-        'INBOX',
-        '\\Seen',
-        true
+      expect(mockImap.setDesiredFlag).toHaveBeenCalledWith(
+        account, 'msg-1', '\\Seen', true, expect.objectContaining({ snapshot: expect.any(Object) })
       );
       expect(consoleError).toHaveBeenCalledWith(
         'inboxRules: forward action failed; destination actions suppressed'
@@ -449,12 +454,10 @@ describe('applyInboxRules — archive to Gmail All Mail', () => {
     const result = await applyInboxRules([mkMsg({ is_read: false })], account, mockImap);
 
     expect(result.remaining).toHaveLength(0); // message removed from inbox
-    const deleteCall = query.mock.calls[1];
-    expect(deleteCall[0]).toMatch(/DELETE FROM messages/);
-    expect(deleteCall[1]).toEqual(['msg-1']);
-    // Source folder count decrements; All Mail destination count is never touched.
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX', -1, -1);
-    expect(adjustFolderCounts).toHaveBeenCalledTimes(1);
+    expect(mockImap.bulkMoveMessages.mock.calls[0][4]).toEqual(expect.objectContaining({
+      materialize: expect.any(Function), sourceSnapshots: expect.any(Map),
+    }));
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
   });
 });
 
@@ -472,9 +475,9 @@ describe('applyInboxRules — UID update after move', () => {
     const result = await applyInboxRules([mkMsg()], account, mockImap);
 
     expect(result.remaining).toHaveLength(0); // message removed from inbox
-    const updateCall = query.mock.calls[1];
-    expect(updateCall[0]).toMatch(/uid/i); // SQL includes uid update
-    expect(updateCall[1]).toEqual(['INBOX/Work', 789, 'msg-1']);
+    expect(mockImap.bulkMoveMessages.mock.calls[0][4]).toEqual(expect.objectContaining({
+      materialize: expect.any(Function), sourceSnapshots: expect.any(Map),
+    }));
   });
 
   it('updates only folder when uidMap is empty (no UIDPLUS)', async () => {
@@ -490,8 +493,9 @@ describe('applyInboxRules — UID update after move', () => {
     const result = await applyInboxRules([mkMsg()], account, mockImap);
 
     expect(result.remaining).toHaveLength(0);
-    const updateCall = query.mock.calls[1];
-    expect(updateCall[1]).toEqual(['INBOX/Work', 'msg-1']); // only folder, no uid
+    expect(mockImap.bulkMoveMessages.mock.calls[0][4]).toEqual(expect.objectContaining({
+      materialize: expect.any(Function), sourceSnapshots: expect.any(Map),
+    }));
   });
 });
 
@@ -512,7 +516,10 @@ describe('applyInboxRules — destination action deduplication', () => {
     await applyInboxRules([mkMsg()], account, mockImap);
 
     expect(mockImap.bulkMoveMessages).toHaveBeenCalledOnce();
-    expect(mockImap.bulkMoveMessages).toHaveBeenCalledWith(account, [100], 'INBOX', 'INBOX/Work');
+    expect(mockImap.bulkMoveMessages).toHaveBeenCalledWith(
+      account, [100], 'INBOX', 'INBOX/Work',
+      expect.objectContaining({ operationKey: 'rule-move:msg-1:INBOX:INBOX/Work' }),
+    );
   });
 
   it('executes only the first destination action when a legacy rule has move + delete', async () => {
@@ -528,7 +535,10 @@ describe('applyInboxRules — destination action deduplication', () => {
     await applyInboxRules([mkMsg()], account, mockImap);
 
     expect(mockImap.bulkMoveMessages).toHaveBeenCalledOnce();
-    expect(mockImap.bulkMoveMessages).toHaveBeenCalledWith(account, [100], 'INBOX', 'INBOX/Archive');
+    expect(mockImap.bulkMoveMessages).toHaveBeenCalledWith(
+      account, [100], 'INBOX', 'INBOX/Archive',
+      expect.objectContaining({ operationKey: 'rule-move:msg-1:INBOX:INBOX/Archive' }),
+    );
   });
 
   it('skips subsequent destination actions even when the first one fails', async () => {
@@ -563,7 +573,9 @@ describe('applyInboxRules — destination action deduplication', () => {
     await applyInboxRules([mkMsg()], account, mockImap);
 
     expect(mockImap.bulkMoveMessages).toHaveBeenCalledOnce();
-    expect(mockImap.setFlag).toHaveBeenCalledWith(account, 100, 'INBOX', '\\Seen', true);
+    expect(mockImap.setDesiredFlag).toHaveBeenCalledWith(
+      account, 'msg-1', '\\Seen', true, expect.objectContaining({ snapshot: expect.any(Object) })
+    );
   });
 });
 
@@ -587,7 +599,10 @@ describe('applyInboxRules — already-relocated message skips subsequent rules',
     // message removed from remaining; second move never fired
     expect(result.remaining).toHaveLength(0);
     expect(mockImap.bulkMoveMessages).toHaveBeenCalledOnce();
-    expect(mockImap.bulkMoveMessages).toHaveBeenCalledWith(account, [100], 'INBOX', 'INBOX/Work');
+    expect(mockImap.bulkMoveMessages).toHaveBeenCalledWith(
+      account, [100], 'INBOX', 'INBOX/Work',
+      expect.objectContaining({ operationKey: 'rule-move:msg-1:INBOX:INBOX/Work' }),
+    );
   });
 
   it('applies a subsequent mark_read rule even after an earlier rule moved the message', async () => {
@@ -612,10 +627,12 @@ describe('applyInboxRules — already-relocated message skips subsequent rules',
     const result = await applyInboxRules([mkMsg()], account, mockImap);
 
     expect(result.remaining).toHaveLength(0); // message still moved
-    // mark_read DB update fired: third query call (after rules fetch + move update)
-    expect(query).toHaveBeenCalledTimes(3);
-    // setFlag targeted the NEW uid (200) in the destination folder (INBOX/Work)
-    expect(mockImap.setFlag).toHaveBeenCalledWith(account, 200, 'INBOX/Work', '\\Seen', true);
+    // Durable desired-flag acceptance owns the local row mutation and provider
+    // delivery; inbox rules only persists the preceding move coordinates.
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(mockImap.setDesiredFlag).toHaveBeenCalledWith(
+      account, 'msg-1', '\\Seen', true, expect.objectContaining({ snapshot: expect.any(Object) })
+    );
   });
 
   it('does not double-decrement unread count when mark_read fires before move (reversed priority)', async () => {
@@ -639,16 +656,190 @@ describe('applyInboxRules — already-relocated message skips subsequent rules',
 
     await applyInboxRules([mkMsg({ is_read: false })], account, mockImap);
 
-    // mark_read should adjust INBOX unread (-1); move should NOT adjust unread again
-    // because wasUnread is false after mark_read updated msg.is_read in-memory.
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX', 0, -1);  // mark_read
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX', -1, 0);  // move source (no unread delta)
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX/Work', 1, 0); // move dest (no unread delta)
-    expect(adjustFolderCounts).toHaveBeenCalledTimes(3);
+    // Desired-flag acceptance owns the read count. The subsequent move sees
+    // the updated in-memory state and only transfers total counts.
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
   });
 });
 
 describe('applyInboxRules — mutedIds for mark_read', () => {
+  it('stops later move/count work and preserves in-memory state when read acceptance fails', async () => {
+    const rule = mkRule([
+      { type: 'mark_read', value: '' },
+      { type: 'move', value: 'INBOX/Work' },
+    ]);
+    const message = mkMsg({ is_read: false, isRead: false });
+    const imap = {
+      ...mockImap,
+      setDesiredFlag: vi.fn().mockRejectedValue(new Error('accept failed')),
+    };
+    query.mockResolvedValueOnce({ rows: [rule] });
+
+    const result = await applyInboxRules([message], account, imap);
+
+    expect(imap.setDesiredFlag).toHaveBeenCalledWith(
+      account, 'msg-1', '\\Seen', true,
+      expect.objectContaining({ snapshot: expect.any(Object) }),
+    );
+    expect(imap.bulkMoveMessages).not.toHaveBeenCalled();
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+    expect(message).toMatchObject({ uid: 100, folder: 'INBOX', is_read: false, isRead: false });
+    expect(result.remaining).toEqual([message]);
+    expect(result.mutedIds.has(message.id)).toBe(false);
+  });
+
+  it('keeps accepted local read state muted while stopping later work on non-confirmed delivery', async () => {
+    const rules = [
+      mkRule([{ type: 'mark_read', value: '' }], { id: 'read-rule' }),
+      mkRule([{ type: 'archive', value: '' }, { type: 'delete', value: '' }], { id: 'move-rule' }),
+    ];
+    const message = mkMsg({ is_read: false, isRead: false });
+    const imap = {
+      ...mockImap,
+      setDesiredFlag: vi.fn().mockResolvedValue({
+        changed: true,
+        acceptance: {
+          changed: true,
+          delivery: { state: 'pending', desiredValue: true, flag: 'read' },
+        },
+        delivery: { state: 'uncertain' },
+      }),
+    };
+    query.mockResolvedValueOnce({ rows: rules });
+
+    const result = await applyInboxRules([message], account, imap);
+
+    expect(resolveArchiveFolder).not.toHaveBeenCalled();
+    expect(imap.bulkMoveMessages).not.toHaveBeenCalled();
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+    expect(message).toMatchObject({ uid: 100, folder: 'INBOX', is_read: true, isRead: true });
+    expect(result.remaining).toEqual([message]);
+    expect(result.mutedIds.has(message.id)).toBe(true);
+  });
+
+  it('uses structured committed acceptance on delivery rejection to mute and suppress broadcast', async () => {
+    const rule = mkRule([
+      { type: 'mark_read', value: '' },
+      { type: 'move', value: 'INBOX/Work' },
+    ]);
+    const message = mkMsg({ is_read: false, isRead: false });
+    const deliveryError = Object.assign(new Error('provider delivery failed'), {
+      desiredFlagAcceptance: {
+        changed: true,
+        delivery: { state: 'pending', desiredValue: true, flag: 'read' },
+      },
+    });
+    const imap = {
+      ...mockImap,
+      setDesiredFlag: vi.fn().mockRejectedValue(deliveryError),
+    };
+    query.mockResolvedValueOnce({ rows: [rule] });
+
+    const result = await applyInboxRules([message], account, imap);
+
+    expect(imap.bulkMoveMessages).not.toHaveBeenCalled();
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+    expect(message).toMatchObject({ uid: 100, folder: 'INBOX', is_read: true, isRead: true });
+    expect(result.remaining).toEqual([message]);
+    expect(result.mutedIds.has(message.id)).toBe(true);
+    expect(result.remaining.filter(item => !result.mutedIds.has(item.id))).toEqual([]);
+  });
+
+  it('retains accepted read muting when a later accepted star delivery fails', async () => {
+    const rule = mkRule([
+      { type: 'mark_read', value: '' },
+      { type: 'star', value: '' },
+      { type: 'move', value: 'INBOX/Work' },
+    ]);
+    const message = mkMsg({ is_read: false, isRead: false, is_starred: false, isStarred: false });
+    const starError = Object.assign(new Error('star provider delivery failed'), {
+      desiredFlagAcceptance: {
+        changed: true,
+        delivery: { state: 'pending', desiredValue: true, flag: 'star' },
+      },
+    });
+    const imap = {
+      ...mockImap,
+      setDesiredFlag: vi.fn()
+        .mockResolvedValueOnce({
+          changed: true,
+          acceptance: {
+            changed: true,
+            delivery: { state: 'pending', desiredValue: true, flag: 'read' },
+          },
+          delivery: { state: 'confirmed' },
+        })
+        .mockRejectedValueOnce(starError),
+    };
+    query.mockResolvedValueOnce({ rows: [rule] });
+
+    const result = await applyInboxRules([message], account, imap);
+
+    expect(imap.setDesiredFlag).toHaveBeenCalledTimes(2);
+    expect(imap.bulkMoveMessages).not.toHaveBeenCalled();
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
+    expect(message).toMatchObject({
+      uid: 100, folder: 'INBOX', is_read: true, isRead: true,
+      is_starred: true, isStarred: true,
+    });
+    expect(result.mutedIds.has(message.id)).toBe(true);
+  });
+
+  it('records rule read intent against the exact observed row and folder epoch', async () => {
+    const rule = mkRule([{ type: 'mark_read', value: '' }]);
+    const observationContext = {
+      accountId: account.id,
+      tokens: [{ folder: 'INBOX', uidValidity: '100', generation: '7' }],
+    };
+    const imap = {
+      ...mockImap,
+      setDesiredFlag: vi.fn().mockResolvedValue({ changed: true }),
+    };
+    query.mockResolvedValueOnce({ rows: [rule] });
+
+    await applyInboxRules([mkMsg({ read_revision: 4, star_revision: 2 })], account, imap, observationContext);
+
+    expect(imap.setDesiredFlag).toHaveBeenCalledWith(
+      account, 'msg-1', '\\Seen', true,
+      { snapshot: {
+        id: 'msg-1', accountId: 'acc-1', uid: 100, folder: 'INBOX',
+        uidValidity: '100', folderGeneration: '7', readRevision: 4, starRevision: 2,
+      } },
+    );
+    expect(mockImap.setFlag).not.toHaveBeenCalled();
+  });
+
+  it('awaits the provider flag mutation and carries the sync observation context', async () => {
+    const rule = mkRule([{ type: 'mark_read', value: '' }]);
+    const observationContext = {
+      accountId: account.id,
+      tokens: [{ folder: 'INBOX', uidValidity: '100', generation: '7' }],
+    };
+    let releaseFlag;
+    const flagPending = new Promise(resolve => { releaseFlag = resolve; });
+    query
+      .mockResolvedValueOnce({ rows: [rule] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockImap.setDesiredFlag.mockReturnValue(flagPending);
+
+    let settled = false;
+    const applying = applyInboxRules([mkMsg()], account, mockImap, observationContext)
+      .then(result => { settled = true; return result; });
+    await vi.waitFor(() => expect(mockImap.setDesiredFlag).toHaveBeenCalledOnce());
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(mockImap.setDesiredFlag).toHaveBeenCalledWith(
+      account, 'msg-1', '\\Seen', true, { snapshot: {
+        id: 'msg-1', accountId: 'acc-1', uid: 100, folder: 'INBOX',
+        uidValidity: '100', folderGeneration: '7', readRevision: 0, starRevision: 0,
+      } }
+    );
+
+    releaseFlag({ changed: true, delivery: { state: 'confirmed' } });
+    await applying;
+  });
+
   it('adds message id to mutedIds when mark_read rule applies', async () => {
     const rule = mkRule([{ type: 'mark_read', value: '' }]);
     query
@@ -686,6 +877,30 @@ describe('applyInboxRules — mutedIds for mark_read', () => {
 });
 
 describe('applyInboxRules — adjustFolderCounts on action', () => {
+  it('passes the same sync observation context into a destination move', async () => {
+    const rule = mkRule([{ type: 'move', value: 'INBOX/Work' }]);
+    const observationContext = {
+      accountId: account.id,
+      tokens: [{ folder: 'INBOX', uidValidity: '100', generation: '7' }],
+    };
+    query
+      .mockResolvedValueOnce({ rows: [rule] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockImap.bulkMoveMessages.mockResolvedValue({
+      failed: [],
+      uidMap: new Map([[100, 200]]),
+    });
+
+    await applyInboxRules([mkMsg()], account, mockImap, observationContext);
+
+    expect(mockImap.bulkMoveMessages).toHaveBeenCalledWith(
+      account, [100], 'INBOX', 'INBOX/Work', expect.objectContaining({
+        observationContext,
+        operationKey: 'rule-move:msg-1:INBOX:INBOX/Work',
+      })
+    );
+  });
+
   it('calls adjustFolderCounts for source and destination after a successful move', async () => {
     const rule = mkRule([{ type: 'move', value: 'INBOX/Work' }]);
     query
@@ -696,8 +911,7 @@ describe('applyInboxRules — adjustFolderCounts on action', () => {
     await applyInboxRules([mkMsg({ is_read: false })], account, mockImap);
 
     // unread message moved: source loses 1 total and 1 unread; dest gains 1 of each
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX', -1, -1);
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX/Work', 1, 1);
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
   });
 
   it('calls adjustFolderCounts with zero unread delta when message is already read', async () => {
@@ -709,8 +923,7 @@ describe('applyInboxRules — adjustFolderCounts on action', () => {
 
     await applyInboxRules([mkMsg({ is_read: true })], account, mockImap);
 
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX', -1, 0);
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX/Work', 1, 0);
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
   });
 
   it('calls adjustFolderCounts with unread delta only for mark_read on an unread message', async () => {
@@ -722,8 +935,7 @@ describe('applyInboxRules — adjustFolderCounts on action', () => {
 
     await applyInboxRules([mkMsg({ is_read: false })], account, mockImap);
 
-    expect(adjustFolderCounts).toHaveBeenCalledWith('acc-1', 'INBOX', 0, -1);
-    expect(adjustFolderCounts).toHaveBeenCalledTimes(1);
+    expect(adjustFolderCounts).not.toHaveBeenCalled();
   });
 
   it('does not call adjustFolderCounts for mark_read when message is already read', async () => {

--- a/backend/src/services/labels.js
+++ b/backend/src/services/labels.js
@@ -1,5 +1,5 @@
 import { query } from './db.js';
-import { fanOutReadToSiblings } from '../utils/mailUtils.js';
+import { snapshotFromMessageRow } from './messageSnapshots.js';
 
 // Generic "labels" capability (v3.0 plugin platform).
 //
@@ -18,19 +18,36 @@ import { fanOutReadToSiblings } from '../utils/mailUtils.js';
 // (an IMAP COPY duplicates it verbatim) joins to the sibling copy. A message with no
 // Message-ID can only be resolved via the acted-row case.
 export async function resolveLabelCopyUid(message, folder) {
-  if (message.folder === folder) return message.uid;
+  return (await resolveLabelCopyRow(message, folder))?.uid ?? null;
+}
+
+async function resolveLabelCopyRow(message, folder) {
+  if (message.folder === folder) return message;
   if (!message.message_id) return null;
   const { rows } = await query(
-    'SELECT uid FROM messages WHERE account_id = $1 AND folder = $2 AND message_id = $3 AND is_deleted = false LIMIT 1',
+    `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                     AND f.is_present = true AND f.uid_validity IS NOT NULL
+      WHERE m.account_id = $1 AND m.folder = $2 AND m.message_id = $3
+        AND m.is_deleted = false AND m.metadata_complete = true
+      ORDER BY m.id LIMIT 2`,
     [message.account_id, folder, message.message_id]
   );
-  return rows[0]?.uid ?? null;
+  if (rows.length > 1) {
+    const err = new Error(`More than one live copy exists in label folder ${folder}`);
+    err.code = 'AMBIGUOUS_LABEL_COPY';
+    throw err;
+  }
+  return rows[0] || null;
 }
 
 // Apply a label: ensure the label folder exists, then COPY the message into it (leaving the
 // original in place). imapManager.copyMessage also emits the section-refresh event. No-op when
 // the message already lives in the label folder. `message` needs { uid, folder }.
-export async function applyLabel(imapManager, account, message, labelFolder) {
+export async function applyLabel(imapManager, account, message, labelFolder, { operationKey } = {}) {
   if (message.folder === labelFolder) {
     return { applied: false, uid: message.uid, reason: 'already-there' };
   }
@@ -39,7 +56,10 @@ export async function applyLabel(imapManager, account, message, labelFolder) {
     return { applied: false, uid: existingUid, reason: 'already-labelled' };
   }
   await imapManager.ensureFolder(account, labelFolder);
-  const uid = await imapManager.copyMessage(account.id, message.uid, message.folder, labelFolder);
+  const uid = await imapManager.copyMessage(account.id, message.uid, message.folder, labelFolder, {
+    operationKey,
+    snapshot: snapshotFromMessageRow(message),
+  });
   return { applied: true, uid: uid ?? null };
 }
 
@@ -50,25 +70,52 @@ export async function applyLabel(imapManager, account, message, labelFolder) {
 export async function removeExactLabelCopy(imapManager, message, labelFolder, uid) {
   if (!message.message_id) return { removed: false };
   const { rows } = await query(
-    `SELECT uid FROM messages
-      WHERE account_id = $1 AND folder = $2 AND uid = $3
-        AND message_id = $4 AND is_deleted = false
+    `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                     AND f.is_present = true AND f.uid_validity IS NOT NULL
+      WHERE m.account_id = $1 AND m.folder = $2 AND m.uid = $3
+        AND m.message_id = $4 AND m.is_deleted = false AND m.metadata_complete = true
       LIMIT 1`,
     [message.account_id, labelFolder, uid, message.message_id]
   );
   if (!rows[0]) return { removed: false };
-  await imapManager.removeMessageCopy(message.account_id, uid, labelFolder);
-  return { removed: true };
+  return removeLabelRow(imapManager, rows[0]);
 }
 
 // Remove a label: delete the message's copy living in the label folder, leaving INBOX and any
 // other labels intact. No-op when no such copy exists. `message` needs { account_id, uid,
 // folder, message_id }.
 export async function removeLabel(imapManager, message, labelFolder) {
-  const uid = await resolveLabelCopyUid(message, labelFolder);
-  if (uid == null) return { removed: false };
-  await imapManager.removeMessageCopy(message.account_id, uid, labelFolder);
+  const row = await resolveLabelCopyRow(message, labelFolder);
+  if (!row) return { removed: false };
+  await imapManager.removeMessageCopy(message.account_id, row.uid, labelFolder, {
+    expectedId: row.id,
+    expectedUidValidity: row.folder_uid_validity,
+    snapshot: snapshotFromMessageRow(row),
+  });
   return { removed: true };
+}
+
+// Remove one concrete row from a label folder. Unlike removeLabel(), this never resolves through
+// Message-ID: callers that already hold an authorized thread snapshot can delete every exact copy
+// without an arbitrary LIMIT 1. The engine's expectedId option makes the DB half a CAS; rowCount 0
+// is an idempotent concurrent completion, not an error. Batch callers suppress per-row plugin
+// hooks and emit one terminal refresh themselves.
+export async function removeLabelRow(imapManager, row, { notify = true } = {}) {
+  const options = { expectedId: row.id, notify, snapshot: snapshotFromMessageRow(row) };
+  if (Object.prototype.hasOwnProperty.call(row, 'folder_uid_validity')) {
+    options.expectedUidValidity = row.folder_uid_validity;
+  }
+  const removed = await imapManager.removeMessageCopy(
+    row.account_id,
+    row.uid,
+    row.folder,
+    options,
+  );
+  return { removed: removed > 0, alreadyGone: removed === 0 };
 }
 
 // Ensure a set of label folders exist on the IMAP server, resolving each to its REAL server
@@ -93,26 +140,83 @@ export async function ensureLabelFolders(imapManager, account, folderPaths) {
   return results;
 }
 
-// Mark an entire thread read: a DB fan-out across every sibling copy (by Message-ID, adjusting
-// each folder's unread count) plus a best-effort \Seen on the durable INBOX copy (it rides the
-// archive move; Gmail propagates message-wide). The INBOX copy is looked up first and returned
-// so the caller can archive it afterward — it survives even if the fan-out/flag push degrades.
-// The lookup itself may throw (caller treats that as fatal, matching the plain read route); the
-// fan-out + flag push are best-effort and reported via the returned `error`, never thrown.
+// Mark an entire thread read by resolving every actionable sibling descriptively, then accepting
+// an independent exact-row desired Seen delivery for each. The INBOX copy is returned so the
+// caller can archive it afterward; a sibling failure is reported only after all rows were tried.
 // `message` needs { account_id, message_id }.
 export async function markThreadRead(imapManager, account, message) {
   const { rows } = await query(
-    'SELECT id, uid, is_read FROM messages WHERE account_id = $1 AND folder = $2 AND message_id = $3 AND is_deleted = false LIMIT 1',
-    [message.account_id, 'INBOX', message.message_id]
+    `SELECT m.id, m.account_id, m.uid, m.folder, m.is_read,
+            m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                     AND f.is_present = true AND f.uid_validity IS NOT NULL
+      WHERE m.account_id = $1 AND m.message_id = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+      ORDER BY m.id`,
+    [message.account_id, message.message_id]
   );
-  const inboxCopy = rows[0] || null;
-  try {
-    await fanOutReadToSiblings(message.account_id, message.message_id, true);
-    if (inboxCopy && !inboxCopy.is_read) {
-      await imapManager.setFlag(account, inboxCopy.uid, 'INBOX', '\\Seen', true);
+  const inboxCopy = rows.find(row => row.folder === 'INBOX') || null;
+  let firstError;
+  for (const row of rows) {
+    try {
+      await imapManager.setDesiredFlag(account, row.id, '\\Seen', true, {
+        snapshot: snapshotFromMessageRow(row),
+      });
+    } catch (err) {
+      firstError ||= err;
     }
-  } catch (err) {
-    return { inboxCopy, error: err };
   }
-  return { inboxCopy };
+  return firstError ? { inboxCopy, error: firstError } : { inboxCopy };
+}
+
+// Mark the exact authorized thread snapshot read before destructive mutations. The desired-flag
+// service owns the atomic visible-state/count update and durable provider retry for each row.
+export async function markThreadRowsRead(imapManager, account, rows) {
+  const exactRows = [...new Map((rows || []).filter(row => row.id).map(row => [row.id, row])).values()];
+  if (exactRows.length === 0) return { changedCount: 0, seenFailedCount: 0 };
+  let changedCount = 0;
+  let seenFailedCount = 0;
+  const postSeenRows = [];
+  // Confirm every snapshot copy, including rows already marked read locally. A previous request
+  // may have queued a failed push under that row id; re-confirming here prevents destructive Done
+  // from deleting/moving the retry identity before the server has accepted \Seen.
+  for (const row of exactRows) {
+    try {
+      const outcome = await imapManager.setDesiredFlag(account, row.id, '\\Seen', true, {
+        snapshot: snapshotFromMessageRow(row),
+      });
+      if (outcome?.changed) changedCount++;
+      if (outcome?.delivery?.state !== 'confirmed') {
+        const err = new Error(`Seen delivery for row ${row.id} is not confirmed`);
+        err.code = 'DESIRED_SEEN_NOT_CONFIRMED';
+        err.retryable = true;
+        err.uncertain = true;
+        throw err;
+      }
+      const revision = Number(outcome?.acceptance?.delivery?.revision);
+      if (!Number.isSafeInteger(revision) || revision < 0) {
+        const err = new Error(`Seen acceptance revision for row ${row.id} is unavailable`);
+        err.code = 'DESIRED_SEEN_REVISION_UNAVAILABLE';
+        err.retryable = true;
+        throw err;
+      }
+      postSeenRows.push({ ...row, is_read: true, read_revision: revision });
+    } catch (err) {
+      if (err?.code === 'MESSAGE_SNAPSHOT_SUPERSEDED'
+          || err?.code === 'MESSAGE_SNAPSHOT_NOT_ACTIONABLE'
+          || err?.code === 'DESIRED_FLAG_ROW_SUPERSEDED') {
+        err.retryable = false;
+        throw err;
+      }
+      seenFailedCount++;
+      console.warn(`GTD done: desired Seen delivery for row ${row.id} deferred:`, err.message);
+    }
+  }
+
+  return postSeenRows.length > 0
+    ? { changedCount, seenFailedCount, postSeenRows }
+    : { changedCount, seenFailedCount };
 }

--- a/backend/src/services/labels.test.js
+++ b/backend/src/services/labels.test.js
@@ -1,54 +1,89 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./db.js', () => ({ query: vi.fn() }));
-vi.mock('../utils/mailUtils.js', () => ({ fanOutReadToSiblings: vi.fn() }));
+
 import { query } from './db.js';
-import { fanOutReadToSiblings } from '../utils/mailUtils.js';
 import {
   applyLabel,
   removeExactLabelCopy,
   removeLabel,
+  removeLabelRow,
   resolveLabelCopyUid,
   markThreadRead,
+  markThreadRowsRead,
   ensureLabelFolders,
 } from './labels.js';
 
 const account = { id: 'acct-1' };
 const mkImap = () => ({ ensureFolder: vi.fn(), copyMessage: vi.fn(), removeMessageCopy: vi.fn() });
 
-beforeEach(() => { query.mockReset(); fanOutReadToSiblings.mockReset(); });
+beforeEach(() => query.mockReset());
 
-describe('resolveLabelCopyUid', () => {
+describe('label copy primitives', () => {
   it('uses the acted row directly when it already lives in the folder', async () => {
-    const uid = await resolveLabelCopyUid({ folder: 'Todo', uid: 42, account_id: 'a', message_id: '<m>' }, 'Todo');
-    expect(uid).toBe(42);
-    expect(query).not.toHaveBeenCalled(); // no DB lookup needed
+    await expect(resolveLabelCopyUid(
+      { folder: 'Todo', uid: 42, account_id: 'a', message_id: '<m>' }, 'Todo',
+    )).resolves.toBe(42);
+    expect(query).not.toHaveBeenCalled();
   });
 
-  it('resolves the sibling copy via shared Message-ID otherwise', async () => {
-    query.mockResolvedValueOnce({ rows: [{ uid: 99 }] });
-    const uid = await resolveLabelCopyUid({ folder: 'INBOX', uid: 1, account_id: 'a', message_id: '<m>' }, 'Todo');
-    expect(uid).toBe(99);
-    const [sql, params] = query.mock.calls[0];
-    expect(sql).toMatch(/FROM messages WHERE account_id = \$1 AND folder = \$2 AND message_id = \$3/);
-    expect(params).toEqual(['a', 'Todo', '<m>']);
+  it('resolves a sibling copy by account, folder, and Message-ID', async () => {
+    query.mockResolvedValueOnce({ rows: [{
+      id: 'row-99', account_id: 'a', uid: 99, folder: 'Todo',
+      folder_uid_validity: '202', folder_observation_generation: '8',
+    }] });
+    await expect(resolveLabelCopyUid(
+      { folder: 'INBOX', uid: 1, account_id: 'a', message_id: '<m>' }, 'Todo',
+    )).resolves.toBe(99);
+    expect(query.mock.calls[0][0]).toMatch(/m\.account_id = \$1 AND m\.folder = \$2 AND m\.message_id = \$3/);
+    expect(query.mock.calls[0][0]).toMatch(/JOIN folders/);
+    expect(query.mock.calls[0][0]).toMatch(/metadata_complete = true/);
+    expect(query.mock.calls[0][0]).toMatch(/uid_validity IS NOT NULL/);
+    expect(query.mock.calls[0][1]).toEqual(['a', 'Todo', '<m>']);
   });
 
-  it('returns null when no sibling exists, and when the message has no Message-ID', async () => {
+  it('returns null when no sibling exists or the source lacks Message-ID', async () => {
     query.mockResolvedValueOnce({ rows: [] });
-    expect(await resolveLabelCopyUid({ folder: 'INBOX', uid: 1, account_id: 'a', message_id: '<m>' }, 'Todo')).toBeNull();
-    expect(await resolveLabelCopyUid({ folder: 'INBOX', uid: 1, account_id: 'a', message_id: null }, 'Todo')).toBeNull();
+    await expect(resolveLabelCopyUid(
+      { folder: 'INBOX', uid: 1, account_id: 'a', message_id: '<m>' }, 'Todo',
+    )).resolves.toBeNull();
+    await expect(resolveLabelCopyUid(
+      { folder: 'INBOX', uid: 1, account_id: 'a', message_id: null }, 'Todo',
+    )).resolves.toBeNull();
   });
-});
 
-describe('applyLabel', () => {
-  it('returns the exact UIDPLUS destination identity after copying', async () => {
+  it('fails closed when Message-ID discovers more than one eligible sibling', async () => {
+    query.mockResolvedValueOnce({ rows: [
+      { id: 'row-a', uid: 9, folder: 'Todo' },
+      { id: 'row-b', uid: 10, folder: 'Todo' },
+    ] });
+    await expect(resolveLabelCopyUid(
+      { folder: 'INBOX', uid: 1, account_id: 'a', message_id: '<duplicate>' }, 'Todo',
+    )).rejects.toMatchObject({ code: 'AMBIGUOUS_LABEL_COPY' });
+    expect(query.mock.calls[0][0]).not.toMatch(/LIMIT 1/);
+  });
+
+  it('ensures the target folder, copies an exact snapshot, and returns its destination UID', async () => {
     const imap = mkImap();
     imap.copyMessage.mockResolvedValueOnce(77);
-    const r = await applyLabel(imap, account, { uid: 7, folder: 'INBOX' }, 'Todo');
-    expect(r).toEqual({ applied: true, uid: 77 });
+    const message = {
+      id: 'row-7', account_id: 'acct-1', uid: 7, folder: 'INBOX',
+      folder_uid_validity: '101', folder_observation_generation: '4',
+      read_revision: 2, star_revision: 3,
+    };
+    await expect(applyLabel(
+      imap, account, message, 'Todo', { operationKey: 'label-1' },
+    )).resolves.toEqual({ applied: true, uid: 77 });
     expect(imap.ensureFolder).toHaveBeenCalledWith(account, 'Todo');
-    expect(imap.copyMessage).toHaveBeenCalledWith('acct-1', 7, 'INBOX', 'Todo');
+    expect(imap.copyMessage).toHaveBeenCalledWith(
+      'acct-1', 7, 'INBOX', 'Todo', {
+        operationKey: 'label-1',
+        snapshot: {
+          id: 'row-7', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+          uidValidity: '101', folderGeneration: '4', readRevision: 2, starRevision: 3,
+        },
+      },
+    );
   });
 
   it('reports a successful non-UIDPLUS copy without inventing an identity', async () => {
@@ -80,17 +115,31 @@ describe('applyLabel', () => {
 
 describe('removeExactLabelCopy', () => {
   const source = { account_id: 'acct-1', message_id: '<source@example.com>', thread_key: 'thread-1' };
+  const exactCopy = {
+    id: 'row-77', account_id: 'acct-1', uid: 77, folder: 'Todo',
+    folder_uid_validity: 202, folder_observation_generation: 8,
+    read_revision: 2, star_revision: 3,
+  };
 
   it('removes only the requested UID when it belongs to the exact source message', async () => {
-    query.mockResolvedValueOnce({ rows: [{ uid: 77 }] });
+    query.mockResolvedValueOnce({ rows: [exactCopy] });
     const imap = mkImap();
+    imap.removeMessageCopy.mockResolvedValueOnce(1);
     const result = await removeExactLabelCopy(imap, source, 'Todo', 77);
 
-    expect(result).toEqual({ removed: true });
+    expect(result).toEqual({ removed: true, alreadyGone: false });
     expect(query).toHaveBeenCalledWith(expect.stringMatching(/message_id = \$4/), [
       'acct-1', 'Todo', 77, '<source@example.com>',
     ]);
-    expect(imap.removeMessageCopy).toHaveBeenCalledWith('acct-1', 77, 'Todo');
+    expect(imap.removeMessageCopy).toHaveBeenCalledWith('acct-1', 77, 'Todo', {
+      expectedId: 'row-77',
+      expectedUidValidity: 202,
+      notify: true,
+      snapshot: {
+        id: 'row-77', accountId: 'acct-1', uid: 77, folder: 'Todo',
+        uidValidity: '202', folderGeneration: '8', readRevision: 2, starRevision: 3,
+      },
+    });
   });
 
   it('does not remove an absent UID or a UID belonging to another message', async () => {
@@ -117,86 +166,271 @@ describe('removeExactLabelCopy', () => {
   });
 });
 
-describe('removeLabel', () => {
-  it('removes the resolved sibling copy from the label folder', async () => {
-    query.mockResolvedValueOnce({ rows: [{ uid: 99 }] });
+describe('label removal and folder setup', () => {
+  it('does not copy a message already in the label folder', async () => {
     const imap = mkImap();
-    const r = await removeLabel(imap, { account_id: 'acct-1', uid: 1, folder: 'INBOX', message_id: '<m>' }, 'Todo');
-    expect(r).toEqual({ removed: true });
-    expect(imap.removeMessageCopy).toHaveBeenCalledWith('acct-1', 99, 'Todo');
+    await expect(applyLabel(imap, account, { uid: 7, folder: 'Todo' }, 'Todo'))
+      .resolves.toEqual({ applied: false, uid: 7, reason: 'already-there' });
+    expect(imap.ensureFolder).not.toHaveBeenCalled();
+    expect(imap.copyMessage).not.toHaveBeenCalled();
   });
 
-  it('is a no-op (no IMAP call) when no copy lives in the label folder', async () => {
-    query.mockResolvedValueOnce({ rows: [] });
+  it('removes a resolved sibling and no-ops when none exists', async () => {
+    query.mockResolvedValueOnce({ rows: [{
+      id: 'label-row', account_id: 'acct-1', uid: 99, folder: 'Todo',
+      folder_uid_validity: '202', folder_observation_generation: '8',
+    }] }).mockResolvedValueOnce({ rows: [] });
     const imap = mkImap();
-    const r = await removeLabel(imap, { account_id: 'acct-1', uid: 1, folder: 'INBOX', message_id: '<m>' }, 'Todo');
-    expect(r).toEqual({ removed: false });
-    expect(imap.removeMessageCopy).not.toHaveBeenCalled();
+    const source = { account_id: 'acct-1', uid: 1, folder: 'INBOX', message_id: '<m>' };
+    await expect(removeLabel(imap, source, 'Todo')).resolves.toEqual({ removed: true });
+    await expect(removeLabel(imap, source, 'Watch')).resolves.toEqual({ removed: false });
+    expect(imap.removeMessageCopy).toHaveBeenCalledOnce();
+    expect(imap.removeMessageCopy).toHaveBeenCalledWith('acct-1', 99, 'Todo', {
+      expectedId: 'label-row', expectedUidValidity: '202',
+      snapshot: expect.objectContaining({ id: 'label-row', folderGeneration: '8' }),
+    });
   });
-});
 
-describe('ensureLabelFolders', () => {
-  it('dedupes paths, resolves each to its real server path, and reports created', async () => {
+  it('removes one exact snapshot row and preserves UIDVALIDITY', async () => {
+    const imap = mkImap();
+    imap.removeMessageCopy.mockResolvedValueOnce(1);
+    const row = {
+      id: 'row-1', account_id: 'acct-1', uid: 99, folder: 'Todo', folder_uid_validity: 123,
+    };
+    await expect(removeLabelRow(imap, row, { notify: false })).resolves.toEqual({
+      removed: true, alreadyGone: false,
+    });
+    expect(imap.removeMessageCopy).toHaveBeenCalledWith('acct-1', 99, 'Todo', {
+      expectedId: 'row-1', notify: false, expectedUidValidity: 123,
+      snapshot: expect.objectContaining({ id: 'row-1', uidValidity: '123' }),
+    });
+  });
+
+  it('treats an exact row already removed concurrently as idempotent success', async () => {
+    const imap = mkImap();
+    imap.removeMessageCopy.mockResolvedValueOnce(0);
+    await expect(removeLabelRow(imap, {
+      id: 'row-1', account_id: 'acct-1', uid: 99, folder: 'Todo',
+    }, { notify: false })).resolves.toEqual({ removed: false, alreadyGone: true });
+  });
+
+  it('deduplicates and resolves label folder creation independently', async () => {
     const imap = { ensureFolder: vi.fn()
       .mockResolvedValueOnce({ path: 'INBOX.Todo', created: true })
       .mockResolvedValueOnce({ path: 'INBOX.Watch', created: false }) };
-    const results = await ensureLabelFolders(imap, account, ['Todo', 'Watch', 'Todo']);
-    expect(results).toEqual([
-      { folder: 'Todo', path: 'INBOX.Todo', created: true },
-      { folder: 'Watch', path: 'INBOX.Watch', created: false },
-    ]);
-    expect(imap.ensureFolder).toHaveBeenCalledTimes(2); // 'Todo' deduped
-    expect(imap.ensureFolder).toHaveBeenCalledWith(account, 'Todo', { resolvePath: true });
+    await expect(ensureLabelFolders(imap, account, ['Todo', 'Watch', 'Todo']))
+      .resolves.toEqual([
+        { folder: 'Todo', path: 'INBOX.Todo', created: true },
+        { folder: 'Watch', path: 'INBOX.Watch', created: false },
+      ]);
+    expect(imap.ensureFolder).toHaveBeenCalledTimes(2);
   });
 
-  it('isolates a single folder failure and continues with the rest', async () => {
+  it('isolates one label-folder failure and continues', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
     const imap = { ensureFolder: vi.fn()
       .mockRejectedValueOnce(new Error('nope'))
       .mockResolvedValueOnce({ path: 'Watch', created: true }) };
-    const results = await ensureLabelFolders(imap, account, ['Todo', 'Watch']);
-    expect(results).toEqual([
-      { folder: 'Todo', error: true },
-      { folder: 'Watch', path: 'Watch', created: true },
-    ]);
+    try {
+      await expect(ensureLabelFolders(imap, account, ['Todo', 'Watch'])).resolves.toEqual([
+        { folder: 'Todo', error: true },
+        { folder: 'Watch', path: 'Watch', created: true },
+      ]);
+    } finally {
+      error.mockRestore();
+    }
   });
 });
 
-describe('markThreadRead', () => {
-  const msg = { account_id: 'acct-1', message_id: '<m>' };
-  const imapMR = () => ({ setFlag: vi.fn() });
+const exactRows = [
+  { id: 'i1', account_id: 'acct-1', uid: 5, folder: 'INBOX', is_read: false,
+    folder_uid_validity: 101, folder_observation_generation: 201,
+    read_revision: 0, star_revision: 0 },
+  { id: 't1', account_id: 'acct-1', uid: 9, folder: 'Todo', is_read: false,
+    folder_uid_validity: 102, folder_observation_generation: 202,
+    read_revision: 3, star_revision: 1 },
+  { id: 's1', account_id: 'acct-1', uid: 11, folder: 'Sent', is_read: true,
+    folder_uid_validity: 103, folder_observation_generation: 203,
+    read_revision: 4, star_revision: 2 },
+];
+const confirmedSeen = (changed, revision = 1) => ({
+  changed,
+  acceptance: { delivery: { revision } },
+  delivery: { state: 'confirmed' },
+});
 
-  it('fans out read state and sets \\Seen on an unread INBOX copy; returns the copy', async () => {
-    query.mockResolvedValueOnce({ rows: [{ id: 'i1', uid: 5, is_read: false }] });
-    const imap = imapMR();
-    const r = await markThreadRead(imap, { id: 'acct-1' }, msg);
-    expect(fanOutReadToSiblings).toHaveBeenCalledWith('acct-1', '<m>', true);
-    expect(imap.setFlag).toHaveBeenCalledWith({ id: 'acct-1' }, 5, 'INBOX', '\\Seen', true);
-    expect(r.inboxCopy).toEqual({ id: 'i1', uid: 5, is_read: false });
-    expect(r.error).toBeUndefined();
+describe('revisioned desired Seen fan-out', () => {
+  it('returns the exact post-acceptance revision for destructive snapshot handoff', async () => {
+    const imap = { setDesiredFlag: vi.fn().mockResolvedValue({
+      changed: true,
+      acceptance: { delivery: { revision: 9 } },
+      delivery: { state: 'confirmed' },
+    }) };
+
+    await expect(markThreadRowsRead(imap, account, [exactRows[0]])).resolves.toMatchObject({
+      changedCount: 1,
+      seenFailedCount: 0,
+      postSeenRows: [{ ...exactRows[0], is_read: true, read_revision: 9 }],
+    });
   });
 
-  it('skips the flag push when the INBOX copy is already read', async () => {
-    query.mockResolvedValueOnce({ rows: [{ id: 'i1', uid: 5, is_read: true }] });
-    const imap = imapMR();
-    await markThreadRead(imap, { id: 'acct-1' }, msg);
-    expect(fanOutReadToSiblings).toHaveBeenCalled();
+  it('terminates the frozen Seen lifecycle when the desired row snapshot is superseded', async () => {
+    const imap = { setDesiredFlag: vi.fn().mockRejectedValue(Object.assign(
+      new Error('row moved'),
+      { code: 'DESIRED_FLAG_ROW_SUPERSEDED', retryable: true },
+    )) };
+
+    await expect(markThreadRowsRead(imap, account, [exactRows[0]])).rejects.toMatchObject({
+      code: 'DESIRED_FLAG_ROW_SUPERSEDED', retryable: false,
+    });
+  });
+
+  it('creates one independent exact-row delivery for every GTD snapshot row', async () => {
+    const imap = { setDesiredFlag: vi.fn()
+      .mockResolvedValueOnce(confirmedSeen(true))
+      .mockResolvedValueOnce(confirmedSeen(true, 4))
+      .mockResolvedValueOnce(confirmedSeen(false, 5)) };
+    await expect(markThreadRowsRead(imap, account, exactRows)).resolves.toEqual({
+      changedCount: 2, seenFailedCount: 0,
+      postSeenRows: [
+        { ...exactRows[0], is_read: true, read_revision: 1 },
+        { ...exactRows[1], is_read: true, read_revision: 4 },
+        { ...exactRows[2], is_read: true, read_revision: 5 },
+      ],
+    });
+    expect(imap.setDesiredFlag).toHaveBeenCalledTimes(3);
+    expect(imap.setDesiredFlag).toHaveBeenNthCalledWith(
+      1, account, 'i1', '\\Seen', true,
+      { snapshot: expect.objectContaining({
+        id: 'i1', accountId: 'acct-1', uid: 5, folder: 'INBOX',
+        uidValidity: '101', folderGeneration: '201', readRevision: 0,
+      }) },
+    );
+  });
+
+  it('awaits every delivery before destructive GTD work can continue', async () => {
+    let release;
+    const imap = { setDesiredFlag: vi.fn(() => new Promise(resolve => { release = resolve; })) };
+    let settled = false;
+    const pending = markThreadRowsRead(imap, account, [exactRows[0]])
+      .then(result => { settled = true; return result; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    release(confirmedSeen(true));
+    await expect(pending).resolves.toEqual({
+      changedCount: 1, seenFailedCount: 0,
+      postSeenRows: [{ ...exactRows[0], is_read: true, read_revision: 1 }],
+    });
+  });
+
+  it('continues independently after uncertainty and reports the failed delivery', async () => {
+    const imap = { setDesiredFlag: vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('disconnect'), { uncertain: true }))
+      .mockResolvedValueOnce(confirmedSeen(true, 4)) };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await expect(markThreadRowsRead(imap, account, exactRows.slice(0, 2)))
+        .resolves.toEqual({
+          changedCount: 1, seenFailedCount: 1,
+          postSeenRows: [{ ...exactRows[1], is_read: true, read_revision: 4 }],
+        });
+      expect(imap.setDesiredFlag).toHaveBeenCalledTimes(2);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('blocks GTD destructive work when non-CONDSTORE delivery resolves uncertain', async () => {
+    const imap = { setDesiredFlag: vi.fn().mockResolvedValue({
+      changed: true,
+      delivery: { state: 'uncertain', condstore: false, uncertaintyTombstones: [{}] },
+    }) };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await expect(markThreadRowsRead(imap, account, [exactRows[0]])).resolves.toEqual({
+        changedCount: 1, seenFailedCount: 1,
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('blocks GTD destructive work when same-MODSEQ reassertion remains uncertain', async () => {
+    const imap = { setDesiredFlag: vi.fn().mockResolvedValue({
+      changed: false,
+      delivery: {
+        state: 'uncertain', condstore: true, capturedModseq: '44',
+        uncertaintyTombstones: [{ baseline: '44' }],
+      },
+    }) };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await expect(markThreadRowsRead(imap, account, [exactRows[2]])).resolves.toEqual({
+        changedCount: 0, seenFailedCount: 1,
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('reasserts Seen even for rows already read locally', async () => {
+    const imap = { setDesiredFlag: vi.fn().mockResolvedValue({
+      ...confirmedSeen(false, 5),
+    }) };
+    await expect(markThreadRowsRead(imap, account, [exactRows[2]])).resolves.toEqual({
+      changedCount: 0, seenFailedCount: 0,
+      postSeenRows: [{ ...exactRows[2], is_read: true, read_revision: 5 }],
+    });
+    expect(imap.setDesiredFlag).toHaveBeenCalledOnce();
+  });
+
+  it('deduplicates duplicate snapshot ids and handles an empty snapshot', async () => {
+    const imap = { setDesiredFlag: vi.fn().mockResolvedValue({
+      ...confirmedSeen(true),
+    }) };
+    await expect(markThreadRowsRead(imap, account, [exactRows[0], exactRows[0]]))
+      .resolves.toEqual({
+        changedCount: 1, seenFailedCount: 0,
+        postSeenRows: [{ ...exactRows[0], is_read: true, read_revision: 1 }],
+      });
+    await expect(markThreadRowsRead(imap, account, [])).resolves.toEqual({
+      changedCount: 0, seenFailedCount: 0,
+    });
+    expect(imap.setDesiredFlag).toHaveBeenCalledOnce();
+  });
+
+  it('uses exact live sibling rows for thread fan-out and never provider-mutates by Message-ID', async () => {
+    query.mockResolvedValueOnce({ rows: exactRows });
+    const imap = { setDesiredFlag: vi.fn().mockResolvedValue({ changed: true }), setFlag: vi.fn() };
+    const result = await markThreadRead(imap, account, {
+      account_id: 'acct-1', message_id: '<thread@example>',
+    });
+    expect(query.mock.calls[0][0]).toMatch(/JOIN folders/);
+    expect(query.mock.calls[0][0]).toMatch(/metadata_complete = true/);
+    expect(imap.setDesiredFlag).toHaveBeenCalledTimes(3);
     expect(imap.setFlag).not.toHaveBeenCalled();
+    expect(result.inboxCopy).toEqual(exactRows[0]);
   });
 
-  it('handles no INBOX copy (nothing to flag, inboxCopy null)', async () => {
+  it('returns the Inbox anchor plus an error if one independent delivery fails', async () => {
+    query.mockResolvedValueOnce({ rows: exactRows });
+    const imap = { setDesiredFlag: vi.fn()
+      .mockResolvedValueOnce({ changed: true })
+      .mockRejectedValueOnce(new Error('delivery failed')) };
+    const result = await markThreadRead(imap, account, {
+      account_id: 'acct-1', message_id: '<thread@example>',
+    });
+    expect(result.inboxCopy).toEqual(exactRows[0]);
+    expect(result.error).toMatchObject({ message: 'delivery failed' });
+    expect(imap.setDesiredFlag).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns a null Inbox anchor and performs no delivery when no live siblings remain', async () => {
     query.mockResolvedValueOnce({ rows: [] });
-    const imap = imapMR();
-    const r = await markThreadRead(imap, { id: 'acct-1' }, msg);
-    expect(r.inboxCopy).toBeNull();
-    expect(imap.setFlag).not.toHaveBeenCalled();
-  });
-
-  it('degrades gracefully: a fan-out failure returns the copy + error, never throws', async () => {
-    query.mockResolvedValueOnce({ rows: [{ id: 'i1', uid: 5, is_read: false }] });
-    fanOutReadToSiblings.mockRejectedValueOnce(new Error('db down'));
-    const imap = imapMR();
-    const r = await markThreadRead(imap, { id: 'acct-1' }, msg);
-    expect(r.inboxCopy).toEqual({ id: 'i1', uid: 5, is_read: false }); // still available for archive
-    expect(r.error).toBeInstanceOf(Error);
+    const imap = { setDesiredFlag: vi.fn() };
+    await expect(markThreadRead(imap, account, {
+      account_id: 'acct-1', message_id: '<thread@example>',
+    })).resolves.toEqual({ inboxCopy: null });
+    expect(imap.setDesiredFlag).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/labelsRead.js
+++ b/backend/src/services/labelsRead.js
@@ -31,8 +31,13 @@ const SECTION_SQL = `
     SELECT m.id, m.account_id, m.thread_key, m.message_id, m.folder,
            m.subject, m.from_name, m.from_email, m.date, m.snippet, m.is_read, m.is_starred, m.uid
     FROM messages m
+    JOIN folders live_folder ON live_folder.account_id = m.account_id
+      AND live_folder.path = m.folder
+      AND live_folder.is_present = true
+      AND live_folder.uid_validity IS NOT NULL
     WHERE m.account_id = $1
       AND m.is_deleted = false
+      AND m.metadata_complete = true
       AND m.folder <> ALL($4::text[])
   ),
   folders_agg AS (

--- a/backend/src/services/labelsRead.test.js
+++ b/backend/src/services/labelsRead.test.js
@@ -18,6 +18,10 @@ describe('listThreadHeadsByLabels', () => {
     });
     expect(rows).toEqual([{ state: 'todo', total: 3, unread: 1 }]);
     const [sql, params] = query.mock.calls[0];
+    expect(sql).toContain('m.metadata_complete = true');
+    expect(sql).toMatch(/JOIN folders live_folder/);
+    expect(sql).toContain('live_folder.is_present = true');
+    expect(sql).toContain('live_folder.uid_validity IS NOT NULL');
     expect(sql).toMatch(/WITH gtd\(state, folder\)/);       // the thread-aware CTE
     expect(sql).toMatch(/bool_or\(NOT is_read\)\s+AS thread_unread/); // thread-level unread
     expect(params).toEqual(['acct-1', ['todo', 'watch'], ['Todo', 'Watch'], ['Drafts'], 8, ['watch']]);

--- a/backend/src/services/mailAccess.js
+++ b/backend/src/services/mailAccess.js
@@ -8,15 +8,119 @@
 // userId and enforce ownership. Account-scoped reads take an accountId the caller has already
 // established it owns (via one of the user-keyed reads) and only ever read within that account —
 // they never span accounts or users.
-import { query } from './db.js';
+import { createHash } from 'node:crypto';
+import { query, withTransaction } from './db.js';
+
+function canonicalValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (!value || typeof value !== 'object') return value;
+  if (value instanceof Date) return value.toISOString();
+  return Object.fromEntries(Object.keys(value).sort().map(key => [key, canonicalValue(value[key])]));
+}
+
+function snapshotVersion(snapshot) {
+  const canonical = JSON.stringify(canonicalValue({
+    userId: snapshot.userId,
+    pluginId: snapshot.pluginId,
+    anchorId: snapshot.anchorId,
+    account: snapshot.account,
+    config: snapshot.config,
+    configUpdatedAt: snapshot.configUpdatedAt,
+    activated: snapshot.activated,
+    threadKey: snapshot.threadKey,
+    rows: snapshot.rows,
+  }));
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+export async function readPluginThreadSnapshot(tx, userId, messageId, pluginId) {
+  const anchorResult = await tx.query(
+    `SELECT m.id AS anchor_id, m.account_id, m.thread_key,
+            jsonb_build_object(
+              'id', a.id,
+              'user_id', a.user_id,
+              'enabled', a.enabled,
+              'folder_mappings', COALESCE(a.folder_mappings, '{}'::jsonb),
+              'mailbox_topology_generation', a.mailbox_topology_generation
+            ) AS account,
+            COALESCE(pac.config, '{}'::jsonb) AS plugin_config,
+            pac.updated_at AS plugin_config_updated_at,
+            COALESCE(u.preferences -> 'enabledPlugins', '[]'::jsonb) AS enabled_plugins
+       FROM messages m
+       JOIN email_accounts a ON a.id = m.account_id
+       JOIN users u ON u.id = a.user_id
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+       LEFT JOIN plugin_account_config pac
+         ON pac.account_id = a.id AND pac.plugin_id = $3
+      WHERE m.id = $1 AND a.user_id = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL`,
+    [messageId, userId, pluginId],
+  );
+  const anchor = anchorResult.rows[0];
+  if (!anchor?.thread_key) return null;
+  const threadResult = await tx.query(
+    `SELECT m.id, m.account_id, m.thread_key, m.uid, m.folder, m.message_id, m.is_read,
+            m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation,
+            f.topology_identity AS folder_topology_identity
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+      WHERE m.account_id = $1 AND m.thread_key = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL
+      ORDER BY m.folder, m.uid, m.id`,
+    [anchor.account_id, anchor.thread_key],
+  );
+  const enabledPlugins = Array.isArray(anchor.enabled_plugins) ? anchor.enabled_plugins : [];
+  const snapshot = {
+    userId,
+    pluginId,
+    anchorId: anchor.anchor_id,
+    account: anchor.account,
+    config: anchor.plugin_config || {},
+    configUpdatedAt: anchor.plugin_config_updated_at || null,
+    activated: enabledPlugins.includes(pluginId),
+    threadKey: anchor.thread_key,
+    rows: threadResult.rows || [],
+  };
+  if (!snapshot.rows.some(row => row.id === snapshot.anchorId)) return null;
+  return { ...snapshot, version: snapshotVersion(snapshot) };
+}
+
+export async function loadPluginThreadSnapshot(userId, messageId, pluginId) {
+  return withTransaction(async tx => {
+    await tx.query('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY');
+    return readPluginThreadSnapshot(tx, userId, messageId, pluginId);
+  });
+}
+
+export async function validatePluginThreadSnapshot(snapshot) {
+  const current = await loadPluginThreadSnapshot(
+    snapshot.userId, snapshot.anchorId, snapshot.pluginId,
+  );
+  if (!current || current.version !== snapshot.version) {
+    const error = new Error('Plugin thread snapshot was superseded');
+    error.code = 'PLUGIN_THREAD_SNAPSHOT_SUPERSEDED';
+    error.retryable = true;
+    throw error;
+  }
+  return current;
+}
 
 // A message the user owns (joined through their accounts), or null. Full row (m.*).
 export async function loadOwnedMessage(userId, messageId) {
   const { rows } = await query(
-    `SELECT m.*
+    `SELECT m.*, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
        FROM messages m
        JOIN email_accounts a ON a.id = m.account_id
-      WHERE m.id = $1 AND a.user_id = $2`,
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+      WHERE m.id = $1 AND a.user_id = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL`,
     [messageId, userId]
   );
   return rows[0] || null;
@@ -93,10 +197,38 @@ export async function getThreadKeysForMessageIdHeaders(accountId, messageIdHeade
 export async function getMessagesByThreadKeys(accountId, threadKeys) {
   if (!threadKeys || threadKeys.length === 0) return [];
   const { rows } = await query(
-    `SELECT thread_key, uid, folder, from_email, date, id
-       FROM messages
-      WHERE account_id = $1 AND thread_key = ANY($2::text[]) AND is_deleted = false`,
+    `SELECT m.thread_key, m.uid, m.folder, m.from_email, m.date, m.id,
+            m.account_id, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+      WHERE m.account_id = $1 AND m.thread_key = ANY($2::text[])
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL`,
     [accountId, threadKeys]
+  );
+  return rows;
+}
+
+// Exact immutable worklist for a thread mutation. The caller first establishes ownership by
+// loading the acted row and account; this capability stays within that account and returns only
+// verified live rows plus the identity/state needed by core mutation primitives. Late arrivals
+// are intentionally not included: /done acts on the snapshot it authorized, never on a moving
+// thread-key target.
+export async function listLiveThreadRows(accountId, threadKey) {
+  const { rows } = await query(
+    `SELECT m.id, m.account_id, m.thread_key, m.uid, m.folder, m.message_id, m.is_read,
+            m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+      WHERE m.account_id = $1 AND m.thread_key = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL
+      ORDER BY m.folder, m.uid, m.id`,
+    [accountId, threadKey]
   );
   return rows;
 }
@@ -125,13 +257,90 @@ export async function getMessageCopyFolders(accountId, messageIdHeader) {
 export async function getMessageFields(accountId, ids) {
   if (!ids || ids.length === 0) return [];
   const { rows } = await query(
-    `SELECT id, subject, from_name, from_email,
-            COALESCE(NULLIF(body_text, ''), snippet) AS content
-       FROM messages
-      WHERE id = ANY($1::uuid[]) AND account_id = $2`,
+    `SELECT m.id, m.uid, m.folder, m.subject, m.from_name, m.from_email,
+            m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation,
+            COALESCE(NULLIF(m.body_text, ''), m.snippet) AS content
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+      WHERE m.id = ANY($1::uuid[]) AND m.account_id = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL`,
     [ids, accountId]
   );
   return rows;
+}
+
+function messageFieldsSnapshotValues(snapshot) {
+  return [
+    snapshot.uid,
+    snapshot.folder,
+    snapshot.read_revision,
+    snapshot.star_revision,
+    snapshot.folder_uid_validity,
+    snapshot.folder_observation_generation,
+    snapshot.subject ?? null,
+    snapshot.from_name ?? null,
+    snapshot.from_email ?? null,
+    snapshot.content ?? null,
+  ];
+}
+
+function messageFieldsSnapshotPredicate(startIndex) {
+  const p = Array.from({ length: 10 }, (_, index) => `$${startIndex + index}`);
+  return `m.uid = ${p[0]} AND m.folder = ${p[1]}
+        AND m.read_revision = ${p[2]} AND m.star_revision = ${p[3]}
+        AND f.uid_validity = ${p[4]} AND f.observation_generation = ${p[5]}
+        AND m.subject IS NOT DISTINCT FROM ${p[6]}
+        AND m.from_name IS NOT DISTINCT FROM ${p[7]}
+        AND m.from_email IS NOT DISTINCT FROM ${p[8]}
+        AND COALESCE(NULLIF(m.body_text, ''), m.snippet) IS NOT DISTINCT FROM ${p[9]}`;
+}
+
+// Recheck the exact live row snapshot immediately before an external/content-derived action.
+// Returning false (rather than a partially refreshed row) makes callers explicitly restart from
+// a fresh actionable read after any row revision, folder epoch, or summarized-content change.
+export async function validateMessageFieldsSnapshot(accountId, snapshot) {
+  if (!accountId || !snapshot?.id) return false;
+  const { rows } = await query(
+    `SELECT 1
+       FROM messages m
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+      WHERE m.account_id = $1 AND m.id = $2
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL
+        AND ${messageFieldsSnapshotPredicate(3)}
+      LIMIT 1`,
+    [accountId, snapshot.id, ...messageFieldsSnapshotValues(snapshot)],
+  );
+  return rows.length === 1;
+}
+
+// Snapshot-CAS variant for content-derived annotations. The second validation in the caller is
+// intentionally backed by this predicate again so a row cannot become stale in the final await
+// gap between validation and UPDATE.
+export async function setMessageAnnotationForSnapshot(accountId, snapshot, pluginId, patch) {
+  if (!accountId || !snapshot?.id) return 0;
+  const { rowCount } = await query(
+    `UPDATE messages m
+        SET plugin_annotations = jsonb_set(
+              COALESCE(m.plugin_annotations, '{}'::jsonb),
+              ARRAY[$3::text],
+              COALESCE(m.plugin_annotations -> $3, '{}'::jsonb) || $4::jsonb,
+              true)
+       FROM folders f
+      WHERE m.account_id = $1 AND m.id = $2
+        AND f.account_id = m.account_id AND f.path = m.folder
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL
+        AND ${messageFieldsSnapshotPredicate(5)}`,
+    [
+      accountId, snapshot.id, pluginId, JSON.stringify(patch),
+      ...messageFieldsSnapshotValues(snapshot),
+    ],
+  );
+  return rowCount;
 }
 
 // A plugin's own per-message annotations for a set of message ids within an account, as

--- a/backend/src/services/mailAccess.test.js
+++ b/backend/src/services/mailAccess.test.js
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./db.js', () => ({
+  query: vi.fn(),
+  withTransaction: vi.fn(callback => callback({ query })),
+}));
+
+import { query, withTransaction } from './db.js';
+import {
+  getMessagesByThreadKeys,
+  listLiveThreadRows,
+  loadOwnedMessage,
+  loadPluginThreadSnapshot,
+  validatePluginThreadSnapshot,
+} from './mailAccess.js';
+import * as mailAccess from './mailAccess.js';
+
+describe('loadOwnedMessage', () => {
+  beforeEach(() => query.mockReset());
+
+  it('hides deleted or metadata-incomplete anchors from plugin mutations', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(loadOwnedMessage('user-1', 'row-1')).resolves.toBeNull();
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/m\.is_deleted = false/);
+    expect(sql).toMatch(/m\.metadata_complete = true/);
+    expect(sql).toMatch(/JOIN folders f/);
+    expect(sql).toMatch(/f\.is_present = true/);
+    expect(sql).toMatch(/f\.uid_validity IS NOT NULL/);
+    expect(sql).toMatch(/f\.uid_validity AS folder_uid_validity/);
+    expect(sql).toMatch(/f\.observation_generation AS folder_observation_generation/);
+    expect(sql).toMatch(/m\.read_revision/);
+    expect(sql).toMatch(/m\.star_revision/);
+    expect(params).toEqual(['row-1', 'user-1']);
+  });
+});
+
+describe('getMessagesByThreadKeys', () => {
+  beforeEach(() => query.mockReset());
+
+  it('returns only complete rows backed by a present epochful folder', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    await getMessagesByThreadKeys('acct-1', ['thread-1']);
+    const [sql] = query.mock.calls[0];
+    expect(sql).toMatch(/JOIN folders f/);
+    expect(sql).toMatch(/metadata_complete = true/);
+    expect(sql).toMatch(/f\.is_present = true/);
+    expect(sql).toMatch(/f\.uid_validity IS NOT NULL/);
+    expect(sql).toMatch(/folder_observation_generation/);
+  });
+});
+
+describe('listLiveThreadRows', () => {
+  beforeEach(() => query.mockReset());
+
+  it('loads only live rows from the acted account and thread with a bounded field set', async () => {
+    const rows = [{
+      id: 'row-1', account_id: 'acct-1', thread_key: 'thread-1', uid: 7,
+      folder: 'INBOX', message_id: null, is_read: false, folder_uid_validity: 123,
+    }];
+    query.mockResolvedValueOnce({ rows });
+
+    await expect(listLiveThreadRows('acct-1', 'thread-1')).resolves.toEqual(rows);
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/account_id = \$1/);
+    expect(sql).toMatch(/thread_key = \$2/);
+    expect(sql).toMatch(/is_deleted = false/);
+    expect(sql).toMatch(/metadata_complete = true/);
+    expect(sql).toMatch(/JOIN folders f/);
+    expect(sql).toMatch(/f\.uid_validity AS folder_uid_validity/);
+    expect(sql).toMatch(/f\.observation_generation AS folder_observation_generation/);
+    expect(sql).toMatch(/m\.read_revision/);
+    expect(sql).toMatch(/m\.star_revision/);
+    expect(sql).toMatch(/f\.is_present = true/);
+    expect(sql).toMatch(/f\.uid_validity IS NOT NULL/);
+    expect(sql).not.toMatch(/SELECT \*/);
+    expect(params).toEqual(['acct-1', 'thread-1']);
+    expect(sql).toMatch(/ORDER BY m\.folder, m\.uid, m\.id/);
+  });
+
+  it('returns an empty immutable worklist when the thread no longer has live rows', async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+    await expect(listLiveThreadRows('acct-1', 'thread-1')).resolves.toEqual([]);
+  });
+});
+
+describe('GTD gist message-field snapshots', () => {
+  const snapshot = {
+    id: 'row-1', uid: '7', folder: 'Watch', subject: 'Subject',
+    from_name: 'Alice', from_email: 'alice@example.com', content: 'Body',
+    read_revision: '4', star_revision: '2',
+    folder_uid_validity: '88', folder_observation_generation: '6',
+  };
+
+  beforeEach(() => query.mockReset());
+
+  it('loads only live metadata-complete rows and returns the exact row and folder revisions', async () => {
+    query.mockResolvedValueOnce({ rows: [snapshot] });
+
+    await expect(mailAccess.getMessageFields('acct-1', ['row-1'])).resolves.toEqual([snapshot]);
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/JOIN folders f/);
+    expect(sql).toMatch(/m\.is_deleted = false/);
+    expect(sql).toMatch(/m\.metadata_complete = true/);
+    expect(sql).toMatch(/f\.is_present = true/);
+    expect(sql).toMatch(/f\.uid_validity IS NOT NULL/);
+    expect(sql).toMatch(/m\.uid/);
+    expect(sql).toMatch(/m\.folder/);
+    expect(sql).toMatch(/m\.read_revision/);
+    expect(sql).toMatch(/m\.star_revision/);
+    expect(sql).toMatch(/f\.uid_validity AS folder_uid_validity/);
+    expect(sql).toMatch(/f\.observation_generation AS folder_observation_generation/);
+    expect(params).toEqual([['row-1'], 'acct-1']);
+  });
+
+  it('revalidates every exact identity, revision, epoch, and summarized field fail closed', async () => {
+    expect(mailAccess.validateMessageFieldsSnapshot).toBeTypeOf('function');
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await expect(mailAccess.validateMessageFieldsSnapshot('acct-1', snapshot)).resolves.toBe(false);
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/m\.is_deleted = false/);
+    expect(sql).toMatch(/m\.metadata_complete = true/);
+    expect(sql).toMatch(/f\.is_present = true/);
+    expect(sql).toMatch(/f\.uid_validity IS NOT NULL/);
+    expect(sql).toMatch(/m\.uid = \$3/);
+    expect(sql).toMatch(/m\.folder = \$4/);
+    expect(sql).toMatch(/m\.read_revision = \$5/);
+    expect(sql).toMatch(/m\.star_revision = \$6/);
+    expect(sql).toMatch(/f\.uid_validity = \$7/);
+    expect(sql).toMatch(/f\.observation_generation = \$8/);
+    expect(sql).toMatch(/m\.subject IS NOT DISTINCT FROM \$9/);
+    expect(sql).toMatch(/COALESCE\(NULLIF\(m\.body_text, ''\), m\.snippet\) IS NOT DISTINCT FROM \$12/);
+    expect(params).toEqual([
+      'acct-1', 'row-1', '7', 'Watch', '4', '2', '88', '6',
+      'Subject', 'Alice', 'alice@example.com', 'Body',
+    ]);
+  });
+
+  it('writes a plugin annotation only while the exact live snapshot still matches', async () => {
+    expect(mailAccess.setMessageAnnotationForSnapshot).toBeTypeOf('function');
+    query.mockResolvedValueOnce({ rowCount: 0 });
+
+    await expect(mailAccess.setMessageAnnotationForSnapshot(
+      'acct-1', snapshot, 'gtd', { gist: 'Waiting' },
+    )).resolves.toBe(0);
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/UPDATE messages m/);
+    expect(sql).toMatch(/FROM folders f/);
+    expect(sql).toMatch(/m\.is_deleted = false/);
+    expect(sql).toMatch(/m\.metadata_complete = true/);
+    expect(sql).toMatch(/f\.is_present = true/);
+    expect(sql).toMatch(/f\.uid_validity IS NOT NULL/);
+    expect(sql).toMatch(/m\.read_revision = \$7/);
+    expect(sql).toMatch(/f\.observation_generation = \$10/);
+    expect(sql).toMatch(/m\.subject IS NOT DISTINCT FROM \$11/);
+    expect(sql).toMatch(/COALESCE\(NULLIF\(m\.body_text, ''\), m\.snippet\) IS NOT DISTINCT FROM \$14/);
+    expect(params).toEqual([
+      'acct-1', 'row-1', 'gtd', JSON.stringify({ gist: 'Waiting' }),
+      '7', 'Watch', '4', '2', '88', '6', 'Subject', 'Alice', 'alice@example.com', 'Body',
+    ]);
+  });
+});
+
+describe('plugin thread mutation snapshot', () => {
+  const anchor = {
+    anchor_id: 'row-1', account_id: 'acct-1', thread_key: 'thread-1',
+    account: { id: 'acct-1', user_id: 'user-1', mailbox_topology_generation: '7', folder_mappings: {} },
+    plugin_config: { enabled: true, folders: { watch: 'Waiting' } },
+    plugin_config_updated_at: '2026-08-26T12:00:00.000Z',
+    enabled_plugins: ['gtd'],
+  };
+  const rows = [{
+    id: 'row-1', account_id: 'acct-1', thread_key: 'thread-1', uid: 9,
+    folder: 'Waiting', message_id: '<x@example>', is_read: false,
+    read_revision: '4', star_revision: '2', folder_uid_validity: '88',
+    folder_observation_generation: '6',
+  }];
+
+  beforeEach(() => {
+    query.mockReset();
+    withTransaction.mockReset();
+    withTransaction.mockImplementation(callback => callback({ query }));
+  });
+
+  it('freezes ownership, plugin config, thread identity, and exact rows in one repeatable-read snapshot', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [anchor] })
+      .mockResolvedValueOnce({ rows });
+
+    const snapshot = await loadPluginThreadSnapshot('user-1', 'row-1', 'gtd');
+
+    expect(withTransaction).toHaveBeenCalledOnce();
+    expect(query.mock.calls[0][0]).toBe('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY');
+    expect(query.mock.calls[1][0]).toMatch(/a\.user_id = \$2/);
+    expect(query.mock.calls[1][0]).toMatch(/pac\.plugin_id = \$3/);
+    expect(query.mock.calls[1][0]).toMatch(/f\.is_present = true/);
+    expect(query.mock.calls[2][0]).toMatch(/m\.metadata_complete = true/);
+    expect(query.mock.calls[2][0]).toMatch(/ORDER BY m\.folder, m\.uid, m\.id/);
+    expect(snapshot).toMatchObject({
+      userId: 'user-1', pluginId: 'gtd', anchorId: 'row-1',
+      account: anchor.account, config: anchor.plugin_config, activated: true, rows,
+    });
+    expect(snapshot.version).toEqual(expect.any(String));
+  });
+
+  it('rejects a config, thread-row revision, or folder-epoch change before destructive work', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [anchor] })
+      .mockResolvedValueOnce({ rows })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{
+        ...anchor,
+        plugin_config_updated_at: '2026-08-26T12:01:00.000Z',
+      }] })
+      .mockResolvedValueOnce({ rows: [{
+        ...rows[0], read_revision: '5', folder_observation_generation: '7',
+      }] });
+
+    const snapshot = await loadPluginThreadSnapshot('user-1', 'row-1', 'gtd');
+    await expect(validatePluginThreadSnapshot(snapshot)).rejects.toMatchObject({
+      code: 'PLUGIN_THREAD_SNAPSHOT_SUPERSEDED', retryable: true,
+    });
+  });
+});

--- a/backend/src/services/messageService.js
+++ b/backend/src/services/messageService.js
@@ -12,7 +12,12 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
   } = resolveAccountScope(accountsResult.rows, accountId);
   if (!scopedAccountIds.length) return { messages: [], total: 0 };
 
-  let whereConditions = ['m.is_deleted = false'];
+  let whereConditions = [
+    'm.is_deleted = false',
+    'm.metadata_complete = true',
+    'f.is_present = true',
+    'f.uid_validity IS NOT NULL',
+  ];
   const values = [];
   let p = 1;
 
@@ -50,7 +55,9 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
   try {
     if (isSpecificAccount) {
       const r = await query(
-        'SELECT total_count, unread_count FROM folders WHERE account_id = $1 AND path = $2',
+        `SELECT total_count, unread_count FROM folders
+          WHERE account_id = $1 AND path = $2
+            AND is_present = true AND uid_validity IS NOT NULL`,
         [accountId, folder]
       );
       if (r.rows.length) {
@@ -59,11 +66,15 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
     } else {
       const r = isUnreadOnly
         ? await query(
-            "SELECT COALESCE(SUM(unread_count), 0)::int AS n FROM folders WHERE account_id = ANY($1) AND path = 'INBOX'",
+            `SELECT COALESCE(SUM(unread_count), 0)::int AS n FROM folders
+              WHERE account_id = ANY($1) AND path = 'INBOX'
+                AND is_present = true AND uid_validity IS NOT NULL`,
             [scopedAccountIds]
           )
         : await query(
-            "SELECT COALESCE(SUM(total_count), 0)::int AS n FROM folders WHERE account_id = ANY($1) AND path = 'INBOX'",
+            `SELECT COALESCE(SUM(total_count), 0)::int AS n FROM folders
+              WHERE account_id = ANY($1) AND path = 'INBOX'
+                AND is_present = true AND uid_validity IS NOT NULL`,
             [scopedAccountIds]
           );
       total = r.rows[0]?.n ?? 0;
@@ -86,6 +97,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
       WITH paged_threads AS (
         SELECT m.thread_key AS thread_id
         FROM messages m
+        JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
         WHERE ${where}
         GROUP BY m.thread_key
         ORDER BY MAX(m.date) DESC
@@ -106,6 +118,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
                (co.id IS NOT NULL) AS has_contact_photo
         FROM messages m
         JOIN email_accounts a ON m.account_id = a.id
+        JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
         LEFT JOIN contacts co ON co.user_id = a.user_id
                               AND co.primary_email = lower(m.from_email)
                               AND co.photo_data IS NOT NULL
@@ -121,8 +134,12 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
         SELECT m.thread_key AS thread_id,
                COUNT(DISTINCT m.message_id)::int AS message_count
         FROM messages m
+        JOIN folders tf ON tf.account_id = m.account_id AND tf.path = m.folder
         WHERE m.account_id = ANY($${p})
           AND m.is_deleted = false
+          AND m.metadata_complete = true
+          AND tf.is_present = true
+          AND tf.uid_validity IS NOT NULL
           AND m.message_id IS NOT NULL
           ${threadFolderFilter}
           AND m.thread_key IN (SELECT thread_id FROM paged_threads)
@@ -156,6 +173,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
     const threadCountResult = await query(`
       SELECT COUNT(DISTINCT m.thread_key)::int AS total
       FROM messages m
+      JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
       WHERE ${where}
     `, filterValues);
 
@@ -181,6 +199,7 @@ export async function listMessages({ userId, accountId, folder = 'INBOX', limit 
            (co.id IS NOT NULL) AS has_contact_photo
     FROM messages m
     JOIN email_accounts a ON m.account_id = a.id
+    JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
     LEFT JOIN contacts co ON co.user_id = a.user_id
                           AND co.primary_email = lower(m.from_email)
                           AND co.photo_data IS NOT NULL

--- a/backend/src/services/messageService.test.js
+++ b/backend/src/services/messageService.test.js
@@ -186,6 +186,21 @@ describe('listMessages — threaded mode', () => {
 });
 
 describe('listMessages — message shape', () => {
+  it('suppresses legacy rows until an envelope-backed backfill verifies them', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })
+      .mockResolvedValueOnce({ rows: [{ total_count: 1, unread_count: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await listMessages({ userId: 'user-1', accountId: 'acc-1' });
+
+    const sql = query.mock.calls[2][0];
+    expect(sql).toContain('m.metadata_complete = true');
+    expect(sql).toMatch(/JOIN folders f/);
+    expect(sql).toContain('f.is_present = true');
+    expect(sql).toContain('f.uid_validity IS NOT NULL');
+  });
+
   it('selects delivery_addresses in the flat query', async () => {
     query
       .mockResolvedValueOnce({ rows: [{ id: 'acc-1' }] })

--- a/backend/src/services/messageSnapshots.js
+++ b/backend/src/services/messageSnapshots.js
@@ -1,0 +1,136 @@
+import { query, withTransaction } from './db.js';
+
+export class MessageSnapshotError extends Error {
+  constructor(message, { code = 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable = true } = {}) {
+    super(message);
+    this.name = 'MessageSnapshotError';
+    this.code = code;
+    this.retryable = retryable;
+  }
+}
+
+export function snapshotFromMessageRow(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    accountId: row.account_id,
+    uid: Number(row.uid),
+    folder: row.folder,
+    uidValidity: row.folder_uid_validity == null ? null : String(row.folder_uid_validity),
+    folderGeneration: row.folder_observation_generation == null
+      ? null
+      : String(row.folder_observation_generation),
+    readRevision: Number(row.read_revision || 0),
+    starRevision: Number(row.star_revision || 0),
+  };
+}
+
+function notActionable(messageId) {
+  return new MessageSnapshotError(`Message ${messageId} is not actionable`, {
+    code: 'MESSAGE_SNAPSHOT_NOT_ACTIONABLE', retryable: false,
+  });
+}
+
+export async function captureLiveMessageSnapshot(messageId, {
+  accountId,
+  userId,
+  runQuery = query,
+} = {}) {
+  if (!accountId && !userId) throw new Error('A message snapshot requires account or user ownership');
+  const ownership = userId
+    ? 'a.user_id = $2'
+    : 'm.account_id = $2';
+  const result = await runQuery(
+    `SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM messages m
+       JOIN email_accounts a ON a.id = m.account_id
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                     AND f.is_present = true AND f.uid_validity IS NOT NULL
+      WHERE m.id = $1 AND ${ownership}
+        AND m.is_deleted = false AND m.metadata_complete = true`,
+    [messageId, userId || accountId],
+  );
+  const snapshot = snapshotFromMessageRow(result.rows[0]);
+  if (!snapshot || snapshot.uidValidity == null || snapshot.folderGeneration == null) {
+    throw notActionable(messageId);
+  }
+  return snapshot;
+}
+
+export async function assertLiveMessageSnapshots(
+  tx, accountId, snapshots, {
+    includeRevisions = true, includeFolderGeneration = true,
+  } = {},
+) {
+  const unique = new Map();
+  for (const snapshot of snapshots || []) {
+    if (!snapshot?.id || snapshot.accountId !== accountId || unique.has(snapshot.id)) {
+      throw new MessageSnapshotError('Invalid or duplicate exact message snapshot');
+    }
+    unique.set(snapshot.id, snapshot);
+  }
+  if (unique.size === 0) return [];
+  const payload = [...unique.values()].map(snapshot => ({
+    id: snapshot.id,
+    uid: Number(snapshot.uid),
+    folder: snapshot.folder,
+    uid_validity: String(snapshot.uidValidity),
+    folder_generation: String(snapshot.folderGeneration),
+    read_revision: snapshot.readRevision == null ? null : Number(snapshot.readRevision),
+    star_revision: snapshot.starRevision == null ? null : Number(snapshot.starRevision),
+  }));
+  const result = await tx.query(
+    `WITH expected AS (
+       SELECT * FROM jsonb_to_recordset($2::jsonb) AS e(
+         id uuid, uid bigint, folder text, uid_validity numeric, folder_generation bigint,
+         read_revision bigint, star_revision bigint
+       )
+     )
+     SELECT m.id, m.account_id, m.uid, m.folder, m.read_revision, m.star_revision,
+            f.uid_validity AS folder_uid_validity,
+            f.observation_generation AS folder_observation_generation
+       FROM expected
+       JOIN messages m ON m.id = expected.id
+                      AND m.uid = expected.uid
+                      AND m.folder = expected.folder
+                      ${includeRevisions ? `AND (expected.read_revision IS NULL OR m.read_revision = expected.read_revision)
+                      AND (expected.star_revision IS NULL OR m.star_revision = expected.star_revision)` : ''}
+       JOIN folders f ON f.account_id = m.account_id AND f.path = m.folder
+                     AND f.uid_validity = expected.uid_validity
+                     ${includeFolderGeneration
+                       ? 'AND f.observation_generation = expected.folder_generation'
+                       : ''}
+      WHERE m.account_id = $1
+        AND m.is_deleted = false AND m.metadata_complete = true
+        AND f.is_present = true AND f.uid_validity IS NOT NULL
+      ORDER BY m.id
+      FOR SHARE OF f, m`,
+    [accountId, JSON.stringify(payload)],
+  );
+  if (result.rows.length !== unique.size) {
+    throw new MessageSnapshotError('Message snapshot was relocated or superseded');
+  }
+  const found = new Set(result.rows.map(row => row.id));
+  if ([...unique.keys()].some(id => !found.has(id))) {
+    throw new MessageSnapshotError('Message snapshot was relocated or superseded');
+  }
+  return [...unique.values()];
+}
+
+export async function revalidateLiveMessageSnapshots(accountId, snapshots, {
+  runTransaction = withTransaction,
+} = {}) {
+  return runTransaction(tx => assertLiveMessageSnapshots(tx, accountId, snapshots));
+}
+
+export async function revalidateLiveMessageSnapshotGroups(groups, {
+  runTransaction = withTransaction,
+} = {}) {
+  return runTransaction(async tx => {
+    for (const [accountId, snapshots] of groups || []) {
+      await assertLiveMessageSnapshots(tx, accountId, snapshots);
+    }
+  });
+}

--- a/backend/src/services/messageSnapshots.test.js
+++ b/backend/src/services/messageSnapshots.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  MessageSnapshotError,
+  assertLiveMessageSnapshots,
+  captureLiveMessageSnapshot,
+  revalidateLiveMessageSnapshotGroups,
+  revalidateLiveMessageSnapshots,
+  snapshotFromMessageRow,
+} from './messageSnapshots.js';
+
+const row = {
+  id: 'row-1', account_id: 'acct-1', uid: '7', folder: 'INBOX',
+  folder_uid_validity: '101', folder_observation_generation: '9',
+  read_revision: '3', star_revision: '5',
+};
+
+describe('non-advancing live message snapshots', () => {
+  it('revalidates publication snapshots inside a checked transaction', async () => {
+    const snapshot = snapshotFromMessageRow(row);
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [row] }) };
+    const runTransaction = vi.fn(callback => callback(tx));
+
+    await expect(revalidateLiveMessageSnapshots('acct-1', [snapshot], { runTransaction }))
+      .resolves.toEqual([snapshot]);
+    expect(runTransaction).toHaveBeenCalledOnce();
+    expect(tx.query.mock.calls[0][0]).toMatch(/FOR SHARE OF f, m/);
+  });
+
+  it('holds one checked transaction across publication snapshots from multiple accounts', async () => {
+    const first = snapshotFromMessageRow(row);
+    const second = { ...first, id: 'row-2', accountId: 'acct-2', uid: 8 };
+    const tx = { query: vi.fn()
+      .mockResolvedValueOnce({ rows: [row] })
+      .mockResolvedValueOnce({ rows: [{ ...row, id: 'row-2', account_id: 'acct-2', uid: '8' }] }) };
+    const runTransaction = vi.fn(callback => callback(tx));
+
+    await expect(revalidateLiveMessageSnapshotGroups(new Map([
+      ['acct-1', [first]], ['acct-2', [second]],
+    ]), { runTransaction })).resolves.toBeUndefined();
+    expect(runTransaction).toHaveBeenCalledOnce();
+    expect(tx.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes the stable row, UID epoch, folder generation, and flag revisions', () => {
+    expect(snapshotFromMessageRow(row)).toEqual({
+      id: 'row-1', accountId: 'acct-1', uid: 7, folder: 'INBOX',
+      uidValidity: '101', folderGeneration: '9', readRevision: 3, starRevision: 5,
+    });
+  });
+
+  it('captures only an owned live metadata-complete row without advancing any generation', async () => {
+    const runQuery = vi.fn().mockResolvedValue({ rows: [row] });
+
+    await expect(captureLiveMessageSnapshot('row-1', {
+      userId: 'user-1', runQuery,
+    })).resolves.toEqual(snapshotFromMessageRow(row));
+
+    const [sql, params] = runQuery.mock.calls[0];
+    expect(sql).toMatch(/JOIN email_accounts a/);
+    expect(sql).toMatch(/a\.user_id = \$2/);
+    expect(sql).toMatch(/JOIN folders f[\s\S]*f\.is_present = true[\s\S]*f\.uid_validity IS NOT NULL/);
+    expect(sql).toMatch(/m\.is_deleted = false[\s\S]*m\.metadata_complete = true/);
+    expect(sql).not.toMatch(/UPDATE[\s\S]*observation_generation/i);
+    expect(params).toEqual(['row-1', 'user-1']);
+  });
+
+  it('rejects incomplete, deleted, orphaned, absent, and null-epoch rows', async () => {
+    const runQuery = vi.fn().mockResolvedValue({ rows: [] });
+    await expect(captureLiveMessageSnapshot('row-1', { accountId: 'acct-1', runQuery }))
+      .rejects.toMatchObject({ code: 'MESSAGE_SNAPSHOT_NOT_ACTIONABLE' });
+  });
+
+  it('locks and validates the same exact row and folder token around a provider read', async () => {
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [row] }) };
+    const snapshot = snapshotFromMessageRow(row);
+
+    await expect(assertLiveMessageSnapshots(tx, 'acct-1', [snapshot])).resolves.toEqual([snapshot]);
+    const [sql, params] = tx.query.mock.calls[0];
+    expect(sql).toMatch(/m\.id = expected\.id/);
+    expect(sql).toMatch(/m\.uid = expected\.uid/);
+    expect(sql).toMatch(/m\.folder = expected\.folder/);
+    expect(sql).toMatch(/f\.uid_validity = expected\.uid_validity/);
+    expect(sql).toMatch(/f\.observation_generation = expected\.folder_generation/);
+    expect(sql).toMatch(/m\.read_revision = expected\.read_revision/);
+    expect(sql).toMatch(/m\.star_revision = expected\.star_revision/);
+    expect(sql).toMatch(/FOR SHARE OF f, m/);
+    expect(params).toEqual(['acct-1', JSON.stringify([{
+      id: 'row-1', uid: 7, folder: 'INBOX', uid_validity: '101', folder_generation: '9',
+      read_revision: 3, star_revision: 5,
+    }])]);
+  });
+
+  it('discards a result when any bulk snapshot row relocated or was superseded', async () => {
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [row] }) };
+    const snapshots = [
+      snapshotFromMessageRow(row),
+      { ...snapshotFromMessageRow(row), id: 'row-2', uid: 8 },
+    ];
+
+    await expect(assertLiveMessageSnapshots(tx, 'acct-1', snapshots)).rejects.toBeInstanceOf(MessageSnapshotError);
+    await expect(assertLiveMessageSnapshots(tx, 'acct-1', snapshots)).rejects.toMatchObject({
+      code: 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable: true,
+    });
+  });
+});

--- a/backend/src/services/metadataCompleteness.test.js
+++ b/backend/src/services/metadataCompleteness.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const migration = readFileSync(
+  new URL('../../migrations/0051_folder_backfill_incomplete.sql', import.meta.url),
+  'utf8'
+);
+const imapManagerSource = readFileSync(new URL('./imapManager.js', import.meta.url), 'utf8');
+const mailRoutesSource = readFileSync(new URL('../routes/mail.js', import.meta.url), 'utf8');
+
+describe('legacy metadata completeness migration', () => {
+  it('matches the empty-string snippet shape persisted by the old UID-only parser', () => {
+    expect(migration).toMatch(/COALESCE\(snippet,\s*''\)\s*=\s*''/);
+  });
+
+  it('does not require an empty from_email because Sent enrichment populated it', () => {
+    const legacyUpdate = migration.match(/UPDATE messages[\s\S]*?;/)?.[0] || '';
+    expect(legacyUpdate).not.toMatch(/COALESCE\(from_email/);
+    expect(legacyUpdate).not.toMatch(/COALESCE\(from_name/);
+  });
+
+  it('excludes unverified rows from the push-notification unread badge', () => {
+    const pushCount = imapManagerSource.match(/Try to include the total unread count[\s\S]*?\.then\(r =>/)?.[0] || '';
+    expect(pushCount).toContain('m.metadata_complete = true');
+  });
+
+  it('excludes unverified and deleted rows from mailbox cleanup reads', () => {
+    const start = mailRoutesSource.indexOf("router.get('/mailbox-usage'");
+    const end = mailRoutesSource.indexOf("router.post('/messages/bulk-move'", start);
+    const cleanup = mailRoutesSource.slice(start, end);
+    expect(cleanup.match(/metadata_complete = true/g)).toHaveLength(4);
+    expect(cleanup.match(/is_deleted = false/g)).toHaveLength(4);
+  });
+
+  it('rejects unverified and deleted rows from body and raw-header reads', () => {
+    const bodyStart = mailRoutesSource.indexOf("router.get('/messages/:id/body'");
+    const headersStart = mailRoutesSource.indexOf("router.get('/messages/:id/headers'");
+    const bodyRoute = mailRoutesSource.slice(bodyStart, headersStart);
+    const headersRoute = mailRoutesSource.slice(headersStart, mailRoutesSource.indexOf("router.get('/messages/:id/attachments", headersStart));
+    for (const route of [bodyRoute, headersRoute]) {
+      expect(route).toContain('m.is_deleted = false');
+      expect(route).toContain('m.metadata_complete = true');
+    }
+  });
+
+  it('fully replaces manufactured legacy metadata before marking a conflict complete', () => {
+    const required = [
+      'message_id', 'date', 'has_attachments', 'attachments', 'subject',
+      'from_name', 'from_email', 'to_addresses', 'cc_addresses', 'reply_to',
+      'in_reply_to', 'snippet', 'flags', 'thread_references', 'thread_id',
+    ];
+    for (const field of required) {
+      expect(imapManagerSource).toMatch(new RegExp(
+        `${field}\\s*=\\s*CASE\\s+WHEN NOT messages\\.metadata_complete\\s+THEN EXCLUDED\\.${field}`
+      ));
+    }
+    expect(imapManagerSource.match(/\$\{COMPLETE_METADATA_CONFLICT_UPDATE_SQL\}/g)).toHaveLength(2);
+  });
+});

--- a/backend/src/services/operationPrivacy.migration.test.js
+++ b/backend/src/services/operationPrivacy.migration.test.js
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL('../../migrations/0060_completed_operation_privacy.sql', import.meta.url),
+  'utf8',
+);
+
+describe('completed provider payload privacy migration', () => {
+  it('redacts existing completed send and forward payloads and enforces terminal cleanup', () => {
+    const sendCleanup = migration.match(
+      /UPDATE\s+send_operations[\s\S]*?WHERE\s+state\s*=\s*'completed'/i,
+    )?.[0];
+    const forwardCleanup = migration.match(
+      /UPDATE\s+inbox_rule_forwards[\s\S]*?WHERE\s+status\s*=\s*'sent'/i,
+    )?.[0];
+    for (const field of [
+      'message_id', 'sent_folder', 'sent_metadata', 'raw_message',
+      'server_auto_saves', 'smtp_message', 'smtp_envelope',
+      'prepared_payload_digest', 'source_snapshots',
+    ]) {
+      expect(sendCleanup).toMatch(new RegExp(`${field}\\s*=\\s*NULL`, 'i'));
+    }
+    for (const field of ['recipient', 'smtp_message', 'smtp_envelope', 'source_snapshot']) {
+      expect(forwardCleanup).toMatch(new RegExp(`${field}\\s*=\\s*NULL`, 'i'));
+    }
+    expect(migration).toMatch(
+      /CHECK\s*\([\s\S]*state\s*<>\s*'completed'[\s\S]*smtp_message\s+IS\s+NULL/i,
+    );
+    expect(migration).toMatch(
+      /CHECK\s*\([\s\S]*status\s*<>\s*'sent'[\s\S]*source_snapshot\s+IS\s+NULL/i,
+    );
+  });
+});

--- a/backend/src/services/preparedSmtp.js
+++ b/backend/src/services/preparedSmtp.js
@@ -1,0 +1,103 @@
+import { createHash } from 'node:crypto';
+import nodemailer from 'nodemailer';
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map(key => (
+      `${JSON.stringify(key)}:${stableJson(value[key])}`
+    )).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function parseStoredJson(value) {
+  if (typeof value !== 'string') return value;
+  return JSON.parse(value);
+}
+
+function withoutCustomBccHeaders(headers) {
+  if (Array.isArray(headers)) {
+    return headers.filter(header => String(header?.key || '').toLowerCase() !== 'bcc');
+  }
+  if (headers && typeof headers === 'object') {
+    return Object.fromEntries(
+      Object.entries(headers).filter(([name]) => name.toLowerCase() !== 'bcc'),
+    );
+  }
+  return headers;
+}
+
+function withoutBcc(mailOptions) {
+  const deliveryOptions = { ...mailOptions };
+  const headers = deliveryOptions.headers;
+  delete deliveryOptions.bcc;
+  delete deliveryOptions.headers;
+  return {
+    ...deliveryOptions,
+    ...(headers === undefined ? {} : { headers: withoutCustomBccHeaders(headers) }),
+  };
+}
+
+function hasTopLevelBccHeader(message) {
+  const headerBlock = Buffer.from(message).toString('latin1').split(/\r?\n\r?\n/, 1)[0];
+  return headerBlock.split(/\r?\n/).some(line => /^bcc[ \t]*:/i.test(line));
+}
+
+async function renderMessage(mailOptions, envelope, date) {
+  const transport = nodemailer.createTransport({ streamTransport: true, newline: 'windows' });
+  const info = await transport.sendMail({ ...mailOptions, date, envelope });
+  const chunks = [];
+  await new Promise((resolve, reject) => {
+    info.message.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    info.message.on('end', resolve);
+    info.message.on('error', reject);
+  });
+  return Buffer.concat(chunks);
+}
+
+export function preparedSmtpDigest(message, envelope) {
+  return createHash('sha256')
+    .update(Buffer.from(message))
+    .update('\0')
+    .update(stableJson(envelope))
+    .digest('hex');
+}
+
+export async function renderPreparedSmtp(
+  mailOptions,
+  envelope,
+  { includeBccInSentCopy = false } = {},
+) {
+  const date = mailOptions.date || new Date();
+  const cleanHeaders = withoutCustomBccHeaders(mailOptions.headers);
+  const message = await renderMessage(withoutBcc(mailOptions), envelope, date);
+  if (hasTopLevelBccHeader(message)) {
+    const error = new Error('Prepared SMTP delivery contains a Bcc header');
+    error.code = 'SMTP_PREPARED_BCC_DISCLOSURE';
+    error.retryable = false;
+    throw error;
+  }
+  const sentMessage = includeBccInSentCopy
+    ? await renderMessage({ ...mailOptions, headers: cleanHeaders }, envelope, date)
+    : null;
+  return {
+    message,
+    sentMessage,
+    envelope,
+    digest: preparedSmtpDigest(message, envelope),
+  };
+}
+
+export function loadPreparedSmtp({ message, envelope, digest }) {
+  const storedMessage = message == null ? null : Buffer.from(message);
+  const storedEnvelope = parseStoredJson(envelope);
+  if (!storedMessage?.length || !storedEnvelope || typeof digest !== 'string' ||
+      preparedSmtpDigest(storedMessage, storedEnvelope) !== digest) {
+    const error = new Error('Durable SMTP payload is incomplete or corrupt');
+    error.code = 'SMTP_PREPARED_PAYLOAD_INVALID';
+    error.retryable = false;
+    throw error;
+  }
+  return { raw: storedMessage, envelope: storedEnvelope };
+}

--- a/backend/src/services/preparedSmtp.test.js
+++ b/backend/src/services/preparedSmtp.test.js
@@ -1,0 +1,55 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { renderPreparedSmtp } from './preparedSmtp.js';
+
+function headersFrom(message) {
+  const headerBlock = Buffer.from(message).toString('utf8').split(/\r?\n\r?\n/, 1)[0];
+  const unfolded = headerBlock.replace(/\r?\n[ \t]+/g, ' ');
+  const headers = new Map();
+  for (const line of unfolded.split(/\r?\n/)) {
+    const separator = line.indexOf(':');
+    if (separator < 1) continue;
+    headers.set(line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim());
+  }
+  return headers;
+}
+
+describe('prepared SMTP rendering', () => {
+  it('keeps Bcc only in the envelope and a distinct requested Sent copy', async () => {
+    const envelope = {
+      from: 'sender@example.com',
+      to: ['visible@example.com', 'copy@example.com', 'hidden@example.com'],
+    };
+    const rendered = await renderPreparedSmtp({
+      from: 'Sender <sender@example.com>',
+      to: 'Visible <visible@example.com>',
+      cc: 'Copy <copy@example.com>',
+      bcc: 'A Very Long Hidden Recipient Name That Forces Header Folding <hidden@example.com>',
+      headers: [{ key: 'bCc', value: 'custom-hidden@example.com' }],
+      subject: 'Disclosure boundary',
+      text: 'body',
+      messageId: '<stable@example.com>',
+      date: new Date('2026-08-26T10:00:00Z'),
+    }, envelope, { includeBccInSentCopy: true });
+
+    const deliveryHeaders = headersFrom(rendered.message);
+    expect(deliveryHeaders.get('to')).toContain('visible@example.com');
+    expect(deliveryHeaders.get('cc')).toContain('copy@example.com');
+    expect(deliveryHeaders.has('bcc')).toBe(false);
+    expect(rendered.envelope).toEqual(envelope);
+
+    const sentHeaders = headersFrom(rendered.sentMessage);
+    expect(sentHeaders.get('to')).toContain('visible@example.com');
+    expect(sentHeaders.get('cc')).toContain('copy@example.com');
+    expect(sentHeaders.get('bcc')).toContain('hidden@example.com');
+    expect(sentHeaders.get('bcc')).not.toContain('custom-hidden@example.com');
+
+    const expectedDigest = createHash('sha256')
+      .update(rendered.message)
+      .update('\0')
+      .update('{"from":"sender@example.com","to":["visible@example.com","copy@example.com","hidden@example.com"]}')
+      .digest('hex');
+    expect(rendered.digest).toBe(expectedDigest);
+  });
+});

--- a/backend/src/services/providerMutationBoundary.test.js
+++ b/backend/src/services/providerMutationBoundary.test.js
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const imapSource = readFileSync(new URL('./imapManager.js', import.meta.url), 'utf8');
+const desiredFlagSource = readFileSync(new URL('./desiredFlags.js', import.meta.url), 'utf8');
+const archiveSource = readFileSync(new URL('./archiveInbox.js', import.meta.url), 'utf8');
+
+function rawMutationLines(source) {
+  return source.split('\n')
+    .map(line => line.trim())
+    .filter(line => /\bclient\.(messageMove|messageCopy|messageDelete|messageFlagsAdd|messageFlagsRemove|append)\(/.test(line));
+}
+
+describe('provider mutation boundary allowlist', () => {
+  it('keeps raw IMAP writes inside the reviewed durable executor primitives', () => {
+    expect(rawMutationLines(imapSource)).toEqual([
+      'const stored = await client.messageFlagsAdd(String(uid), [marker], { uid: true });',
+      'const removed = await client.messageFlagsRemove(String(uid), [marker], { uid: true });',
+      'const result = await client.append(folder, rawMessage, appendFlags);',
+      'const result = await client.messageMove(String(uid), toFolder, { uid: true });',
+      'const result = await client.messageDelete(String(uid), { uid: true });',
+      'const copyResult = await client.messageCopy(String(uid), toFolder, { uid: true });',
+    ]);
+  });
+
+  it('keeps raw flag STORE calls inside the desired-flag delivery session', () => {
+    expect(rawMutationLines(desiredFlagSource)).toEqual([
+      '? client.messageFlagsAdd(uid, [imapFlag], options)',
+      ': client.messageFlagsRemove(uid, [imapFlag], options);',
+    ]);
+  });
+
+  it('allows only the receipt-fenced All Mail completion to apply accepted flags before cascade', () => {
+    expect(rawMutationLines(archiveSource)).toEqual([
+      '? await providerResource.client.messageFlagsAdd(String(receipt.uid), [imapFlag], { uid: true })',
+      ': await providerResource.client.messageFlagsRemove(String(receipt.uid), [imapFlag], { uid: true });',
+    ]);
+  });
+
+  it('does not reintroduce bypass-capable mutation exports or manager methods', () => {
+    expect(imapSource).not.toMatch(/export async function (?:moveMessageOnClient|copyMessageOnClient|appendMessageOnClient)\b/);
+    expect(imapSource).not.toMatch(/async (?:setFlag|moveMessageGetNewUid|emptyFolder|markAllReadImap|clearMoveRecoveryKeyword|_bulkMoveMessages|bulkPermanentDelete)\b/);
+  });
+});

--- a/backend/src/services/providerOperations.js
+++ b/backend/src/services/providerOperations.js
@@ -1,0 +1,737 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { pool } from './db.js';
+
+const STATES = ['ready', 'provider_started', 'provider_applied', 'completed', 'manual_intervention'];
+
+function required(value, label) {
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+function observation(value, label) {
+  if (!value || value.uidValidity === undefined || value.uidValidity === null) {
+    throw new Error(`${label} UIDVALIDITY is required`);
+  }
+  if (value.generation === undefined || value.generation === null) {
+    throw new Error(`${label} observation generation is required`);
+  }
+  return {
+    folder: required(value.folder, `${label} folder`),
+    ...(value.uid === undefined ? {} : { uid: Number(value.uid) }),
+    uidValidity: String(value.uidValidity),
+    generation: String(value.generation),
+    ...(value.topologyIdentity == null ? {} : {
+      topologyIdentity: String(value.topologyIdentity),
+    }),
+  };
+}
+
+function identityMismatch(message) {
+  return new ProviderOperationError(message, {
+    code: 'PROVIDER_OPERATION_IDENTITY_MISMATCH', retryable: true, uncertain: true,
+  });
+}
+
+function rebaseToken(persisted, fresh, label, { includeUid = false } = {}) {
+  if (!persisted || !fresh || persisted.folder !== fresh.folder ||
+      String(persisted.uidValidity) !== String(fresh.uidValidity) ||
+      (includeUid && Number(persisted.uid) !== Number(fresh.uid))) {
+    throw identityMismatch(`${label} provider observation identity changed`);
+  }
+  let persistedGeneration;
+  let freshGeneration;
+  try {
+    persistedGeneration = BigInt(persisted.generation);
+    freshGeneration = BigInt(fresh.generation);
+  } catch {
+    throw identityMismatch(`${label} provider observation generation is invalid`);
+  }
+  if (freshGeneration < persistedGeneration) {
+    throw identityMismatch(`${label} provider observation generation moved backward`);
+  }
+  if (freshGeneration !== persistedGeneration && (
+    persisted.topologyIdentity == null || fresh.topologyIdentity == null ||
+    String(persisted.topologyIdentity) !== String(fresh.topologyIdentity)
+  )) {
+    throw identityMismatch(`${label} provider folder incarnation changed`);
+  }
+  return {
+    ...persisted,
+    generation: String(fresh.generation),
+    ...(fresh.topologyIdentity == null ? {} : {
+      topologyIdentity: String(fresh.topologyIdentity),
+    }),
+  };
+}
+
+function rebaseInFlightOperation(operation, intent) {
+  if (operation.id !== intent.id || operation.kind !== intent.kind ||
+      operation.accountId !== intent.accountId || operation.marker !== intent.marker ||
+      (operation.sourceMessageId != null && intent.sourceMessageId != null &&
+       operation.sourceMessageId !== intent.sourceMessageId)) {
+    throw identityMismatch('Provider operation identity changed during recovery');
+  }
+  const source = operation.source
+    ? rebaseToken(operation.source, intent.source, 'Source', { includeUid: true })
+    : null;
+  const destination = rebaseToken(operation.destination, intent.destination, 'Destination');
+  let receipt = operation.receipt;
+  if (receipt) {
+    receipt = {
+      ...receipt,
+      ...(receipt.sourceToken ? {
+        sourceToken: rebaseToken(receipt.sourceToken, intent.source, 'Receipt source', {
+          includeUid: true,
+        }),
+      } : {}),
+      ...(receipt.destinationToken ? {
+        destinationToken: rebaseToken(
+          receipt.destinationToken, intent.destination, 'Receipt destination',
+        ),
+      } : {}),
+    };
+  }
+  return {
+    ...operation, source, destination, receipt,
+    requestKey: operation.requestKey || intent.requestKey,
+    sourceMessageId: operation.sourceMessageId || intent.sourceMessageId || null,
+  };
+}
+
+export function providerOperationMarker(operationId) {
+  const digest = createHash('sha256').update(String(operationId)).digest('base64url');
+  return `$MailFlowOp-${digest}`;
+}
+
+export function buildProviderOperationId(input) {
+  const kind = required(input?.kind, 'operation kind').toLowerCase();
+  if (!['move', 'copy', 'append', 'delete'].includes(kind)) {
+    throw new Error(`Unsupported provider operation ${kind}`);
+  }
+  const accountId = required(input.accountId, 'account id');
+  const requestKey = required(input.requestKey, `${kind.toUpperCase()} request key`);
+  const destinationFolder = required(
+    input.destinationFolder ?? input.destination?.folder,
+    'destination folder',
+  );
+  const stableSource = kind === 'append' ? null : {
+    folder: required(input.source?.folder, 'source folder'),
+    uid: Number(required(input.source?.uid, 'source uid')),
+  };
+  return createHash('sha256').update(JSON.stringify({
+    kind, accountId, source: stableSource, destinationFolder, requestKey,
+  })).digest('hex');
+}
+
+export function buildProviderOperationIdentity(input) {
+  const kind = required(input?.kind, 'operation kind').toLowerCase();
+  if (!['move', 'copy', 'append', 'delete'].includes(kind)) throw new Error(`Unsupported provider operation ${kind}`);
+  const accountId = required(input.accountId, 'account id');
+  const destination = observation(input.destination, 'destination');
+  const source = kind === 'append' ? null : observation(input.source, 'source');
+  if (source) required(source.uid, 'source uid');
+  const requestKey = required(input.requestKey, `${kind.toUpperCase()} request key`);
+  // Observation generations and UID epochs fence the provider mutation, but are deliberately
+  // not caller identity. A fresh process can read a later observation or changed epoch; hashing
+  // either would create a second operation and marker instead of safely rejecting recovery of
+  // the original logical action. Persisted observations still validate both epochs and topology.
+  const id = buildProviderOperationId({
+    kind, accountId, source, destinationFolder: destination.folder, requestKey,
+  });
+  return {
+    id,
+    kind,
+    accountId,
+    source,
+    destination,
+    requestKey,
+    sourceMessageId: input.sourceMessageId == null ? null : String(input.sourceMessageId),
+    marker: providerOperationMarker(id),
+  };
+}
+
+export class ProviderOperationError extends Error {
+  constructor(message, {
+    code, retryable = true, uncertain = true, details = null, manual = false,
+  } = {}) {
+    super(message);
+    this.name = 'ProviderOperationError';
+    this.code = code;
+    this.retryable = retryable;
+    this.uncertain = uncertain;
+    this.details = details;
+    this.manual = manual;
+  }
+}
+
+function recoveryError(result) {
+  if (result?.status === 'absent') {
+    return new ProviderOperationError('Provider marker is not currently observable', {
+      code: 'PROVIDER_MARKER_ABSENT', details: result,
+    });
+  }
+  return new ProviderOperationError('Provider marker recovery is ambiguous', {
+    code: 'PROVIDER_MARKER_AMBIGUOUS', details: result,
+  });
+}
+
+function createSemaphore(limit) {
+  let active = 0;
+  const waiting = [];
+  return async function withSlot(callback) {
+    if (active >= limit) await new Promise(resolve => waiting.push(resolve));
+    active++;
+    try {
+      return await callback();
+    } finally {
+      active--;
+      waiting.shift()?.();
+    }
+  };
+}
+
+export function createProviderOperationExecutor({ repository, maxConcurrent = 4 } = {}) {
+  if (!repository?.withOwnership) throw new Error('Provider operation repository is required');
+  const withSlot = createSemaphore(maxConcurrent);
+  return {
+    getExisting(operationId) {
+      return withSlot(() => repository.withOwnership(operationId, session => session.loadExisting()));
+    },
+
+    listPendingCleanup(limit = 20) {
+      if (!repository.listPendingCleanup) return Promise.resolve([]);
+      return repository.listPendingCleanup(limit);
+    },
+
+    findMoveBySource(input) {
+      if (!repository.findMoveBySource) return Promise.resolve(null);
+      return repository.findMoveBySource(input);
+    },
+
+    completeExisting(operationId, spec = {}) {
+      return withSlot(() => repository.withOwnership(operationId, async session => {
+        let operation = await session.loadExisting();
+        if (!operation) return { status: 'missing' };
+        if (operation.state === 'provider_applied' && spec.intent) {
+          const rebased = rebaseInFlightOperation(operation, spec.intent);
+          const changed = JSON.stringify([
+            operation.requestKey, operation.sourceMessageId,
+            operation.source, operation.destination, operation.receipt,
+          ]) !== JSON.stringify([
+            rebased.requestKey, rebased.sourceMessageId,
+            rebased.source, rebased.destination, rebased.receipt,
+          ]);
+          if (changed) operation = await session.rebaseInFlightIntent(operation, rebased);
+        }
+        await spec.validateExisting?.(operation);
+        const runPostCommit = async (provider = null, { claimCompleted = false } = {}) => {
+          await spec.afterCommit?.(operation.receipt, operation, provider);
+          if (!spec.cleanup || operation.cleanupState === 'completed') return;
+          if (claimCompleted) {
+            operation = await session.claimAttempt(operation, 'completed', randomUUID());
+          }
+          const attempt = {
+            generation: operation.attemptGeneration, owner: operation.attemptOwner,
+          };
+          try {
+            await spec.cleanup(provider, operation.marker, operation.receipt, operation);
+            operation = await session.markCleanupCompleted(operation.id, attempt);
+          } catch (cause) {
+            await session.recordCleanupError(operation.id, attempt, {
+              message: cause?.message || String(cause), at: new Date().toISOString(),
+            });
+            throw cause;
+          }
+        };
+        if (operation.state === 'completed') {
+          if (spec.cleanup && operation.cleanupState !== 'completed') {
+            if (!spec.acquireProvider) throw new Error('Provider cleanup requires acquisition');
+            await spec.acquireProvider(
+              provider => runPostCommit(provider, { claimCompleted: true }), operation,
+            );
+          } else {
+            await runPostCommit();
+          }
+          return {
+            status: 'completed', operation, receipt: operation.receipt, replayed: true,
+          };
+        }
+        if (operation.state !== 'provider_applied') {
+          return { status: 'pending', operation };
+        }
+
+        const finish = async (provider = null) => {
+          operation = await session.claimAttempt(operation, 'provider_applied', randomUUID());
+          const attempt = {
+            generation: operation.attemptGeneration, owner: operation.attemptOwner,
+          };
+          await session.withMutationFence(async tx => {
+            await spec.validateCompletion?.(tx, operation);
+            const receipt = spec.complete
+              ? await spec.complete(operation.receipt, operation, tx, provider)
+              : operation.receipt;
+            operation = await session.markCompleted(operation.id, attempt, receipt, tx);
+          });
+          await runPostCommit(provider);
+        };
+        if (spec.completeWithProvider || spec.cleanup) {
+          if (!spec.acquireProvider) throw new Error('Provider-backed completion requires acquisition');
+          await spec.acquireProvider(finish, operation);
+        } else {
+          await finish();
+        }
+        return {
+          status: 'completed', operation, receipt: operation.receipt, replayed: false,
+        };
+      }));
+    },
+
+    execute(spec) {
+      return withSlot(() => repository.withOwnership(spec.intent.id, async session => {
+        let operation = await session.loadOrCreate(spec.intent);
+        if (operation.state === 'ready') {
+          operation = await session.refreshReadyIntent(operation, spec.intent);
+        }
+        if (['provider_started', 'provider_applied'].includes(operation.state)) {
+          const rebased = rebaseInFlightOperation(operation, spec.intent);
+          const changed = JSON.stringify([
+            operation.requestKey, operation.sourceMessageId,
+            operation.source, operation.destination, operation.receipt,
+          ]) !== JSON.stringify([
+            rebased.requestKey, rebased.sourceMessageId,
+            rebased.source, rebased.destination, rebased.receipt,
+          ]);
+          if (changed) operation = await session.rebaseInFlightIntent(operation, rebased);
+        }
+        const runPostCommit = async (provider = null, { claimCompleted = false } = {}) => {
+          await spec.afterCommit?.(operation.receipt, operation, provider);
+          if (!spec.cleanup || operation.cleanupState === 'completed') return;
+          if (claimCompleted) {
+            operation = await session.claimAttempt(operation, 'completed', randomUUID());
+          }
+          const attempt = {
+            generation: operation.attemptGeneration, owner: operation.attemptOwner,
+          };
+          try {
+            await spec.cleanup(provider, operation.marker, operation.receipt, operation);
+            operation = await session.markCleanupCompleted(operation.id, attempt);
+          } catch (cause) {
+            await session.recordCleanupError(operation.id, attempt, {
+              message: cause?.message || String(cause), at: new Date().toISOString(),
+            });
+            throw cause;
+          }
+        };
+        if (operation.state === 'completed') {
+          if (spec.cleanup && operation.cleanupState !== 'completed') {
+            await spec.acquireProvider(
+              provider => runPostCommit(provider, { claimCompleted: true }), operation,
+            );
+          } else {
+            await runPostCommit();
+          }
+          return operation.receipt;
+        }
+        if (operation.state === 'manual_intervention') {
+          throw new ProviderOperationError(
+            operation.uncertainty?.message || 'Provider operation requires manual integrity review',
+            {
+              code: operation.uncertainty?.code || 'PROVIDER_INTEGRITY_FAILURE',
+              retryable: false,
+              uncertain: true,
+              details: operation.uncertainty?.details || null,
+              manual: true,
+            },
+          );
+        }
+
+        if (operation.state === 'provider_applied') {
+          const finish = async (provider = null) => {
+            operation = await session.claimAttempt(operation, 'provider_applied', randomUUID());
+            const attempt = {
+              generation: operation.attemptGeneration, owner: operation.attemptOwner,
+            };
+            await session.withMutationFence(async tx => {
+              await spec.validateCompletion?.(tx, operation);
+              const completed = spec.complete
+                ? await spec.complete(operation.receipt, operation, tx, provider)
+                : operation.receipt;
+              operation = await session.markCompleted(operation.id, attempt, completed, tx);
+            });
+            await runPostCommit(provider);
+          };
+          if (spec.completeWithProvider || spec.cleanup) {
+            await spec.acquireProvider(finish, operation);
+          } else {
+            await finish();
+          }
+          return operation.receipt;
+        }
+
+        if (operation.state === 'provider_started') {
+          operation = await session.claimAttempt(operation, 'provider_started', randomUUID());
+        }
+
+        return spec.acquireProvider(async provider => {
+          if (operation.state === 'ready') {
+            const owner = randomUUID();
+            await session.withMutationFence(async tx => {
+              await spec.validate?.(provider, tx, operation);
+              operation = await session.markProviderStarted(operation.id, owner);
+              const attempt = {
+                generation: operation.attemptGeneration, owner: operation.attemptOwner,
+              };
+              try {
+                await spec.prepare?.(provider, operation.marker, operation);
+                const receipt = await spec.command(provider, operation.marker, operation);
+                operation = await session.markProviderApplied(operation.id, attempt, receipt);
+              } catch (cause) {
+                const error = cause instanceof ProviderOperationError ? cause : new ProviderOperationError(
+                  `Provider command outcome is uncertain: ${cause?.message || cause}`,
+                  { code: 'PROVIDER_COMMAND_UNCERTAIN', details: { cause: cause?.message || String(cause) } },
+                );
+                const uncertainty = {
+                  code: error.code, message: error.message, details: error.details,
+                  at: new Date().toISOString(),
+                };
+                if (error.manual) {
+                  operation = await session.markManualIntervention(operation.id, attempt, uncertainty);
+                } else {
+                  await session.recordUncertainty(operation.id, attempt, uncertainty);
+                }
+                throw error;
+              }
+            });
+          } else if (operation.state === 'provider_started') {
+            const attempt = {
+              generation: operation.attemptGeneration, owner: operation.attemptOwner,
+            };
+            let recovery;
+            try {
+              await session.withMutationFence(async tx => {
+                await spec.validateRecovery?.(provider, tx, operation);
+                recovery = await spec.recover(provider, operation.marker, operation);
+              });
+            } catch (cause) {
+              const error = cause instanceof ProviderOperationError ? cause : new ProviderOperationError(
+                `Provider recovery failed: ${cause?.message || cause}`,
+                { code: 'PROVIDER_RECOVERY_FAILED', details: { cause: cause?.message || String(cause) } },
+              );
+              await session.recordUncertainty(operation.id, attempt, {
+                code: error.code, message: error.message, at: new Date().toISOString(),
+              });
+              throw error;
+            }
+            if (recovery?.status !== 'unique') {
+              const error = recoveryError(recovery);
+              await session.recordUncertainty(operation.id, attempt, {
+                code: error.code, details: recovery, at: new Date().toISOString(),
+              });
+              throw error;
+            }
+            const receipt = { ...recovery };
+            delete receipt.status;
+            operation = await session.markProviderApplied(operation.id, attempt, receipt);
+          }
+
+          const completionAttempt = {
+            generation: operation.attemptGeneration, owner: operation.attemptOwner,
+          };
+          await session.withMutationFence(async tx => {
+            await spec.validateCompletion?.(tx, operation);
+            const completed = spec.complete
+              ? await spec.complete(operation.receipt, operation, tx, provider)
+              : operation.receipt;
+            operation = await session.markCompleted(operation.id, completionAttempt, completed, tx);
+          });
+          await runPostCommit(provider);
+          return operation.receipt;
+        }, operation);
+      }));
+    },
+  };
+}
+
+function ownershipLost(id) {
+  return new ProviderOperationError(`Provider operation ownership was lost for ${id}`, {
+    code: 'PROVIDER_OPERATION_OWNERSHIP_LOST', retryable: true, uncertain: true,
+  });
+}
+
+function fromRow(row) {
+  return {
+    id: row.operation_key,
+    kind: row.kind,
+    accountId: row.account_id,
+    marker: row.marker,
+    requestKey: row.request_key,
+    sourceMessageId: row.source_message_id,
+    source: row.source_observation,
+    destination: row.destination_observation,
+    state: row.state,
+    attemptGeneration: Number(row.attempt_generation),
+    attemptOwner: row.attempt_owner,
+    receipt: row.receipt,
+    uncertainty: row.uncertainty,
+    cleanupState: row.marker_cleanup_state,
+    cleanupError: row.marker_cleanup_error,
+  };
+}
+
+async function inTransaction(client, callback) {
+  await client.query('BEGIN');
+  try {
+    const result = await callback(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  }
+}
+
+export function createPostgresProviderOperationRepository(dbPool = pool) {
+  return {
+    async listPendingCleanup(limit = 20) {
+      const bounded = Math.max(1, Math.min(100, Number(limit) || 20));
+      const result = await dbPool.query(
+        `SELECT * FROM provider_operations
+          WHERE state = 'completed' AND marker_cleanup_state = 'pending'
+          ORDER BY updated_at, operation_key
+          LIMIT $1`,
+        [bounded],
+      );
+      return result.rows.map(fromRow);
+    },
+
+    async findMoveBySource({ accountId, sourceMessageId, folder, uid }) {
+      const result = await dbPool.query(
+        `SELECT * FROM provider_operations
+          WHERE account_id = $1 AND kind = 'move'
+            AND state IN ('provider_started', 'provider_applied', 'completed')
+            AND (
+              (source_message_id = $2 AND source_folder = $3 AND source_uid = $4)
+              OR (source_message_id IS NULL AND source_folder = $3 AND source_uid = $4)
+            )
+          ORDER BY updated_at DESC, operation_key
+          LIMIT 2`,
+        [accountId, sourceMessageId, folder, Number(uid)],
+      );
+      if (result.rows.length > 1) {
+        throw identityMismatch('Multiple provider MOVE operations claim the same source row');
+      }
+      return result.rows[0] ? fromRow(result.rows[0]) : null;
+    },
+
+    async withOwnership(operationId, callback) {
+      const client = await dbPool.connect();
+      try {
+        await client.query('SELECT pg_advisory_lock(hashtextextended($1, 0))', [operationId]);
+        const read = async () => {
+          const result = await client.query(
+            'SELECT * FROM provider_operations WHERE operation_key = $1', [operationId],
+          );
+          return result.rows[0] ? fromRow(result.rows[0]) : null;
+        };
+        return await callback({
+          async loadExisting() {
+            return read();
+          },
+          async loadOrCreate(intent) {
+            await client.query(
+              `INSERT INTO provider_operations (
+                 operation_key, account_id, kind, marker, source_folder, source_uid,
+                 destination_folder, source_observation, destination_observation,
+                 request_key, source_message_id
+               ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11)
+               ON CONFLICT (operation_key) DO NOTHING`,
+              [
+                intent.id, intent.accountId, intent.kind, intent.marker,
+                intent.source?.folder || null, intent.source?.uid || null,
+                intent.destination.folder,
+                intent.source ? JSON.stringify(intent.source) : null,
+                JSON.stringify(intent.destination),
+                intent.requestKey, intent.sourceMessageId,
+              ],
+            );
+            return read();
+          },
+          async withMutationFence(run) {
+            // Acquire the observation-lock connection before BEGIN/FOR UPDATE. The caller has
+            // already acquired bounded provider/session ownership, so no pool wait occurs while
+            // folder rows are locked.
+            const fenceClient = await dbPool.connect();
+            try {
+              return await inTransaction(fenceClient, run);
+            } finally {
+              fenceClient.release();
+            }
+          },
+          async refreshReadyIntent(expected, intent) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET source_folder = $2, source_uid = $3, destination_folder = $4,
+                      source_observation = $5::jsonb,
+                      destination_observation = $6::jsonb,
+                      request_key = $9, source_message_id = $10, updated_at = NOW()
+                WHERE operation_key = $1 AND state = 'ready'
+                  AND attempt_generation = $7
+                  AND attempt_owner IS NOT DISTINCT FROM $8::uuid`,
+              [
+                expected.id, intent.source?.folder || null, intent.source?.uid || null,
+                intent.destination.folder, intent.source ? JSON.stringify(intent.source) : null,
+                JSON.stringify(intent.destination), expected.attemptGeneration, expected.attemptOwner,
+                intent.requestKey, intent.sourceMessageId,
+              ],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(expected.id);
+            return read();
+          },
+          async rebaseInFlightIntent(expected, rebased) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET source_observation = $2::jsonb,
+                      destination_observation = $3::jsonb,
+                      receipt = $4::jsonb,
+                      request_key = $8,
+                      source_message_id = $9,
+                      updated_at = NOW()
+                WHERE operation_key = $1 AND state = $5
+                  AND attempt_generation = $6
+                  AND attempt_owner IS NOT DISTINCT FROM $7::uuid`,
+              [
+                expected.id, rebased.source ? JSON.stringify(rebased.source) : null,
+                JSON.stringify(rebased.destination),
+                rebased.receipt ? JSON.stringify(rebased.receipt) : null,
+                expected.state, expected.attemptGeneration, expected.attemptOwner,
+                rebased.requestKey, rebased.sourceMessageId,
+              ],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(expected.id);
+            return read();
+          },
+          async markProviderStarted(id, owner) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET state = 'provider_started',
+                      attempt_generation = attempt_generation + 1,
+                      attempt_owner = $2, provider_started_at = NOW(), updated_at = NOW()
+                WHERE operation_key = $1 AND state = 'ready'
+                  AND attempt_generation = 0 AND attempt_owner IS NULL`,
+              [id, owner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(id);
+            return read();
+          },
+          async markProviderApplied(id, attempt, receipt) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET state = 'provider_applied', receipt = $2::jsonb,
+                      uncertainty = NULL, provider_applied_at = NOW(), updated_at = NOW()
+                WHERE operation_key = $1 AND state = 'provider_started'
+                  AND attempt_generation = $3 AND attempt_owner = $4`,
+              [id, JSON.stringify(receipt), attempt.generation, attempt.owner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(id);
+            return read();
+          },
+          async claimAttempt(expected, state, owner) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET attempt_generation = attempt_generation + 1,
+                      attempt_owner = $2, updated_at = NOW()
+                WHERE operation_key = $1 AND state = $3
+                  AND attempt_generation = $4
+                  AND attempt_owner IS NOT DISTINCT FROM $5::uuid`,
+              [expected.id, owner, state, expected.attemptGeneration, expected.attemptOwner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(expected.id);
+            return read();
+          },
+          async markCompleted(id, attempt, receipt, tx) {
+            if (!tx?.query) throw new Error('Provider completion requires an observation-fence transaction');
+            const result = await tx.query(
+              `UPDATE provider_operations
+                  SET state = 'completed', receipt = $2::jsonb,
+                      completed_at = NOW(), updated_at = NOW()
+                WHERE operation_key = $1 AND state = 'provider_applied'
+                  AND attempt_generation = $3 AND attempt_owner = $4
+                RETURNING *`,
+              [id, JSON.stringify(receipt), attempt.generation, attempt.owner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(id);
+            return fromRow(result.rows[0]);
+          },
+          async markCleanupCompleted(id, attempt) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET marker_cleanup_state = 'completed', marker_cleanup_error = NULL,
+                      marker_cleanup_completed_at = NOW(), updated_at = NOW()
+                WHERE operation_key = $1 AND state = 'completed'
+                  AND marker_cleanup_state = 'pending'
+                  AND attempt_generation = $2 AND attempt_owner = $3`,
+              [id, attempt.generation, attempt.owner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(id);
+            return read();
+          },
+          async recordCleanupError(id, attempt, cleanupError) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET marker_cleanup_error = $2::jsonb, updated_at = NOW()
+                WHERE operation_key = $1 AND state = 'completed'
+                  AND marker_cleanup_state = 'pending'
+                  AND attempt_generation = $3 AND attempt_owner = $4`,
+              [id, JSON.stringify(cleanupError), attempt.generation, attempt.owner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(id);
+            return read();
+          },
+          async recordUncertainty(id, attempt, uncertainty) {
+            const result = await client.query(
+              `UPDATE provider_operations SET uncertainty = $2::jsonb, updated_at = NOW()
+                WHERE operation_key = $1
+                  AND state IN ('provider_started', 'provider_applied')
+                  AND attempt_generation = $3 AND attempt_owner = $4`,
+              [id, JSON.stringify(uncertainty), attempt.generation, attempt.owner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(id);
+            return read();
+          },
+          async markManualIntervention(id, attempt, uncertainty) {
+            const result = await client.query(
+              `UPDATE provider_operations
+                  SET state = 'manual_intervention', uncertainty = $2::jsonb, updated_at = NOW()
+                WHERE operation_key = $1 AND state = 'provider_started'
+                  AND attempt_generation = $3 AND attempt_owner = $4`,
+              [id, JSON.stringify(uncertainty), attempt.generation, attempt.owner],
+            );
+            if (result.rowCount !== 1) throw ownershipLost(id);
+            return read();
+          },
+        });
+      } finally {
+        await client.query('SELECT pg_advisory_unlock(hashtextextended($1, 0))', [operationId]).catch(() => {});
+        client.release();
+      }
+    },
+  };
+}
+
+export const providerOperationExecutor = createProviderOperationExecutor({
+  repository: {
+    withOwnership(...args) {
+      return createPostgresProviderOperationRepository().withOwnership(...args);
+    },
+    listPendingCleanup(...args) {
+      return createPostgresProviderOperationRepository().listPendingCleanup(...args);
+    },
+    findMoveBySource(...args) {
+      return createPostgresProviderOperationRepository().findMoveBySource(...args);
+    },
+  },
+});
+
+export const providerOperationStates = Object.freeze([...STATES]);

--- a/backend/src/services/providerOperations.migration.test.js
+++ b/backend/src/services/providerOperations.migration.test.js
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL('../../migrations/0053_provider_operations.sql', import.meta.url),
+  'utf8',
+);
+const topologyMigration = readFileSync(
+  new URL('../../migrations/0052_folder_observation_generation.sql', import.meta.url),
+  'utf8',
+);
+
+describe('provider operations migration', () => {
+  it('stores monotonic intent, ownership, uncertainty, observations, and receipt data', () => {
+    expect(migration).toMatch(/CREATE TABLE provider_operations/i);
+    expect(migration).toMatch(/operation_key\s+TEXT\s+NOT NULL\s+UNIQUE/i);
+    expect(migration).toMatch(/state\s+TEXT\s+NOT NULL/i);
+    expect(migration).toMatch(/provider_started/i);
+    expect(migration).toMatch(/provider_applied/i);
+    expect(migration).toMatch(/completed/i);
+    expect(migration).toMatch(/manual_intervention/i);
+    expect(migration).toMatch(/attempt_generation\s+BIGINT\s+NOT NULL/i);
+    expect(migration).toMatch(/attempt_owner\s+UUID/i);
+    expect(migration).toMatch(/marker\s+TEXT\s+NOT NULL\s+UNIQUE/i);
+    expect(migration).toMatch(/source_observation\s+JSONB/i);
+    expect(migration).toMatch(/destination_observation\s+JSONB/i);
+    expect(migration).toMatch(/receipt\s+JSONB/i);
+    expect(migration).toMatch(/uncertainty\s+JSONB/i);
+  });
+
+  it('gives snooze wakeup an exact message-row identity', () => {
+    expect(topologyMigration).toMatch(/ALTER TABLE snoozed_messages[\s\S]*message_row_id\s+UUID/i);
+    expect(topologyMigration).toMatch(/REFERENCES messages\s*\(id\)/i);
+    expect(topologyMigration).toMatch(/REFERENCES messages\s*\(id\)\s+ON DELETE SET NULL/i);
+    expect(topologyMigration).not.toMatch(/message_row_id[\s\S]{0,100}ON DELETE CASCADE/i);
+    expect(topologyMigration).toMatch(/UPDATE\s+snoozed_messages[\s\S]*SET\s+message_row_id/i);
+    expect(topologyMigration).not.toMatch(/MIN\s*\(\s*m\.id\s*\)/i);
+    expect(topologyMigration).toMatch(/COUNT\s*\(\*\)\s+OVER\s*\(\s*PARTITION BY\s+sm\.id\s*\)/i);
+    expect(topologyMigration).toMatch(/m\.metadata_complete\s*=\s*true/i);
+    expect(topologyMigration).toMatch(/JOIN\s+folders\s+f[\s\S]*f\.is_present\s*=\s*true[\s\S]*f\.uid_validity\s+IS\s+NOT\s+NULL/i);
+
+    const bindLegacySnoozes = topologyMigration.search(/UPDATE\s+snoozed_messages\s+sm/i);
+    const quarantineFolders = topologyMigration.search(/UPDATE\s+folders\s+SET\s+is_present\s*=\s*false/i);
+    expect(bindLegacySnoozes).toBeGreaterThan(-1);
+    expect(quarantineFolders).toBeGreaterThan(bindLegacySnoozes);
+    expect(migration).not.toMatch(/UPDATE\s+snoozed_messages\s+sm[\s\S]*SET\s+message_row_id/i);
+  });
+
+  it('preserves active and manual snoozes when their correlated message is later deleted', () => {
+    expect(topologyMigration).toMatch(/message_row_id\s+UUID[\s\S]{0,100}ON DELETE SET NULL/i);
+  });
+
+  it('retains ambiguous and null legacy snoozes for manual reconciliation', () => {
+    expect(topologyMigration).not.toMatch(/DELETE\s+FROM\s+snoozed_messages/i);
+  });
+
+  it('persists a manual state that orphan cleanup cannot consume', () => {
+    expect(topologyMigration).toMatch(/resolution_state\s+TEXT\s+NOT\s+NULL\s+DEFAULT\s+'active'/i);
+    expect(topologyMigration).toMatch(/manual_intervention/i);
+  });
+});

--- a/backend/src/services/providerOperations.test.js
+++ b/backend/src/services/providerOperations.test.js
@@ -1,0 +1,1021 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildProviderOperationId,
+  buildProviderOperationIdentity,
+  createPostgresProviderOperationRepository,
+  createProviderOperationExecutor,
+  ProviderOperationError,
+  providerOperationMarker,
+} from './providerOperations.js';
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(r => { resolve = r; });
+  return { promise, resolve };
+}
+
+function memoryRepository(initial = null) {
+  let row = initial;
+  let tail = Promise.resolve();
+  const assertOwner = (attempt) => {
+    if (row.attemptGeneration !== attempt.generation || row.attemptOwner !== attempt.owner) {
+      throw new ProviderOperationError('Provider operation ownership was lost', {
+        code: 'PROVIDER_OPERATION_OWNERSHIP_LOST', retryable: true, uncertain: true,
+      });
+    }
+  };
+  return {
+    get row() { return row; },
+    stealOwnership(owner = 'new-owner') {
+      row = { ...row, attemptGeneration: row.attemptGeneration + 1, attemptOwner: owner };
+    },
+    async withOwnership(operationId, callback) {
+      const previous = tail;
+      const turn = deferred();
+      tail = turn.promise;
+      await previous;
+      try {
+        return await callback({
+          async loadExisting() {
+            return row?.id === operationId ? structuredClone(row) : null;
+          },
+          async loadOrCreate(intent) {
+            row ||= {
+              ...intent, state: 'ready', attemptGeneration: 0, receipt: null,
+              cleanupState: 'pending',
+            };
+            return structuredClone(row);
+          },
+          async refreshReadyIntent(expected, intent) {
+            if (row.state === 'ready' && row.attemptGeneration === expected.attemptGeneration &&
+                row.attemptOwner === expected.attemptOwner) {
+              row = { ...row, source: intent.source, destination: intent.destination };
+            }
+            return structuredClone(row);
+          },
+          async rebaseInFlightIntent(expected, intent) {
+            if (row.state === expected.state &&
+                row.attemptGeneration === expected.attemptGeneration &&
+                row.attemptOwner === expected.attemptOwner) {
+              const rebaseToken = (persisted, fresh) => ({
+                ...persisted,
+                generation: fresh.generation,
+                topologyIdentity: fresh.topologyIdentity,
+              });
+              row = {
+                ...row,
+                requestKey: intent.requestKey,
+                sourceMessageId: intent.sourceMessageId,
+                source: row.source ? rebaseToken(row.source, intent.source) : null,
+                destination: rebaseToken(row.destination, intent.destination),
+                receipt: row.receipt ? {
+                  ...row.receipt,
+                  ...(row.receipt.sourceToken ? {
+                    sourceToken: rebaseToken(row.receipt.sourceToken, intent.source),
+                  } : {}),
+                  ...(row.receipt.destinationToken ? {
+                    destinationToken: rebaseToken(
+                      row.receipt.destinationToken, intent.destination,
+                    ),
+                  } : {}),
+                } : null,
+              };
+            }
+            return structuredClone(row);
+          },
+          async withMutationFence(callback) {
+            return callback({});
+          },
+          async markProviderStarted(_id, owner) {
+            if (row.state !== 'ready') return structuredClone(row);
+            row = {
+              ...row,
+              state: 'provider_started',
+              attemptGeneration: row.attemptGeneration + 1,
+              attemptOwner: owner,
+            };
+            return structuredClone(row);
+          },
+          async markProviderApplied(_id, attempt, receipt) {
+            assertOwner(attempt);
+            if (row.state === 'provider_started') row = { ...row, state: 'provider_applied', receipt };
+            return structuredClone(row);
+          },
+          async claimAttempt(_id, state, owner) {
+            if (row.state === state) {
+              row = {
+                ...row,
+                attemptGeneration: row.attemptGeneration + 1,
+                attemptOwner: owner,
+              };
+            }
+            return structuredClone(row);
+          },
+          async markCompleted(_id, attempt, receipt) {
+            assertOwner(attempt);
+            if (row.state === 'provider_applied') row = { ...row, state: 'completed', receipt };
+            return structuredClone(row);
+          },
+          async markCleanupCompleted(_id, attempt) {
+            assertOwner(attempt);
+            row = { ...row, cleanupState: 'completed' };
+            return structuredClone(row);
+          },
+          async recordCleanupError(_id, attempt, cleanupError) {
+            assertOwner(attempt);
+            row = { ...row, cleanupError };
+            return structuredClone(row);
+          },
+          async recordUncertainty(_id, attempt, uncertainty) {
+            assertOwner(attempt);
+            row = { ...row, uncertainty };
+            return structuredClone(row);
+          },
+          async markManualIntervention(_id, attempt, uncertainty) {
+            assertOwner(attempt);
+            row = { ...row, state: 'manual_intervention', uncertainty };
+            return structuredClone(row);
+          },
+        });
+      } finally {
+        turn.resolve();
+      }
+    },
+  };
+}
+
+const moveIntent = buildProviderOperationIdentity({
+  kind: 'move',
+  accountId: 'account-1',
+  requestKey: 'archive-row-1',
+  source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+  destination: { folder: 'Archive', uidValidity: '202', generation: '8' },
+});
+
+describe('provider operation identity', () => {
+  it('derives the exact persisted operation id from stable archive request facts alone', () => {
+    expect(buildProviderOperationId({
+      kind: 'move', accountId: 'account-1', requestKey: 'archive-row-1',
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101' },
+      destinationFolder: 'Archive',
+    })).toBe(moveIntent.id);
+  });
+
+  it('derives one deterministic IMAP-atom-safe marker without Message-ID causality', () => {
+    const headerful = buildProviderOperationIdentity({
+      ...moveIntent,
+      messageId: '<duplicate@example.com>',
+    });
+    const headerless = buildProviderOperationIdentity({ ...moveIntent, messageId: null });
+
+    expect(headerful.id).toBe(headerless.id);
+    expect(headerful.marker).toBe(headerless.marker);
+    expect(headerful.marker).toMatch(/^\$MailFlowOp-[A-Za-z0-9_-]{43}$/);
+    expect(providerOperationMarker(headerful.id)).toBe(headerful.marker);
+  });
+
+  it('requires authoritative source and destination epochs for UID-addressed transitions', () => {
+    expect(() => buildProviderOperationIdentity({
+      kind: 'copy', accountId: 'account-1',
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+      destination: { folder: 'Todo', uidValidity: null, generation: '8' },
+    })).toThrow(/destination uidvalidity/i);
+  });
+
+  it.each(['move', 'copy'])('keeps %s identity stable across fresh observation generations', kind => {
+    const first = buildProviderOperationIdentity({
+      kind, accountId: 'account-1', requestKey: 'request-1',
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+      destination: { folder: 'Archive', uidValidity: '202', generation: '8' },
+    });
+    const fresh = buildProviderOperationIdentity({
+      kind, accountId: 'account-1', requestKey: 'request-1',
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '40' },
+      destination: { folder: 'Archive', uidValidity: '999', generation: '80' },
+    });
+
+    expect(fresh.id).toBe(first.id);
+    expect(fresh.marker).toBe(first.marker);
+  });
+
+  it('creates a new COPY lifecycle when the caller supplies a new durable request key', () => {
+    const shared = {
+      kind: 'copy', accountId: 'account-1',
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+      destination: { folder: 'Todo', uidValidity: '202', generation: '8' },
+    };
+    const applied = buildProviderOperationIdentity({ ...shared, requestKey: 'label-apply-1' });
+    const reapplied = buildProviderOperationIdentity({ ...shared, requestKey: 'label-apply-2' });
+
+    expect(reapplied.id).not.toBe(applied.id);
+    expect(reapplied.marker).not.toBe(applied.marker);
+  });
+
+  it.each(['move', 'copy'])('requires an explicit durable request key for %s', kind => {
+    expect(() => buildProviderOperationIdentity({
+      kind, accountId: 'account-1',
+      source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+      destination: { folder: 'Archive', uidValidity: '202', generation: '8' },
+    })).toThrow(/request key/i);
+  });
+
+  it('keeps APPEND identity stable across a fresh destination observation', () => {
+    const first = buildProviderOperationIdentity({
+      kind: 'append', accountId: 'account-1', requestKey: 'send-1',
+      destination: { folder: 'Sent', uidValidity: '202', generation: '8' },
+    });
+    const fresh = buildProviderOperationIdentity({
+      kind: 'append', accountId: 'account-1', requestKey: 'send-1',
+      destination: { folder: 'Sent', uidValidity: '999', generation: '80' },
+    });
+
+    expect(fresh.id).toBe(first.id);
+    expect(fresh.marker).toBe(first.marker);
+  });
+});
+
+describe('durable provider operation executor', () => {
+  it.each(['provider_started', 'provider_applied'])(
+    'rebases fresh advancing observations for %s when epochs and topology identities match',
+    async state => {
+      const persistedIntent = buildProviderOperationIdentity({
+        ...moveIntent,
+        source: {
+          ...moveIntent.source, generation: '4', topologyIdentity: 'source-incarnation',
+        },
+        destination: {
+          ...moveIntent.destination, generation: '8', topologyIdentity: 'dest-incarnation',
+        },
+      });
+      const freshIntent = buildProviderOperationIdentity({
+        ...moveIntent,
+        sourceMessageId: '11111111-1111-4111-8111-111111111111',
+        source: {
+          ...moveIntent.source, generation: '40', topologyIdentity: 'source-incarnation',
+        },
+        destination: {
+          ...moveIntent.destination, generation: '80', topologyIdentity: 'dest-incarnation',
+        },
+      });
+      const receipt = state === 'provider_applied' ? {
+        uid: 88, uidValidity: '202', sourceToken: persistedIntent.source,
+        destinationToken: persistedIntent.destination,
+      } : null;
+      const repository = memoryRepository({
+        ...persistedIntent, requestKey: null, sourceMessageId: null,
+        state, attemptGeneration: 1,
+        attemptOwner: 'old-owner', receipt, cleanupState: 'pending',
+      });
+      const executor = createProviderOperationExecutor({ repository });
+      const observed = [];
+
+      await executor.execute({
+        intent: freshIntent,
+        acquireProvider: callback => callback({}),
+        validateRecovery: (_provider, _tx, operation) => observed.push(operation),
+        recover: vi.fn().mockResolvedValue({
+          status: 'unique', uid: 88, uidValidity: '202',
+          sourceToken: freshIntent.source, destinationToken: freshIntent.destination,
+        }),
+        validateCompletion: (_tx, operation) => observed.push(operation),
+        complete: receiptValue => receiptValue,
+      });
+
+      expect(repository.row.source.generation).toBe('40');
+      expect(repository.row.destination.generation).toBe('80');
+      expect(repository.row.requestKey).toBe(moveIntent.requestKey);
+      expect(repository.row.sourceMessageId).toBe('11111111-1111-4111-8111-111111111111');
+      expect(observed.at(-1).destination.generation).toBe('80');
+      if (state === 'provider_applied') {
+        expect(repository.row.receipt.sourceToken.generation).toBe('40');
+        expect(repository.row.receipt.destinationToken.generation).toBe('80');
+      }
+    },
+  );
+
+  it.each([
+    ['source UIDVALIDITY', { source: { uidValidity: '999' } }],
+    ['destination topology identity', { destination: { topologyIdentity: 'recreated' } }],
+  ])('rejects in-flight observation rebasing across %s changes', async (_case, change) => {
+    const persisted = buildProviderOperationIdentity({
+      ...moveIntent,
+      source: { ...moveIntent.source, topologyIdentity: 'source-incarnation' },
+      destination: { ...moveIntent.destination, topologyIdentity: 'dest-incarnation' },
+    });
+    const fresh = buildProviderOperationIdentity({
+      ...persisted,
+      source: { ...persisted.source, generation: '40', ...(change.source || {}) },
+      destination: { ...persisted.destination, generation: '80', ...(change.destination || {}) },
+    });
+    const repository = memoryRepository({
+      ...persisted, state: 'provider_started', attemptGeneration: 1,
+      attemptOwner: 'old-owner', receipt: null, cleanupState: 'pending',
+    });
+    const executor = createProviderOperationExecutor({ repository });
+
+    expect(fresh.id).toBe(persisted.id);
+
+    await expect(executor.execute({
+      intent: fresh, acquireProvider: callback => callback({}),
+      validateRecovery: vi.fn(), recover: vi.fn(), validateCompletion: vi.fn(),
+    })).rejects.toMatchObject({ code: 'PROVIDER_OPERATION_IDENTITY_MISMATCH' });
+  });
+
+  it('runs post-commit work and marker cleanup only after the completion transaction commits', async () => {
+    const events = [];
+    const base = memoryRepository({
+      ...moveIntent, state: 'provider_applied', attemptGeneration: 1,
+      attemptOwner: 'old-owner', receipt: { uid: 88 }, cleanupState: 'pending',
+    });
+    const repository = {
+      ...base,
+      get row() { return base.row; },
+      withOwnership(id, callback) {
+        return base.withOwnership(id, session => callback({
+          ...session,
+          async withMutationFence(run) {
+            events.push('begin');
+            const result = await run({});
+            events.push('commit');
+            return result;
+          },
+        }));
+      },
+    };
+    const executor = createProviderOperationExecutor({ repository });
+
+    await executor.execute({
+      intent: moveIntent,
+      acquireProvider: callback => callback({}),
+      validateCompletion: vi.fn(),
+      complete: receipt => { events.push('materialize'); return receipt; },
+      afterCommit: () => events.push('afterCommit'),
+      cleanup: () => events.push('cleanup'),
+    });
+
+    expect(events).toEqual(['begin', 'materialize', 'commit', 'afterCommit', 'cleanup']);
+    expect(base.row.cleanupState).toBe('completed');
+  });
+
+  it('retries pending marker cleanup on completed receipt replay without rematerializing', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'completed', attemptGeneration: 2,
+      attemptOwner: 'old-owner', receipt: { uid: 88 }, cleanupState: 'pending',
+    });
+    const executor = createProviderOperationExecutor({ repository });
+    const cleanup = vi.fn();
+    const complete = vi.fn();
+
+    await executor.execute({
+      intent: moveIntent, acquireProvider: callback => callback({}), cleanup, complete,
+    });
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(complete).not.toHaveBeenCalled();
+    expect(repository.row.cleanupState).toBe('completed');
+  });
+
+  it('recovery-only lookup never creates or advances a provider_started operation', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_started', attemptGeneration: 1,
+      attemptOwner: 'dead-worker', receipt: null,
+    });
+    const executor = createProviderOperationExecutor({ repository });
+    const complete = vi.fn();
+
+    await expect(executor.completeExisting(moveIntent.id, { complete })).resolves.toMatchObject({
+      status: 'pending', operation: { id: moveIntent.id, state: 'provider_started' },
+    });
+
+    expect(repository.row.state).toBe('provider_started');
+    expect(repository.row.attemptGeneration).toBe(1);
+    expect(complete).not.toHaveBeenCalled();
+  });
+
+  it('recovery-only lookup atomically completes only the exact provider_applied operation', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_applied', attemptGeneration: 1,
+      attemptOwner: 'old-worker', receipt: { uid: 88, uidValidity: '202' },
+    });
+    const executor = createProviderOperationExecutor({ repository });
+    const validateExisting = vi.fn();
+    const validateCompletion = vi.fn();
+    const complete = vi.fn(receipt => ({ ...receipt, materialized: true }));
+
+    await expect(executor.completeExisting(moveIntent.id, {
+      validateExisting, validateCompletion, complete,
+    })).resolves.toMatchObject({
+      status: 'completed', receipt: { uid: 88, uidValidity: '202', materialized: true },
+      replayed: false,
+    });
+
+    expect(repository.row.state).toBe('completed');
+    expect(validateExisting).toHaveBeenCalledOnce();
+    expect(validateCompletion).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it('recovery-only provider_applied replay rebases fresh observations and retries cleanup post-commit', async () => {
+    const persisted = buildProviderOperationIdentity({
+      ...moveIntent,
+      source: { ...moveIntent.source, topologyIdentity: 'source-incarnation' },
+      destination: { ...moveIntent.destination, topologyIdentity: 'dest-incarnation' },
+    });
+    const fresh = buildProviderOperationIdentity({
+      ...persisted,
+      source: { ...persisted.source, generation: '40' },
+      destination: { ...persisted.destination, generation: '80' },
+    });
+    const repository = memoryRepository({
+      ...persisted, state: 'provider_applied', attemptGeneration: 1,
+      attemptOwner: 'old-owner', cleanupState: 'pending',
+      receipt: {
+        uid: 88, sourceToken: persisted.source, destinationToken: persisted.destination,
+      },
+    });
+    const executor = createProviderOperationExecutor({ repository });
+    const cleanup = vi.fn();
+
+    await executor.completeExisting(persisted.id, {
+      intent: fresh, acquireProvider: callback => callback({}), cleanup,
+      validateCompletion: (_tx, operation) => {
+        expect(operation.source.generation).toBe('40');
+        expect(operation.destination.generation).toBe('80');
+      },
+      complete: receipt => receipt,
+    });
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(repository.row.cleanupState).toBe('completed');
+    expect(repository.row.receipt.destinationToken.generation).toBe('80');
+  });
+
+  it('recovery-only lookup replays completed and rejects a different operation id without callbacks', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'completed', attemptGeneration: 1,
+      receipt: { uid: 88, uidValidity: '202' },
+    });
+    const executor = createProviderOperationExecutor({ repository });
+    const validateExisting = vi.fn();
+    const complete = vi.fn();
+
+    await expect(executor.completeExisting(moveIntent.id, {
+      validateExisting, complete,
+    })).resolves.toMatchObject({
+      status: 'completed', receipt: { uid: 88, uidValidity: '202' }, replayed: true,
+    });
+    await expect(executor.completeExisting('different-operation', {
+      validateExisting, complete,
+    })).resolves.toEqual({ status: 'missing' });
+
+    expect(validateExisting).toHaveBeenCalledOnce();
+    expect(complete).not.toHaveBeenCalled();
+  });
+
+  it.each(['copy', 'append'])(
+    'rolls back %s materialization and completed state together when fence COMMIT fails',
+    async kind => {
+      const intent = kind === 'append' ? buildProviderOperationIdentity({
+        kind, accountId: 'account-1', requestKey: 'request-1',
+        destination: { folder: 'Drafts', uidValidity: '202', generation: '8' },
+      }) : buildProviderOperationIdentity({
+        kind, accountId: 'account-1', requestKey: 'request-1',
+        source: { folder: 'INBOX', uid: 7, uidValidity: '101', generation: '4' },
+        destination: { folder: 'Todo', uidValidity: '202', generation: '8' },
+      });
+      let durable = {
+        ...intent, state: 'provider_applied', attemptGeneration: 1,
+        attemptOwner: 'old-owner', receipt: { uid: 88, uidValidity: '202' },
+      };
+      let materialized = false;
+      let failCommit = true;
+      const repository = {
+        get row() { return durable; },
+        get materialized() { return materialized; },
+        async withOwnership(_id, callback) {
+          return callback({
+            async loadOrCreate() { return structuredClone(durable); },
+            async refreshReadyIntent() { throw new Error('not ready'); },
+            async claimAttempt(expected, state, owner) {
+              expect(durable.state).toBe(state);
+              durable = {
+                ...durable, attemptGeneration: expected.attemptGeneration + 1,
+                attemptOwner: owner,
+              };
+              return structuredClone(durable);
+            },
+            async withMutationFence(run) {
+              const staged = { row: structuredClone(durable), materialized };
+              const tx = {
+                staged,
+                materialize() { staged.materialized = true; },
+              };
+              const result = await run(tx);
+              if (failCommit) {
+                failCommit = false;
+                throw new Error('COMMIT failed');
+              }
+              durable = staged.row;
+              materialized = staged.materialized;
+              return result;
+            },
+            async markCompleted(_id, _attempt, receipt, tx) {
+              const completed = { ...durable, state: 'completed', receipt };
+              if (tx) tx.staged.row = completed;
+              else durable = completed;
+              return structuredClone(completed);
+            },
+          });
+        },
+      };
+      const complete = vi.fn(async (receipt, _operation, tx) => {
+        tx.materialize();
+        return { ...receipt, materialized: true };
+      });
+      const executor = createProviderOperationExecutor({ repository });
+      const spec = {
+        intent, acquireProvider: vi.fn(), validateCompletion: vi.fn(), complete,
+      };
+
+      await expect(executor.execute(spec)).rejects.toThrow('COMMIT failed');
+      expect(repository.row.state).toBe('provider_applied');
+      expect(repository.materialized).toBe(false);
+
+      await expect(executor.execute(spec)).resolves.toMatchObject({ materialized: true });
+      expect(repository.row.state).toBe('completed');
+      expect(repository.materialized).toBe(true);
+      expect(complete).toHaveBeenCalledTimes(2);
+      expect(spec.acquireProvider).not.toHaveBeenCalled();
+    },
+  );
+
+  it('serializes simultaneous first attempts and replays the completed receipt', async () => {
+    const repository = memoryRepository();
+    const command = vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202' });
+    const executor = createProviderOperationExecutor({ repository, maxConcurrent: 2 });
+    const run = () => executor.execute({
+      intent: moveIntent,
+      acquireProvider: callback => callback({}),
+      validate: vi.fn().mockResolvedValue(undefined),
+      prepare: vi.fn().mockResolvedValue(undefined),
+      command,
+      recover: vi.fn(),
+      complete: receipt => ({ ...receipt, materialized: true }),
+    });
+
+    const [first, second] = await Promise.all([run(), run()]);
+
+    expect(command).toHaveBeenCalledOnce();
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({ uid: 88, uidValidity: '202', materialized: true });
+    expect(repository.row.state).toBe('completed');
+    expect(repository.row.attemptGeneration).toBe(1);
+  });
+
+  it('takes over provider_started by marker recovery and never repeats the command', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_started', attemptGeneration: 1,
+      attemptOwner: 'dead-worker', receipt: null,
+    });
+    const command = vi.fn();
+    const recover = vi.fn().mockResolvedValue({ status: 'unique', uid: 88, uidValidity: '202' });
+    const executor = createProviderOperationExecutor({ repository });
+
+    await expect(executor.execute({
+      intent: moveIntent,
+      acquireProvider: callback => callback({}),
+      validate: vi.fn(), validateRecovery: vi.fn(), prepare: vi.fn(), command, recover,
+      complete: receipt => receipt,
+    })).resolves.toMatchObject({ uid: 88, uidValidity: '202' });
+
+    expect(command).not.toHaveBeenCalled();
+    expect(recover).toHaveBeenCalledOnce();
+    expect(repository.row.state).toBe('completed');
+    expect(repository.row.attemptGeneration).toBe(2);
+    expect(repository.row.attemptOwner).not.toBe('dead-worker');
+  });
+
+  it.each([
+    ['absent', { status: 'absent' }, 'PROVIDER_MARKER_ABSENT'],
+    ['ambiguous', { status: 'ambiguous', uids: [88, 89] }, 'PROVIDER_MARKER_AMBIGUOUS'],
+  ])('keeps provider_started uncertain when the marker is %s', async (_name, recovery, code) => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_started', attemptGeneration: 3,
+      attemptOwner: 'dead-worker', receipt: null,
+    });
+    const command = vi.fn();
+    const executor = createProviderOperationExecutor({ repository });
+
+    await expect(executor.execute({
+      intent: moveIntent,
+      acquireProvider: callback => callback({}),
+      validate: vi.fn(), validateRecovery: vi.fn(), prepare: vi.fn(), command,
+      recover: vi.fn().mockResolvedValue(recovery),
+      complete: vi.fn(),
+    })).rejects.toMatchObject({ code, retryable: true, uncertain: true });
+
+    expect(command).not.toHaveBeenCalled();
+    expect(repository.row.state).toBe('provider_started');
+    expect(repository.row.uncertainty.code).toBe(code);
+  });
+
+  it('keeps SEARCH failure typed and uncertain without repeating provider command', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_started', attemptGeneration: 1,
+      attemptOwner: 'dead-worker', receipt: null,
+    });
+    const command = vi.fn();
+    const executor = createProviderOperationExecutor({ repository });
+
+    await expect(executor.execute({
+      intent: moveIntent,
+      acquireProvider: callback => callback({}),
+      validate: vi.fn(), validateRecovery: vi.fn(), prepare: vi.fn(), command,
+      recover: vi.fn().mockRejectedValue(new Error('IMAP SEARCH failed')),
+      complete: vi.fn(),
+    })).rejects.toMatchObject({
+      code: 'PROVIDER_RECOVERY_FAILED', retryable: true, uncertain: true,
+    });
+    expect(command).not.toHaveBeenCalled();
+    expect(repository.row.state).toBe('provider_started');
+    expect(repository.row.uncertainty.code).toBe('PROVIDER_RECOVERY_FAILED');
+  });
+
+  it('replays provider_applied and completed receipts without provider acquisition', async () => {
+    for (const state of ['provider_applied', 'completed']) {
+      const repository = memoryRepository({
+        ...moveIntent, state, attemptGeneration: 1,
+        receipt: { uid: 88, uidValidity: '202' },
+      });
+      const acquireProvider = vi.fn(callback => callback({}));
+      const complete = vi.fn(receipt => ({ ...receipt, materialized: true }));
+      const validateCompletion = vi.fn();
+      const executor = createProviderOperationExecutor({ repository });
+
+      const result = await executor.execute({
+        intent: moveIntent, acquireProvider,
+        validate: vi.fn(), validateCompletion, prepare: vi.fn(), command: vi.fn(), recover: vi.fn(), complete,
+      });
+
+      expect(acquireProvider).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ uid: 88, uidValidity: '202' });
+      expect(complete).toHaveBeenCalledTimes(state === 'provider_applied' ? 1 : 0);
+      expect(validateCompletion).toHaveBeenCalledTimes(state === 'provider_applied' ? 1 : 0);
+    }
+  });
+
+  it('reacquires the provider for an opted-in provider_applied completion replay', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_applied', attemptGeneration: 1,
+      receipt: { uid: 88, uidValidity: '202' },
+    });
+    const provider = { client: { id: 'destination-client' } };
+    const acquireProvider = vi.fn(callback => callback(provider));
+    const complete = vi.fn((receipt, _operation, _tx, resource) => {
+      expect(resource).toBe(provider);
+      return receipt;
+    });
+    const executor = createProviderOperationExecutor({ repository });
+
+    await expect(executor.execute({
+      intent: moveIntent, acquireProvider, completeWithProvider: true,
+      validate: vi.fn(), validateCompletion: vi.fn(), prepare: vi.fn(),
+      command: vi.fn(), recover: vi.fn(), complete,
+    })).resolves.toMatchObject({ uid: 88, uidValidity: '202' });
+
+    expect(acquireProvider).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledOnce();
+    expect(repository.row.state).toBe('completed');
+  });
+
+  it('recovery-only completion reacquires the provider when materialization requires it', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_applied', attemptGeneration: 1,
+      receipt: { uid: 88, uidValidity: '202' },
+    });
+    const provider = { client: { id: 'destination-client' } };
+    const acquireProvider = vi.fn(callback => callback(provider));
+    const complete = vi.fn((receipt, _operation, _tx, resource) => {
+      expect(resource).toBe(provider);
+      return receipt;
+    });
+    const executor = createProviderOperationExecutor({ repository });
+
+    await expect(executor.completeExisting(moveIntent.id, {
+      acquireProvider, completeWithProvider: true, complete,
+    })).resolves.toMatchObject({ status: 'completed' });
+
+    expect(acquireProvider).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledOnce();
+  });
+
+  it.each(['first command', 'provider_applied replay'])(
+    'fences completion and refuses a superseded destination on %s',
+    async phase => {
+      let fenced = false;
+      const initial = phase === 'provider_applied replay' ? {
+        ...moveIntent, state: 'provider_applied', attemptGeneration: 1,
+        attemptOwner: 'old-owner', receipt: { uid: 88, uidValidity: '202' },
+      } : null;
+      const base = memoryRepository(initial);
+      const repository = {
+        ...base,
+        withOwnership(id, callback) {
+          return base.withOwnership(id, session => callback({
+            ...session,
+            async withMutationFence(run) {
+              fenced = true;
+              try { return await run({}); } finally { fenced = false; }
+            },
+          }));
+        },
+      };
+      const complete = vi.fn();
+      const executor = createProviderOperationExecutor({ repository });
+
+      await expect(executor.execute({
+        intent: moveIntent,
+        acquireProvider: callback => callback({}),
+        validate: vi.fn(), prepare: vi.fn(),
+        command: vi.fn().mockResolvedValue({ uid: 88, uidValidity: '202' }),
+        recover: vi.fn(),
+        validateCompletion: () => {
+          expect(fenced).toBe(true);
+          throw Object.assign(new Error('destination superseded'), {
+            code: 'FOLDER_OBSERVATION_SUPERSEDED',
+          });
+        },
+        complete,
+      })).rejects.toMatchObject({ code: 'FOLDER_OBSERVATION_SUPERSEDED' });
+
+      expect(complete).not.toHaveBeenCalled();
+      expect(base.row.state).toBe('provider_applied');
+    },
+  );
+
+  it('refreshes a still-ready operation to the caller\'s current validated observations', async () => {
+    const stale = {
+      ...moveIntent,
+      source: { ...moveIntent.source, generation: '1' },
+      destination: { ...moveIntent.destination, generation: '2' },
+      state: 'ready', attemptGeneration: 0, attemptOwner: null, receipt: null,
+    };
+    const repository = memoryRepository(stale);
+    const validate = vi.fn((_provider, _tx, operation) => {
+      expect(operation.source.generation).toBe('4');
+      expect(operation.destination.generation).toBe('8');
+    });
+    const executor = createProviderOperationExecutor({ repository });
+
+    await executor.execute({
+      intent: moveIntent, acquireProvider: callback => callback({}), validate,
+      prepare: vi.fn(), command: vi.fn().mockResolvedValue({ uid: 88 }), recover: vi.fn(),
+      validateCompletion: vi.fn(), complete: receipt => receipt,
+    });
+
+    expect(validate).toHaveBeenCalledOnce();
+  });
+
+  it('bounds concurrent ownership before provider acquisition', async () => {
+    let active = 0;
+    let maximum = 0;
+    const release = deferred();
+    const repositories = Array.from({ length: 5 }, () => memoryRepository());
+    const executor = createProviderOperationExecutor({
+      repository: {
+        withOwnership(id, callback) {
+          return repositories[Number(id.slice(-1))].withOwnership(id, callback);
+        },
+      },
+      maxConcurrent: 2,
+    });
+    const runs = repositories.map((_repo, index) => executor.execute({
+      intent: { ...moveIntent, id: `${moveIntent.id.slice(0, -1)}${index}`, marker: `${moveIntent.marker}${index}` },
+      acquireProvider: async callback => {
+        active++;
+        maximum = Math.max(maximum, active);
+        await release.promise;
+        try { return await callback({}); } finally { active--; }
+      },
+      validate: vi.fn(), prepare: vi.fn(),
+      command: vi.fn().mockResolvedValue({ uid: 80 + index, uidValidity: '202' }),
+      recover: vi.fn(), complete: receipt => receipt,
+    }));
+
+    await new Promise(resolve => setImmediate(resolve));
+    expect(maximum).toBe(2);
+    release.resolve();
+    await Promise.all(runs);
+  });
+
+  it('holds the observation fence across marker preparation and the provider command', async () => {
+    let fenced = false;
+    let releaseCommand;
+    const commandBlocked = new Promise(resolve => { releaseCommand = resolve; });
+    const base = memoryRepository();
+    const repository = {
+      ...base,
+      withOwnership(id, callback) {
+        return base.withOwnership(id, session => callback({
+          ...session,
+          async withMutationFence(run) {
+            fenced = true;
+            try { return await run({}); } finally { fenced = false; }
+          },
+        }));
+      },
+    };
+    const executor = createProviderOperationExecutor({ repository });
+    const run = executor.execute({
+      intent: moveIntent,
+      acquireProvider: callback => callback({}),
+      validate: () => expect(fenced).toBe(true),
+      prepare: () => expect(fenced).toBe(true),
+      command: async () => {
+        expect(fenced).toBe(true);
+        await commandBlocked;
+        return { uid: 88, uidValidity: '202' };
+      },
+      recover: vi.fn(), complete: receipt => receipt,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    expect(fenced).toBe(true);
+    releaseCommand();
+    await run;
+    expect(fenced).toBe(false);
+  });
+
+  it('validates the persisted destination observation before marker recovery', async () => {
+    const repository = memoryRepository({
+      ...moveIntent, state: 'provider_started', attemptGeneration: 1,
+      attemptOwner: 'dead-worker', receipt: null,
+    });
+    const recover = vi.fn();
+    const superseded = Object.assign(new Error('destination superseded'), {
+      code: 'FOLDER_OBSERVATION_SUPERSEDED',
+    });
+    const executor = createProviderOperationExecutor({ repository });
+
+    await expect(executor.execute({
+      intent: { ...moveIntent, destination: { ...moveIntent.destination, generation: '99' } },
+      acquireProvider: callback => callback({}),
+      validate: vi.fn(),
+      validateRecovery: (_provider, _tx, operation) => {
+        expect(operation.destination.generation).toBe('8');
+        throw superseded;
+      },
+      prepare: vi.fn(), command: vi.fn(), recover, complete: vi.fn(),
+    })).rejects.toMatchObject({ code: 'PROVIDER_OPERATION_IDENTITY_MISMATCH' });
+
+    expect(recover).not.toHaveBeenCalled();
+    expect(repository.row.state).toBe('provider_started');
+  });
+
+  it('rejects a stale attempt owner from provider_applied and uncertainty transitions', async () => {
+    for (const outcome of ['receipt', 'uncertainty']) {
+      const repository = memoryRepository();
+      const executor = createProviderOperationExecutor({ repository });
+      const commandError = new Error('connection lost');
+
+      const promise = executor.execute({
+        intent: moveIntent,
+        acquireProvider: callback => callback({}),
+        validate: vi.fn(), prepare: vi.fn(),
+        command: async () => {
+          repository.stealOwnership();
+          if (outcome === 'uncertainty') throw commandError;
+          return { uid: 88, uidValidity: '202' };
+        },
+        recover: vi.fn(), complete: vi.fn(),
+      });
+
+      await expect(promise).rejects.toMatchObject({
+        code: 'PROVIDER_OPERATION_OWNERSHIP_LOST',
+      });
+      expect(repository.row.state).toBe('provider_started');
+    }
+  });
+
+  it('makes UIDPLUS-marker disagreement durable and non-promotable on replay', async () => {
+    const repository = memoryRepository();
+    const executor = createProviderOperationExecutor({ repository });
+    const mismatch = new ProviderOperationError('UIDPLUS disagrees with marker', {
+      code: 'PROVIDER_RECEIPT_MISMATCH', retryable: false, uncertain: true, manual: true,
+    });
+    const recover = vi.fn().mockResolvedValue({ status: 'unique', uid: 88, uidValidity: '202' });
+    const spec = {
+      intent: moveIntent,
+      acquireProvider: callback => callback({}),
+      validate: vi.fn(), validateRecovery: vi.fn(), prepare: vi.fn(),
+      command: vi.fn().mockRejectedValue(mismatch), recover, complete: vi.fn(),
+    };
+
+    await expect(executor.execute(spec)).rejects.toMatchObject({
+      code: 'PROVIDER_RECEIPT_MISMATCH', retryable: false,
+    });
+    expect(repository.row.state).toBe('manual_intervention');
+
+    await expect(executor.execute(spec)).rejects.toMatchObject({
+      code: 'PROVIDER_RECEIPT_MISMATCH', retryable: false,
+    });
+    expect(spec.command).toHaveBeenCalledOnce();
+    expect(recover).not.toHaveBeenCalled();
+  });
+});
+
+describe('Postgres provider operation repository', () => {
+  const dbRow = {
+    operation_key: moveIntent.id,
+    kind: 'move', account_id: 'account-1', marker: moveIntent.marker,
+    source_observation: moveIntent.source,
+    destination_observation: moveIntent.destination,
+    state: 'provider_started', attempt_generation: 3, attempt_owner: 'owner-3',
+    receipt: null, uncertainty: null,
+  };
+
+  function fakePool({ transitionRowCount = 1 } = {}) {
+    const ownership = {
+      release: vi.fn(),
+      query: vi.fn(async sql => {
+        if (/SELECT \* FROM provider_operations/.test(sql)) return { rows: [dbRow] };
+        if (/^\s*UPDATE provider_operations/.test(sql)) return { rowCount: transitionRowCount };
+        return { rows: [], rowCount: 1 };
+      }),
+    };
+    const fence = {
+      release: vi.fn(),
+      query: vi.fn(async sql => (
+        /^\s*UPDATE provider_operations/.test(sql)
+          ? { rows: [dbRow], rowCount: transitionRowCount }
+          : { rows: [], rowCount: 1 }
+      )),
+    };
+    const pool = {
+      connect: vi.fn()
+        .mockResolvedValueOnce(ownership)
+        .mockResolvedValueOnce(fence),
+    };
+    return { pool, ownership, fence };
+  }
+
+  it('acquires the observation session before BEGIN and closes it after the fenced callback', async () => {
+    const { pool, fence } = fakePool();
+    const repository = createPostgresProviderOperationRepository(pool);
+    let inside = false;
+
+    await repository.withOwnership(moveIntent.id, async session => {
+      await session.withMutationFence(async tx => {
+        inside = true;
+        expect(pool.connect).toHaveBeenCalledTimes(2);
+        expect(tx).toBe(fence);
+        expect(fence.query).toHaveBeenCalledWith('BEGIN');
+        expect(fence.release).not.toHaveBeenCalled();
+      });
+      expect(inside).toBe(true);
+      expect(fence.query).toHaveBeenCalledWith('COMMIT');
+      expect(fence.release).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('guards every takeover, result, uncertainty, terminal, and completion update by attempt', async () => {
+    const { pool, ownership, fence } = fakePool();
+    const repository = createPostgresProviderOperationRepository(pool);
+    const attempt = { generation: 3, owner: 'owner-3' };
+
+    await repository.withOwnership(moveIntent.id, async session => {
+      await session.markProviderStarted(moveIntent.id, 'owner-1');
+      await session.claimAttempt({
+        id: moveIntent.id, state: 'provider_started', attemptGeneration: 3,
+        attemptOwner: 'owner-3',
+      }, 'provider_started', 'owner-4');
+      await session.markProviderApplied(moveIntent.id, attempt, { uid: 88 });
+      await session.recordUncertainty(moveIntent.id, attempt, { code: 'UNCERTAIN' });
+      await session.markManualIntervention(moveIntent.id, attempt, { code: 'MISMATCH' });
+      await session.withMutationFence(tx => (
+        session.markCompleted(moveIntent.id, attempt, { uid: 88 }, tx)
+      ));
+    });
+
+    const updates = [...ownership.query.mock.calls, ...fence.query.mock.calls]
+      .filter(([sql]) => /^\s*UPDATE provider_operations/.test(sql))
+      .map(([sql]) => sql);
+    expect(updates).toHaveLength(6);
+    for (const sql of updates) {
+      const where = sql.split(/\bWHERE\b/i)[1];
+      expect(where).toMatch(/attempt_generation\s*=/i);
+      expect(where).toMatch(/attempt_owner/i);
+    }
+  });
+
+  it('surfaces lock loss when a checked Postgres transition updates no row', async () => {
+    const { pool } = fakePool({ transitionRowCount: 0 });
+    const repository = createPostgresProviderOperationRepository(pool);
+
+    await expect(repository.withOwnership(moveIntent.id, session => (
+      session.markProviderApplied(
+        moveIntent.id, { generation: 3, owner: 'stale-owner' }, { uid: 88 },
+      )
+    ))).rejects.toMatchObject({ code: 'PROVIDER_OPERATION_OWNERSHIP_LOST' });
+  });
+});

--- a/backend/src/services/ruleForwardLifecycle.migration.test.js
+++ b/backend/src/services/ruleForwardLifecycle.migration.test.js
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL('../../migrations/0058_rule_forward_lifecycle.sql', import.meta.url),
+  'utf8',
+);
+
+describe('rule-forward lifecycle migration', () => {
+  it('migrates legacy pending deliveries to fail-closed uncertainty', () => {
+    expect(migration).toMatch(
+      /UPDATE\s+inbox_rule_forwards\s+SET\s+status\s*=\s*'uncertain'\s+WHERE\s+status\s*=\s*'pending'/i,
+    );
+    expect(migration).not.toMatch(
+      /UPDATE\s+inbox_rule_forwards\s+SET\s+status\s*=\s*'ready'\s+WHERE\s+status\s*=\s*'pending'/i,
+    );
+  });
+
+  it('adds immutable prepared SMTP payload fields to new retryable forwards', () => {
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS recipient\s+TEXT/i);
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS payload_digest\s+CHAR\(64\)/i);
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS smtp_message\s+BYTEA/i);
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS smtp_envelope\s+JSONB/i);
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS source_snapshot\s+JSONB/i);
+    expect(migration).toMatch(/ADD COLUMN IF NOT EXISTS prepared_at\s+TIMESTAMPTZ/i);
+  });
+});

--- a/backend/src/services/ruleForwarder.js
+++ b/backend/src/services/ruleForwarder.js
@@ -2,6 +2,11 @@ import { embedInlineDataImages } from '../utils/inlineImages.js';
 import { query } from './db.js';
 import { sanitizeEmail } from './emailSanitizer.js';
 import { createAccountSmtpTransport } from './smtpTransport.js';
+import { loadPreparedSmtp, renderPreparedSmtp } from './preparedSmtp.js';
+import {
+  revalidateLiveMessageSnapshots,
+  snapshotFromMessageRow,
+} from './messageSnapshots.js';
 
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
@@ -91,6 +96,11 @@ function parseAttachments(value) {
   }
 }
 
+function parseStoredJson(value) {
+  if (typeof value !== 'string') return value;
+  return JSON.parse(value);
+}
+
 function forwardedHeaders(row) {
   const from = formatAddress({
     name: row.from_name,
@@ -148,6 +158,7 @@ function ensureAttachmentLimit(attachments) {
 }
 
 async function loadForwardContent({ row, account, imapManager }) {
+  const snapshot = snapshotFromMessageRow(row);
   let text = row.body_text;
   let html = row.body_html;
   let fetchedParts = [];
@@ -155,7 +166,8 @@ async function loadForwardContent({ row, account, imapManager }) {
     const fetched = await imapManager.fetchMessageBody(
       account,
       row.uid,
-      row.folder
+      row.folder,
+      { snapshot },
     );
     text = fetched.text;
     html = fetched.html;
@@ -198,7 +210,8 @@ async function loadForwardContent({ row, account, imapManager }) {
       account,
       row.uid,
       row.folder,
-      storedParts
+      storedParts,
+      { snapshot },
     );
     fetchedAttachments = storedParts.map(attachment => {
       const content = buffers.get(attachment.part);
@@ -236,70 +249,165 @@ export async function forwardRuleMessage({
   recipient,
 }) {
   const reserved = await query(
-    `INSERT INTO inbox_rule_forwards (rule_id, message_id)
-     VALUES ($1, $2)
+    `INSERT INTO inbox_rule_forwards (rule_id, message_id, recipient)
+     VALUES ($1, $2, $3)
      ON CONFLICT (rule_id, message_id) DO NOTHING
-     RETURNING id`,
-    [ruleId, message.id]
+     RETURNING id, status, recipient, payload_digest, smtp_message, smtp_envelope,
+               source_snapshot`,
+    [ruleId, message.id, recipient]
   );
-  if (!reserved.rows.length) {
+  let reservation = reserved.rows[0] ? {
+    status: 'ready', recipient, ...reserved.rows[0],
+  } : null;
+  if (!reservation) {
     const existing = await query(
-      `SELECT status
+      `SELECT status, id, recipient, payload_digest, smtp_message, smtp_envelope,
+              source_snapshot
        FROM inbox_rule_forwards
        WHERE rule_id = $1 AND message_id = $2`,
       [ruleId, message.id]
     );
     if (existing.rows[0]?.status === 'sent') return 'duplicate';
-    throw new Error('Forward delivery pending');
+    if (['pending', 'provider_started', 'uncertain'].includes(existing.rows[0]?.status)) {
+      throw new Error('Forward delivery outcome is uncertain');
+    }
+    if (existing.rows[0]?.status !== 'ready' || !existing.rows[0]?.id) {
+      throw new Error('Forward delivery pending');
+    }
+    reservation = existing.rows[0];
+  }
+  const reservationId = reservation.id;
+  if (reservation.recipient && reservation.recipient !== recipient) {
+    throw new Error('Forward operation payload collision');
   }
 
-  const reservationId = reserved.rows[0].id;
-  let delivered = false;
+  let deliveryStarted = false;
+  let deliveryCompleted = false;
+  let preparedDurably = Boolean(reservation.smtp_message);
   try {
-    const rowResult = await query(
-      `SELECT id, account_id, uid, folder, subject, from_name, from_email,
-              to_addresses, cc_addresses, date, body_text, body_html, attachments
-       FROM messages
-       WHERE id = $1 AND account_id = $2`,
-      [message.id, account.id]
-    );
-    if (!rowResult.rows.length) {
-      throw new Error('Forward source message not found');
+    if (!preparedDurably) {
+      const rowResult = await query(
+        `SELECT m.id, m.account_id, m.uid, m.folder, m.subject, m.from_name, m.from_email,
+                m.to_addresses, m.cc_addresses, m.date, m.body_text, m.body_html, m.attachments,
+                m.read_revision, m.star_revision,
+                live_folder.uid_validity AS folder_uid_validity,
+                live_folder.observation_generation AS folder_observation_generation
+         FROM messages m
+         JOIN folders live_folder ON live_folder.account_id = m.account_id
+           AND live_folder.path = m.folder AND live_folder.is_present = true
+           AND live_folder.uid_validity IS NOT NULL
+         WHERE m.id = $1 AND m.account_id = $2
+           AND m.is_deleted = false AND m.metadata_complete = true`,
+        [message.id, account.id]
+      );
+      if (!rowResult.rows.length) {
+        throw new Error('Forward source message not found');
+      }
+      const row = rowResult.rows[0];
+      const sourceSnapshot = snapshotFromMessageRow(row);
+      const content = await loadForwardContent({ row, account, imapManager });
+      await revalidateLiveMessageSnapshots(account.id, [sourceSnapshot]);
+      const prepared = await renderPreparedSmtp(
+        buildForwardMessage({ row, account, recipient, ...content }),
+        { from: account.email_address, to: [recipient] },
+      );
+      const stored = await query(
+        `UPDATE inbox_rule_forwards
+            SET recipient = $2, payload_digest = $3, smtp_message = $4,
+                smtp_envelope = $5::jsonb, source_snapshot = $6::jsonb,
+                prepared_at = NOW()
+          WHERE id = $1 AND status = 'ready' AND smtp_message IS NULL
+            AND (recipient IS NULL OR recipient = $2)
+          RETURNING id, status, recipient, payload_digest, smtp_message, smtp_envelope,
+                    source_snapshot`,
+        [
+          reservationId, recipient, prepared.digest, prepared.message,
+          JSON.stringify(prepared.envelope), JSON.stringify(sourceSnapshot),
+        ],
+      );
+      if (stored?.rowCount === 0) {
+        const replay = await query(
+          `SELECT status, id, recipient, payload_digest, smtp_message, smtp_envelope,
+                  source_snapshot
+             FROM inbox_rule_forwards
+            WHERE id = $1`,
+          [reservationId],
+        );
+        reservation = replay.rows[0];
+      } else {
+        reservation = stored?.rows?.[0]?.smtp_message ? stored.rows[0] : {
+          ...reservation, recipient, payload_digest: prepared.digest,
+          smtp_message: prepared.message, smtp_envelope: prepared.envelope,
+          source_snapshot: sourceSnapshot,
+        };
+      }
+      preparedDurably = Boolean(reservation?.smtp_message);
     }
-    const row = rowResult.rows[0];
 
-    const content = await loadForwardContent({ row, account, imapManager });
-    const mailOptions = buildForwardMessage({
-      row,
-      account,
-      recipient,
-      ...content,
+    if (!preparedDurably || reservation.recipient !== recipient) {
+      throw new Error('Forward operation payload collision');
+    }
+    const sourceSnapshot = parseStoredJson(reservation.source_snapshot);
+    if (!sourceSnapshot?.id || sourceSnapshot.accountId !== account.id) {
+      throw new Error('Durable forward source snapshot is unavailable');
+    }
+    const preparedMail = loadPreparedSmtp({
+      message: reservation.smtp_message,
+      envelope: reservation.smtp_envelope,
+      digest: reservation.payload_digest,
     });
 
     const smtp = await createAccountSmtpTransport(account);
     if (smtp.error) throw new Error(smtp.error);
     if (!smtp.transport) throw new Error('SMTP transport is unavailable');
 
+    await revalidateLiveMessageSnapshots(account.id, [sourceSnapshot]);
+
     try {
-      await smtp.transport.sendMail(mailOptions);
+      const started = await query(
+        `UPDATE inbox_rule_forwards
+            SET status = 'provider_started'
+          WHERE id = $1 AND status = 'ready' AND payload_digest = $2
+          RETURNING id`,
+        [reservationId, reservation.payload_digest],
+      );
+      if (started?.rowCount === 0) throw new Error('Forward delivery could not claim provider start');
+      deliveryStarted = true;
+      await smtp.transport.sendMail(preparedMail);
     } catch {
       throw new Error('Forward delivery failed');
     }
-    delivered = true;
-    await query(
+    const completed = await query(
       `UPDATE inbox_rule_forwards
-       SET status = 'sent', sent_at = NOW()
-       WHERE id = $1`,
-      [reservationId]
+       SET status = 'sent', recipient = NULL, smtp_message = NULL,
+           smtp_envelope = NULL, source_snapshot = NULL, sent_at = NOW()
+       WHERE id = $1 AND status = 'provider_started' AND payload_digest = $2
+       RETURNING id`,
+      [reservationId, reservation.payload_digest]
     );
+    if (completed?.rowCount === 0) throw new Error('Forward delivery completion was not persisted');
+    deliveryCompleted = true;
+    await revalidateLiveMessageSnapshots(account.id, [sourceSnapshot]);
     return 'sent';
   } catch (err) {
-    if (!delivered) {
-      await query(
-        `DELETE FROM inbox_rule_forwards
-         WHERE id = $1 AND status = 'pending'`,
-        [reservationId]
-      ).catch(() => {});
+    if (!deliveryStarted) {
+      if (!preparedDurably) {
+        try {
+          await query(
+            `DELETE FROM inbox_rule_forwards
+             WHERE id = $1 AND status = 'ready' AND smtp_message IS NULL`,
+            [reservationId]
+          );
+        } catch { /* retain the failed reservation */ }
+      }
+    } else if (!deliveryCompleted) {
+      try {
+        await query(
+          `UPDATE inbox_rule_forwards SET status = 'uncertain'
+            WHERE id = $1 AND status = 'provider_started'`,
+          [reservationId],
+        );
+      } catch { /* provider_started remains a durable conservative block */ }
     }
     throw err;
   }

--- a/backend/src/services/ruleForwarder.test.js
+++ b/backend/src/services/ruleForwarder.test.js
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+
+const revalidateLiveMessageSnapshots = vi.hoisted(() => vi.fn());
 
 vi.mock('./db.js', () => ({ query: vi.fn() }));
+vi.mock('./messageSnapshots.js', async importOriginal => ({
+  ...(await importOriginal()),
+  revalidateLiveMessageSnapshots,
+}));
 vi.mock('./smtpTransport.js', () => ({
   createAccountSmtpTransport: vi.fn(),
 }));
@@ -38,6 +45,10 @@ const messageRow = {
   account_id: account.id,
   uid: 42,
   folder: 'INBOX',
+  folder_uid_validity: '101',
+  folder_observation_generation: '9',
+  read_revision: '3',
+  star_revision: '5',
   subject: 'Quarterly review',
   from_name: 'Example Sender',
   from_email: 'sender@example.com',
@@ -48,6 +59,10 @@ const messageRow = {
   body_html: '<p>Original body</p>',
   attachments: [],
 };
+
+function deliveredRaw(transport) {
+  return Buffer.from(transport.sendMail.mock.calls[0][0].raw).toString();
+}
 
 describe('buildForwardMessage', () => {
   it('builds a PII-free-shape Fwd message and escapes forwarded headers', () => {
@@ -154,6 +169,7 @@ describe('forwardRuleMessage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     query.mockReset();
+    revalidateLiveMessageSnapshots.mockReset().mockResolvedValue(undefined);
     transport = { sendMail: vi.fn().mockResolvedValue({ accepted: true }) };
     createAccountSmtpTransport.mockResolvedValue({ account, transport });
     imapManager = {
@@ -177,7 +193,108 @@ describe('forwardRuleMessage', () => {
 
     await expect(forwardRuleMessage(input)).resolves.toBe('sent');
     expect(transport.sendMail).toHaveBeenCalledTimes(1);
-    expect(query.mock.calls.at(-1)[0]).toContain("status = 'sent'");
+    const completionSql = query.mock.calls.at(-1)[0];
+    expect(completionSql).toContain("status = 'sent'");
+    expect(completionSql).toMatch(/recipient\s*=\s*NULL/i);
+    expect(completionSql).toMatch(/smtp_message\s*=\s*NULL/i);
+    expect(completionSql).toMatch(/smtp_envelope\s*=\s*NULL/i);
+    expect(completionSql).toMatch(/source_snapshot\s*=\s*NULL/i);
+  });
+
+  it('does not send fetched body or attachments after the exact source snapshot relocates', async () => {
+    const uncached = { ...messageRow, body_text: null, body_html: null, attachments: storedAttachments };
+    query
+      .mockResolvedValueOnce({ rows: [{ id: 'delivery-1' }] })
+      .mockResolvedValueOnce({ rows: [uncached] })
+      .mockResolvedValueOnce({ rows: [] });
+    imapManager.fetchMessageBody.mockResolvedValue({
+      text: 'stale body', html: '<p>stale body</p>', attachments: storedAttachments,
+    });
+    imapManager.fetchMultipleAttachments.mockResolvedValue(new Map([
+      ['2', Buffer.from('invoice')], ['3', Buffer.from('notes')],
+    ]));
+    revalidateLiveMessageSnapshots.mockRejectedValue(Object.assign(
+      new Error('Message snapshot was relocated or superseded'),
+      { code: 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable: true },
+    ));
+
+    await expect(forwardRuleMessage(input)).rejects.toMatchObject({
+      code: 'MESSAGE_SNAPSHOT_SUPERSEDED',
+    });
+    expect(revalidateLiveMessageSnapshots).toHaveBeenCalledWith(account.id, [expect.objectContaining({
+      id: messageRow.id, uid: 42, folder: 'INBOX', uidValidity: '101', folderGeneration: '9',
+    })]);
+    expect(transport.sendMail).not.toHaveBeenCalled();
+  });
+
+  it('validates the exact source immediately before and after SMTP delivery', async () => {
+    const events = [];
+    let reservationStatus = 'ready';
+    revalidateLiveMessageSnapshots.mockImplementation(async () => {
+      events.push(transport.sendMail.mock.calls.length ? 'validate-post' : 'validate-pre');
+    });
+    transport.sendMail.mockImplementation(async () => {
+      events.push('smtp');
+      return { accepted: true };
+    });
+    query.mockImplementation(async sql => {
+      if (sql.includes('INSERT INTO inbox_rule_forwards')) return { rows: [{ id: 'delivery-1' }] };
+      if (sql.includes('FROM messages')) return { rows: [messageRow] };
+      if (sql.includes('SET recipient =')) return { rows: [], rowCount: 1 };
+      if (sql.includes("SET status = 'provider_started'")) {
+        reservationStatus = 'provider_started';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      if (sql.includes("SET status = 'sent'")) {
+        reservationStatus = 'sent';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      throw new Error('Unexpected query');
+    });
+
+    await expect(forwardRuleMessage(input)).resolves.toBe('sent');
+
+    expect(events).toEqual(['validate-pre', 'validate-pre', 'smtp', 'validate-post']);
+    expect(reservationStatus).toBe('sent');
+  });
+
+  it('keeps a known SMTP submission sent when the post-delivery source fence is superseded', async () => {
+    const events = [];
+    let reservationStatus = 'ready';
+    revalidateLiveMessageSnapshots
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(Object.assign(
+        new Error('Message snapshot was relocated or superseded'),
+        { code: 'MESSAGE_SNAPSHOT_SUPERSEDED', retryable: true },
+      ));
+    query.mockImplementation(async sql => {
+      if (sql.includes('INSERT INTO inbox_rule_forwards')) return { rows: [{ id: 'delivery-1' }] };
+      if (sql.includes('FROM messages')) return { rows: [messageRow] };
+      if (sql.includes('SET recipient =')) return { rows: [], rowCount: 1 };
+      if (sql.includes("SET status = 'provider_started'")) {
+        reservationStatus = 'provider_started';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      if (sql.includes("SET status = 'sent'")) {
+        events.push('sent');
+        reservationStatus = 'sent';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      if (sql.includes("SET status = 'uncertain'")) {
+        reservationStatus = 'uncertain';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      throw new Error('Unexpected query');
+    });
+
+    await expect(forwardRuleMessage(input)).rejects.toMatchObject({
+      code: 'MESSAGE_SNAPSHOT_SUPERSEDED',
+    });
+    expect(transport.sendMail).toHaveBeenCalledTimes(1);
+    expect(revalidateLiveMessageSnapshots).toHaveBeenCalledTimes(3);
+    expect(events).toEqual(['sent']);
+    expect(reservationStatus).toBe('sent');
   });
 
   it('returns duplicate without sending when the existing reservation is sent', async () => {
@@ -197,7 +314,7 @@ describe('forwardRuleMessage', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ status: 'pending' }] });
 
-    await expect(forwardRuleMessage(input)).rejects.toThrow('Forward delivery pending');
+    await expect(forwardRuleMessage(input)).rejects.toThrow('Forward delivery outcome is uncertain');
     expect(query).toHaveBeenCalledTimes(2);
     expect(transport.sendMail).not.toHaveBeenCalled();
     expect(createAccountSmtpTransport).not.toHaveBeenCalled();
@@ -229,6 +346,11 @@ describe('forwardRuleMessage', () => {
       if (sql.includes('FROM messages')) {
         return { rows: [messageRow] };
       }
+      if (sql.includes('SET recipient =')) return { rows: [], rowCount: 1 };
+      if (sql.includes("SET status = 'provider_started'")) {
+        reservationStatus = 'provider_started';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
       if (sql.includes('UPDATE inbox_rule_forwards')) {
         reservationStatus = 'sent';
         return { rows: [] };
@@ -239,7 +361,7 @@ describe('forwardRuleMessage', () => {
     const firstRun = forwardRuleMessage(input);
     await deliveryStarted;
 
-    await expect(forwardRuleMessage(input)).rejects.toThrow('Forward delivery pending');
+    await expect(forwardRuleMessage(input)).rejects.toThrow('Forward delivery outcome is uncertain');
     expect(transport.sendMail).toHaveBeenCalledTimes(1);
     expect(createAccountSmtpTransport).toHaveBeenCalledTimes(1);
 
@@ -258,15 +380,19 @@ describe('forwardRuleMessage', () => {
     expect(query.mock.calls.at(-1)[0]).toContain('DELETE FROM inbox_rule_forwards');
   });
 
-  it('keeps the reservation when recording success fails after SMTP delivery', async () => {
+  it('marks the reservation uncertain when recording success fails after SMTP delivery', async () => {
     query
       .mockResolvedValueOnce({ rows: [{ id: 'delivery-1' }] })
       .mockResolvedValueOnce({ rows: [messageRow] })
-      .mockRejectedValueOnce(new Error('database unavailable'));
+      .mockResolvedValueOnce({ rows: [{ id: 'delivery-1' }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: 'delivery-1' }], rowCount: 1 })
+      .mockRejectedValueOnce(new Error('database unavailable'))
+      .mockResolvedValueOnce({ rows: [{ id: 'delivery-1' }], rowCount: 1 });
 
     await expect(forwardRuleMessage(input)).rejects.toThrow('database unavailable');
     expect(transport.sendMail).toHaveBeenCalledTimes(1);
-    expect(query).toHaveBeenCalledTimes(3);
+    expect(query).toHaveBeenCalledTimes(6);
+    expect(query.mock.calls.at(-1)[0]).toContain("SET status = 'uncertain'");
   });
 
   it('fetches only stored attachment parts once and preserves their metadata', async () => {
@@ -293,22 +419,14 @@ describe('forwardRuleMessage', () => {
       account,
       messageRow.uid,
       messageRow.folder,
-      storedAttachments
+      storedAttachments,
+      { snapshot: expect.objectContaining({ id: messageRow.id, uid: messageRow.uid }) },
     );
-    expect(transport.sendMail).toHaveBeenCalledWith(expect.objectContaining({
-      attachments: [
-        {
-          filename: 'invoice.pdf',
-          content: pdf,
-          contentType: 'application/pdf',
-        },
-        {
-          filename: 'notes.txt',
-          content: notes,
-          contentType: 'text/plain',
-        },
-      ],
-    }));
+    const raw = deliveredRaw(transport);
+    expect(raw).toContain('invoice.pdf');
+    expect(raw).toContain('cGRmZGF0YQ==');
+    expect(raw).toContain('notes.txt');
+    expect(raw).toContain('bm90ZXM=');
   });
 
   it('fetches an uncached body, sanitizes HTML, and embeds inline data images', async () => {
@@ -340,32 +458,31 @@ describe('forwardRuleMessage', () => {
       expect(imapManager.fetchMessageBody).toHaveBeenCalledWith(
         account,
         messageRow.uid,
-        messageRow.folder
+        messageRow.folder,
+        { snapshot: {
+          id: messageRow.id, accountId: account.id, uid: messageRow.uid, folder: messageRow.folder,
+          uidValidity: '101', folderGeneration: '9', readRevision: 3, starRevision: 5,
+        } }
       );
       expect(imapManager.fetchMultipleAttachments).toHaveBeenCalledWith(
         account,
         messageRow.uid,
         messageRow.folder,
-        [storedAttachments[0]]
+        [storedAttachments[0]],
+        { snapshot: {
+          id: messageRow.id, accountId: account.id, uid: messageRow.uid, folder: messageRow.folder,
+          uidValidity: '101', folderGeneration: '9', readRevision: 3, starRevision: 5,
+        } }
       );
-      const mail = transport.sendMail.mock.calls[0][0];
-      expect(mail.html).not.toContain('<script');
-      expect(mail.html).not.toContain('onclick=');
-      expect(mail.html).not.toContain('data:image');
-      expect(mail.html).toMatch(/src="cid:img-[a-f0-9]+-0@mailflow"/);
-      expect(mail.attachments).toEqual([
-        expect.objectContaining({
-          filename: 'image-0.png',
-          content: Buffer.from('ABC'),
-          contentDisposition: 'inline',
-          contentType: 'image/png',
-        }),
-        {
-          filename: 'invoice.pdf',
-          content: pdf,
-          contentType: 'application/pdf',
-        },
-      ]);
+      const raw = deliveredRaw(transport);
+      expect(raw).not.toContain('<script');
+      expect(raw).not.toContain('onclick=');
+      expect(raw).not.toContain('data:image');
+      expect(raw).toMatch(/cid:img-[a-f0-9]+-0@mailflow/);
+      expect(raw).toContain('image-0.png');
+      expect(raw).toContain('QUJD');
+      expect(raw).toContain('invoice.pdf');
+      expect(raw).toContain('cGRmZGF0YQ==');
       const consoleOutput = consoleSpies
         .flatMap(spy => spy.mock.calls.flat())
         .map(value => String(value))
@@ -412,15 +529,12 @@ describe('forwardRuleMessage', () => {
       account,
       messageRow.uid,
       messageRow.folder,
-      [fetchedAttachment]
+      [fetchedAttachment],
+      { snapshot: expect.objectContaining({ id: messageRow.id, uid: messageRow.uid }) },
     );
-    expect(transport.sendMail).toHaveBeenCalledWith(expect.objectContaining({
-      attachments: [{
-        filename: 'discovered.pdf',
-        content: pdf,
-        contentType: 'application/pdf',
-      }],
-    }));
+    const raw = deliveredRaw(transport);
+    expect(raw).toContain('discovered.pdf');
+    expect(raw).toContain('cGRmZGF0YQ==');
   });
 
   it('rejects attachments larger than 25 MiB before SMTP delivery', async () => {
@@ -489,7 +603,7 @@ describe('forwardRuleMessage', () => {
     expect(query.mock.calls.at(-1)[0]).toContain('DELETE FROM inbox_rule_forwards');
   });
 
-  it('deletes the reservation when SMTP setup returns a safe error', async () => {
+  it('retains the exact prepared reservation when SMTP setup fails before provider start', async () => {
     createAccountSmtpTransport.mockResolvedValue({
       error: 'SMTP is unavailable',
     });
@@ -500,10 +614,12 @@ describe('forwardRuleMessage', () => {
 
     await expect(forwardRuleMessage(input)).rejects.toThrow('SMTP is unavailable');
     expect(transport.sendMail).not.toHaveBeenCalled();
-    expect(query.mock.calls.at(-1)[0]).toContain('DELETE FROM inbox_rule_forwards');
+    expect(query.mock.calls.at(-1)[0]).toContain('SET recipient =');
+    expect(query.mock.calls.some(([sql]) => sql.includes('DELETE FROM inbox_rule_forwards'))).toBe(false);
+    expect(query.mock.calls.some(([sql]) => sql.includes("SET status = 'uncertain'"))).toBe(false);
   });
 
-  it('clears a failed delivery reservation so a retry can send', async () => {
+  it('retains an uncertain SMTP reservation so a retry cannot duplicate delivery', async () => {
     const unsafeMessage = 'timeout after DATA for recipient@example.com';
     let reservationStatus = null;
     transport.sendMail
@@ -522,7 +638,14 @@ describe('forwardRuleMessage', () => {
         return { rows: [messageRow] };
       }
       if (sql.includes('DELETE FROM inbox_rule_forwards')) {
-        reservationStatus = null;
+        throw new Error('uncertain reservation must not be deleted');
+      }
+      if (sql.includes("SET status = 'provider_started'")) {
+        reservationStatus = 'provider_started';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      if (sql.includes("SET status = 'uncertain'")) {
+        reservationStatus = 'uncertain';
         return { rows: [] };
       }
       if (sql.includes('UPDATE inbox_rule_forwards')) {
@@ -543,9 +666,74 @@ describe('forwardRuleMessage', () => {
     expect(thrown.message).not.toContain('recipient@example.com');
     expect(thrown.message).not.toContain(unsafeMessage);
     expect(thrown.cause).toBeUndefined();
+    await expect(forwardRuleMessage(input)).rejects.toThrow('Forward delivery outcome is uncertain');
+    expect(transport.sendMail).toHaveBeenCalledTimes(1);
+    expect(createAccountSmtpTransport).toHaveBeenCalledTimes(1);
+    expect(reservationStatus).toBe('uncertain');
+  });
+
+  it('replays the exact durably prepared SMTP bytes without rebuilding message content', async () => {
+    const raw = Buffer.from('From: mailbox@example.com\r\nTo: recipient@example.com\r\n\r\nfrozen');
+    const envelope = { from: 'mailbox@example.com', to: ['recipient@example.com'] };
+    const digest = createHash('sha256')
+      .update(raw)
+      .update('\0')
+      .update('{"from":"mailbox@example.com","to":["recipient@example.com"]}')
+      .digest('hex');
+    const sourceSnapshot = {
+      id: messageRow.id, accountId: account.id, uid: 42, folder: 'INBOX',
+      uidValidity: '101', folderGeneration: '9', readRevision: 3, starRevision: 5,
+    };
+    let status = 'ready';
+    query.mockImplementation(async sql => {
+      if (sql.includes('INSERT INTO inbox_rule_forwards')) return { rows: [] };
+      if (sql.includes('SELECT status')) return { rows: [{
+        id: 'delivery-1', status, recipient: input.recipient, payload_digest: digest,
+        smtp_message: raw, smtp_envelope: envelope, source_snapshot: sourceSnapshot,
+      }] };
+      if (sql.includes('FROM messages')) throw new Error('prepared replay must not reload message content');
+      if (sql.includes("SET status = 'provider_started'")) {
+        status = 'provider_started';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      if (sql.includes("SET status = 'sent'")) {
+        status = 'sent';
+        return { rows: [{ id: 'delivery-1' }], rowCount: 1 };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
     await expect(forwardRuleMessage(input)).resolves.toBe('sent');
-    expect(transport.sendMail).toHaveBeenCalledTimes(2);
-    expect(createAccountSmtpTransport).toHaveBeenCalledTimes(2);
-    expect(reservationStatus).toBe('sent');
+
+    expect(transport.sendMail).toHaveBeenCalledWith({ raw, envelope });
+    expect(imapManager.fetchMessageBody).not.toHaveBeenCalled();
+    expect(imapManager.fetchMultipleAttachments).not.toHaveBeenCalled();
+    expect(revalidateLiveMessageSnapshots).toHaveBeenCalledWith(account.id, [sourceSnapshot]);
+    expect(status).toBe('sent');
+  });
+
+  it('rejects an edited rule recipient that collides with a prepared forward identity', async () => {
+    const raw = Buffer.from('prepared rule forward');
+    const envelope = { from: 'mailbox@example.com', to: ['old-recipient@example.com'] };
+    query.mockImplementation(async sql => {
+      if (sql.includes('INSERT INTO inbox_rule_forwards')) return { rows: [] };
+      if (sql.includes('SELECT status')) return { rows: [{
+        id: 'delivery-1', status: 'ready', recipient: 'old-recipient@example.com',
+        payload_digest: 'a'.repeat(64), smtp_message: raw, smtp_envelope: envelope,
+        source_snapshot: {
+          id: messageRow.id, accountId: account.id, uid: 42, folder: 'INBOX',
+          uidValidity: '101', folderGeneration: '9', readRevision: 3, starRevision: 5,
+        },
+      }] };
+      if (sql.includes('FROM messages')) return { rows: [messageRow] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await expect(forwardRuleMessage({
+      ...input, recipient: 'edited-recipient@example.com',
+    })).rejects.toThrow(/payload collision/i);
+
+    expect(createAccountSmtpTransport).not.toHaveBeenCalled();
+    expect(transport.sendMail).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/sendOperations.migration.test.js
+++ b/backend/src/services/sendOperations.migration.test.js
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const migration = readFileSync(
+  new URL('../../migrations/0057_send_operations.sql', import.meta.url),
+  'utf8',
+);
+
+describe('send operations migration', () => {
+  it('persists an integrity-bound SMTP payload and its source snapshots before provider start', () => {
+    expect(migration).toMatch(/smtp_message\s+BYTEA/i);
+    expect(migration).toMatch(/smtp_envelope\s+JSONB/i);
+    expect(migration).toMatch(/prepared_payload_digest\s+CHAR\(64\)/i);
+    expect(migration).toMatch(/source_snapshots\s+JSONB/i);
+  });
+});

--- a/backend/src/utils/mailUtils.js
+++ b/backend/src/utils/mailUtils.js
@@ -154,17 +154,44 @@ export async function resolveSentFolder(accountId, folderMappings) {
 }
 
 // Adjust cached folder row counts after local message mutations so that pagination
-// totals stay accurate without waiting for the next IMAP sync. Fire-and-forget —
-// errors are logged but never block the caller; sync will correct any discrepancy.
-export function adjustFolderCounts(accountId, path, totalDelta, unreadDelta) {
-  if (totalDelta === 0 && unreadDelta === 0) return;
-  query(
+// totals stay accurate without waiting for the next IMAP sync. Ordinary callers retain
+// the historical best-effort behavior. Integrity-sensitive callers can pass a transaction
+// executor with `strict: true`, making the message mutation and its cached counts one atomic
+// unit instead of reporting success with stale badges.
+export function adjustFolderCounts(accountId, path, totalDelta, unreadDelta, options = {}) {
+  if (totalDelta === 0 && unreadDelta === 0) return Promise.resolve();
+  const runQuery = options.query || query;
+  const pending = runQuery(
     `UPDATE folders
         SET total_count  = GREATEST(0, total_count  + $1),
             unread_count = GREATEST(0, unread_count + $2)
       WHERE account_id = $3 AND path = $4`,
     [totalDelta, unreadDelta, accountId, path]
-  ).catch(err => console.error('Folder count adjust failed:', err.message));
+  );
+  if (options.strict) return pending;
+  return pending.catch(err => console.error('Folder count adjust failed:', err.message));
+}
+
+// Coalesce a transaction's folder-count writes and return them in one global lock order.
+// Every transaction that updates more than one folders row must use this ordering; otherwise
+// concurrent archive/read reconciliation can lock the same folders in opposite orders.
+export function folderCountDeltasInLockOrder(deltas) {
+  const byPath = new Map();
+  for (const { path, totalDelta = 0, unreadDelta = 0 } of deltas || []) {
+    const current = byPath.get(path) || { path, totalDelta: 0, unreadDelta: 0 };
+    current.totalDelta += totalDelta;
+    current.unreadDelta += unreadDelta;
+    byPath.set(path, current);
+  }
+  return [...byPath.values()]
+    .filter(({ totalDelta, unreadDelta }) => totalDelta !== 0 || unreadDelta !== 0)
+    .sort((left, right) => (left.path < right.path ? -1 : left.path > right.path ? 1 : 0));
+}
+
+// A deterministic, IMAP-atom-safe keyword used only to recover a headerless message when the
+// provider MOVE succeeds before its database transaction commits. Message row ids are UUIDs.
+export function moveRecoveryKeyword(messageRowId) {
+  return `$MailFlowMove-${messageRowId}`;
 }
 
 // Fan a read-state change out to a message's sibling label rows. Under GTD a single

--- a/backend/src/utils/mailUtils.test.js
+++ b/backend/src/utils/mailUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mappedFolderUsable, resolveTrashFolder, resolveArchiveFolder, resolveSentFolder, isAllMailFolder, resolveSpamFolder, getDeleteStrategy, fanOutReadToSiblings, fanOutStarToSiblings, fanOutBulkReadToSiblings } from './mailUtils.js';
+import { mappedFolderUsable, resolveTrashFolder, resolveArchiveFolder, resolveSentFolder, isAllMailFolder, resolveSpamFolder, getDeleteStrategy, fanOutReadToSiblings, fanOutStarToSiblings, fanOutBulkReadToSiblings, folderCountDeltasInLockOrder } from './mailUtils.js';
 
 vi.mock('../services/db.js', () => ({
   query: vi.fn(),
@@ -9,6 +9,20 @@ const { query } = await import('../services/db.js');
 
 beforeEach(() => {
   query.mockClear();
+});
+
+describe('folderCountDeltasInLockOrder', () => {
+  it('coalesces duplicate paths and sorts Archive before INBOX for every transaction', () => {
+    expect(folderCountDeltasInLockOrder([
+      { path: 'INBOX', totalDelta: -1, unreadDelta: -1 },
+      { path: 'Archive', totalDelta: 1, unreadDelta: 1 },
+      { path: 'INBOX', unreadDelta: -1 },
+      { path: 'No-op' },
+    ])).toEqual([
+      { path: 'Archive', totalDelta: 1, unreadDelta: 1 },
+      { path: 'INBOX', totalDelta: -1, unreadDelta: -2 },
+    ]);
+  });
 });
 
 describe('mappedFolderUsable', () => {

--- a/frontend/src/components/ComposeModal.jsx
+++ b/frontend/src/components/ComposeModal.jsx
@@ -3,6 +3,11 @@ import { useTranslation } from 'react-i18next';
 import DOMPurify from 'dompurify';
 import { useStore } from '../store/index.js';
 import { api } from '../utils/api.js';
+import {
+  recordSendFailure,
+  selectDraftOperation,
+  selectSendOperation,
+} from '../utils/draftOperation.js';
 import { useMobile } from '../hooks/useMobile.js';
 import { useUiScale, descale } from '../hooks/useUiScale.js';
 import { useEditor, EditorContent, useEditorState, NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react';
@@ -298,10 +303,12 @@ export default function ComposeModal() {
   const [aiStatus, setAiStatus] = useState(null);
   const [aiPanel, setAiPanel] = useState(null);
   const aiAbortRef = useRef(null);
-  // Stable idempotency key for the current logical send. Generated on the first send
-  // attempt, reused across retries (so a retry after a lost response dedupes rather than
-  // double-sending), and cleared on success. Fixes audit finding [1].
+  // Stable operation for the current logical send. A conclusive pre-provider failure may
+  // rotate its key after an edit; ambiguous/provider-started failures retain it.
   const idempotencyKeyRef = useRef(null);
+  // A draft save is its own durable lifecycle. Reuse the key only while retrying the
+  // same failed save; clear it after success so two intentional identical drafts differ.
+  const draftOperationRef = useRef(null);
   const replyTypeRef = useRef(null);
   const textareaRef = useRef(null);
   const fileInputRef = useRef(null);
@@ -734,42 +741,48 @@ export default function ComposeModal() {
     setSending(true);
     setError('');
     const bodyToSend = plaintextEmail ? body : (htmlMode ? htmlSource : (editor?.getHTML() ?? ''));
+    const sendPayload = {
+      accountId,
+      ...(aliasId ? { aliasId } : {}),
+      to: toFinal,
+      cc: [...ccChips, ...(ccInput.trim() ? [ccInput.trim()] : [])],
+      bcc: [...bccChips, ...(bccInput.trim() ? [bccInput.trim()] : [])],
+      subject,
+      body: bodyToSend,
+      bodyIsHtml: !plaintextEmail,
+      ...(quotedBody ? { quotedBody } : {}),
+      ...(!plaintextEmail && (quotedBodyHtml != null || quotedHtmlRef.current)
+        ? { quotedBodyHtml: quotedHtmlRef.current ? quotedHtmlRef.current.innerHTML : quotedBodyHtml }
+        : {}),
+      ...(signatureContentRef.current || fromSignature != null
+        ? { editedSignature: plaintextEmail ? plainSig : signatureContentRef.current }
+        : {}),
+      inReplyTo: composeData?.inReplyTo,
+      references: composeData?.references || undefined,
+      ...(priority !== 'normal' ? { priority } : {}),
+      ...(attachments.length ? {
+        attachments: attachments.map(a => ({
+          filename: a.name,
+          content: a.data,
+          encoding: 'base64',
+          contentType: a.type || 'application/octet-stream',
+        })),
+      } : {}),
+      ...(fwdAttachments.length ? {
+        forwardedAttachments: fwdAttachments.map(a => ({ messageId: a.messageId, part: a.part })),
+      } : {}),
+    };
     // crypto.randomUUID needs a secure context; fall back for plain-HTTP LAN deployments.
-    if (!idempotencyKeyRef.current) {
-      idempotencyKeyRef.current = crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    }
+    idempotencyKeyRef.current = selectSendOperation(
+      idempotencyKeyRef.current,
+      sendPayload,
+      () => crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
     try {
-      const sendResult = await api.post('/mail/send', {
-        accountId,
-        ...(aliasId ? { aliasId } : {}),
-        to: toFinal,
-        cc: [...ccChips, ...(ccInput.trim() ? [ccInput.trim()] : [])],
-        bcc: [...bccChips, ...(bccInput.trim() ? [bccInput.trim()] : [])],
-        subject,
-        body: bodyToSend,
-        bodyIsHtml: !plaintextEmail,
-        ...(quotedBody ? { quotedBody } : {}),
-        ...(!plaintextEmail && (quotedBodyHtml != null || quotedHtmlRef.current)
-          ? { quotedBodyHtml: quotedHtmlRef.current ? quotedHtmlRef.current.innerHTML : quotedBodyHtml }
-          : {}),
-        ...(signatureContentRef.current || fromSignature != null
-          ? { editedSignature: plaintextEmail ? plainSig : signatureContentRef.current }
-          : {}),
-        inReplyTo: composeData?.inReplyTo,
-        references: composeData?.references || undefined,
-        ...(priority !== 'normal' ? { priority } : {}),
-        ...(attachments.length ? {
-          attachments: attachments.map(a => ({
-            filename: a.name,
-            content: a.data,
-            encoding: 'base64',
-            contentType: a.type || 'application/octet-stream',
-          })),
-        } : {}),
-        ...(fwdAttachments.length ? {
-          forwardedAttachments: fwdAttachments.map(a => ({ messageId: a.messageId, part: a.part })),
-        } : {}),
-      }, { 'X-Idempotency-Key': idempotencyKeyRef.current });
+      const sendResult = await api.post(
+        '/mail/send', sendPayload,
+        { 'X-Idempotency-Key': idempotencyKeyRef.current.key },
+      );
       // Send confirmed — clear the key so a subsequent send from a reused modal gets a fresh one.
       idempotencyKeyRef.current = null;
       const replyThreadId = isReply ? composeData?.threadId : null;
@@ -807,6 +820,7 @@ export default function ComposeModal() {
         setTimeout(refreshThread, 10000);
       }
     } catch (err) {
+      idempotencyKeyRef.current = recordSendFailure(idempotencyKeyRef.current, err);
       setError(err.message);
       setSending(false);
     }
@@ -833,7 +847,7 @@ export default function ComposeModal() {
     setSavingDraft(true);
     try {
       const bodyToSend = plaintextEmail ? body : (htmlMode ? htmlSource : (editor?.isEmpty ? '' : (editor?.getHTML() ?? '')));
-      const result = await api.saveDraft({
+      const draftPayload = {
         accountId,
         ...(aliasId ? { aliasId } : {}),
         to: [...toChips, ...(toInput.trim() ? [toInput.trim()] : [])],
@@ -850,7 +864,14 @@ export default function ComposeModal() {
           ? { editedSignature: plaintextEmail ? plainSig : signatureContentRef.current }
           : {}),
         ...(draftUid != null && draftFolder != null ? { existingUid: draftUid, existingFolder: draftFolder } : {}),
-      });
+      };
+      draftOperationRef.current = selectDraftOperation(
+        draftOperationRef.current,
+        draftPayload,
+        () => crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      );
+      const result = await api.saveDraft(draftPayload, draftOperationRef.current.key);
+      draftOperationRef.current = null;
       if (result.uid != null) {
         setDraftUid(result.uid);
         setDraftFolder(result.folder);
@@ -3169,4 +3190,3 @@ function ChipInput({ chips, onChipsChange, value, onChange, placeholder, autoFoc
     </div>
   );
 }
-

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -111,7 +111,7 @@ export default function MessageList() {
     decrementUnread, incrementUnread, addNotification, notifications, removeNotification,
     searchQuery, setSearchQuery, setIsSearching,
     searchResults, setSearchResults, openCompose, accountsReady, accounts,
-    messagesRefreshToken, layout, setLayout, pageSize, setPageSize, scrollMode,
+    messagesRefreshToken, searchRefreshToken, threadCacheVersion, layout, setLayout, pageSize, setPageSize, scrollMode,
     setMobileSidebarOpen, unreadCounts, showContacts, setShowContacts,
     threadedView, expandedThreadId, setExpandedThreadId,
     threadMessages, setThreadMessages, clearThreadMessages, loadingThread, setLoadingThread,
@@ -537,7 +537,7 @@ export default function MessageList() {
       }
     }, 300);
     return () => clearTimeout(searchTimer.current);
-  }, [searchQuery, selectedAccountId, searchFolder, searchPageSize, searchReloadToken, unifiedInboxAccountKey, applyReadGuard, setIsSearching, setSearchResults]);
+  }, [searchQuery, selectedAccountId, searchFolder, searchPageSize, searchReloadToken, searchRefreshToken, unifiedInboxAccountKey, applyReadGuard, setIsSearching, setSearchResults]);
 
   // Re-run an active search (and refresh the folder view) after inbox rules run, since
   // rules can move messages out of the searched folder and a search snapshot would
@@ -1147,13 +1147,7 @@ export default function MessageList() {
         const deleteIds = ids?.length ? ids : [message.id];
         try {
           if (deleteIds.length > 1) {
-            fetch('/api/mail/messages/bulk-delete', {
-              method: 'POST',
-              credentials: 'include',
-              headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'MailFlow' },
-              body: JSON.stringify({ ids: deleteIds }),
-              keepalive: true,
-            });
+            api.bulkDeleteKeepalive(deleteIds).catch(() => {});
           } else {
             fetch(`/api/mail/messages/${deleteIds[0]}`, {
               method: 'DELETE',
@@ -2409,18 +2403,31 @@ export default function MessageList() {
     setExpandedThreadId(tid);
     if (!threadMessages[tid]) {
       const loadVersion = currentThreadLoadVersion(threadLoadVersionsRef.current, tid);
+      const cacheVersion = threadCacheVersion;
       setLoadingThread(tid);
       try {
         const effectiveFolder = selectedAccountId ? selectedFolder : 'INBOX';
         const data = await api.getThread(tid, effectiveFolder, isUnified);
         const msgs = data.messages || [];
-        if (isCurrentThreadLoad(threadLoadVersionsRef.current, tid, loadVersion)) {
+        if (isCurrentThreadLoad(
+          threadLoadVersionsRef.current,
+          tid,
+          loadVersion,
+          cacheVersion,
+          useStore.getState().threadCacheVersion,
+        )) {
           setThreadMessages(tid, msgs);
         }
       } catch (err) {
         console.error('Failed to load thread:', err);
       } finally {
-        if (isCurrentThreadLoad(threadLoadVersionsRef.current, tid, loadVersion)) {
+        if (isCurrentThreadLoad(
+          threadLoadVersionsRef.current,
+          tid,
+          loadVersion,
+          cacheVersion,
+          useStore.getState().threadCacheVersion,
+        )) {
           setLoadingThread(null);
         }
       }

--- a/frontend/src/hooks/useGtdTriage.js
+++ b/frontend/src/hooks/useGtdTriage.js
@@ -8,7 +8,7 @@ import {
 } from '../utils/gtd.js';
 import { openReplyFromMessage, openForwardFromMessage } from '../utils/composeFromMessage.js';
 import { resolveContextMenuMessage } from '../utils/contextMenuPolicy.js';
-import { doneGtdRow } from '../utils/gtdDone.js';
+import { doneGtdRow, gtdDoneRefreshPatch } from '../utils/gtdDone.js';
 
 // One pending delayed auto-read across ALL GTD surfaces (module scope, not per hook
 // instance): the sidebar and the tab browse list are mounted together in desktop row
@@ -56,7 +56,6 @@ export function useGtdTriage() {
   const setSelectedMessage = useStore(s => s.setSelectedMessage);
   const scheduleGtdSectionsFetch = useStore(s => s.scheduleGtdSectionsFetch);
   const removeGtdThread = useStore(s => s.removeGtdThread);
-  const restoreGtdThread = useStore(s => s.restoreGtdThread);
   const markGtdThreadRead = useStore(s => s.markGtdThreadRead);
   const markGtdThreadStarred = useStore(s => s.markGtdThreadStarred);
   const addNotification = useStore(s => s.addNotification);
@@ -80,15 +79,25 @@ export function useGtdTriage() {
 
   // The GTD "done" action: strip this row's label(s) (`states`), mark read, archive.
   // Optimistically drop and guard the row so stale refetches cannot resurrect it. On
-  // failure, restore its local snapshot and refetch for authoritative reconciliation.
+  // failure, drop the guard and refetch for authoritative reconciliation.
   const doneRow = (thread, states) => {
     cancelAutoMarkReadFor(thread);
     return doneGtdRow(thread, states, {
       gtdDone: api.gtdDone,
       removeGtdThread,
-      restoreGtdThread,
       addNotification,
-      scheduleGtdSectionsFetch,
+      refreshGtdSections: () => useStore.getState().fetchGtdSections(),
+      refreshMessages: ({ target }) => useStore.setState(
+        state => gtdDoneRefreshPatch(state, target),
+      ),
+      refreshUnreadCounts: async () => {
+        const counts = await api.getUnreadCounts();
+        useStore.getState().setUnreadCounts(counts);
+      },
+      refreshFolders: async (accountId) => {
+        const folders = await api.getFolders(accountId);
+        useStore.getState().setFolders(accountId, folders);
+      },
       t,
     });
   };

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -295,6 +295,16 @@ export function useWebSocket() {
         break;
       }
 
+      case 'backfill_all_deferred': {
+        // The server withheld completion because at least one IMAP FETCH returned
+        // incomplete metadata. Clear the busy state so the user can retry while
+        // leaving the existing messages visible and refreshing any valid rows.
+        clearTimeout(backfillRefreshTimer);
+        window.dispatchEvent(new CustomEvent('mailflow:refresh'));
+        setBackfillProgress(data.accountId, null);
+        break;
+      }
+
       case 'folder_updated': {
         // Emitted by move/archive/delete routes after messages leave one folder and land in
         // another. The event names ONE folder (usually the move destination), but the change

--- a/frontend/src/plugins/gtd/GtdRowDone.jsx
+++ b/frontend/src/plugins/gtd/GtdRowDone.jsx
@@ -3,6 +3,7 @@ import { useStore } from '../../store/index.js';
 import { api } from '../../utils/api.js';
 import { advanceSelectionAfterRemoval } from '../../utils/listSelection.js';
 import { ActionBtn } from '../../components/RowHoverActions.jsx';
+import { doneGtdInboxRow, gtdDoneRefreshPatch } from '../../utils/gtdDone.js';
 
 // The GTD "done" checkmark for the row hover cluster, rendered via the 'row-hover-action' slot.
 //
@@ -13,8 +14,8 @@ import { ActionBtn } from '../../components/RowHoverActions.jsx';
 export default function GtdRowDone({ message, done }) {
   const { t } = useTranslation();
   const removeMessage = useStore(s => s.removeMessage);
+  const restoreMessages = useStore(s => s.restoreMessages);
   const decrementUnread = useStore(s => s.decrementUnread);
-  const incrementUnread = useStore(s => s.incrementUnread);
   const addNotification = useStore(s => s.addNotification);
 
   const inboxDone = async (e) => {
@@ -27,19 +28,25 @@ export default function GtdRowDone({ message, done }) {
     const unreadCount = Number.parseInt(message.unread_count, 10);
     const unreadDelta = Number.isFinite(unreadCount) ? unreadCount : (message.is_read ? 0 : 1);
     if (unreadDelta > 0) decrementUnread(message.account_id, unreadDelta);
-    try {
-      const res = await api.gtdDone(message.id);
-      // Labels stripped but the archive step failed: the optimistic removal is still correct, but
-      // the email is still in the inbox — say so rather than leave a gap.
-      if (res?.archiveFailed) {
-        addNotification({ title: t('gtd.doneArchiveFailed'), body: message.subject || t('common.noSubject') });
-      }
-    } catch (err) {
-      console.error('GTD done failed:', err.message);
-      useStore.getState().restoreMessages([message]);
-      if (unreadDelta > 0) incrementUnread(message.account_id, unreadDelta);
-      addNotification({ title: t('gtd.doneFailed'), body: message.subject || t('common.noSubject') });
-    }
+    await doneGtdInboxRow(message, {
+      gtdDone: api.gtdDone,
+      refreshMessages: () => useStore.setState(gtdDoneRefreshPatch),
+      refreshUnreadCounts: async () => {
+        const counts = await api.getUnreadCounts();
+        useStore.getState().setUnreadCounts(counts);
+      },
+      refreshFolders: async (accountId) => {
+        const folders = await api.getFolders(accountId);
+        useStore.getState().setFolders(accountId, folders);
+      },
+      refreshGtdSections: () => useStore.getState().fetchGtdSections(),
+      restoreInbox: restored => {
+        restoreMessages([restored]);
+        if (unreadDelta > 0) useStore.getState().incrementUnread(restored.account_id, unreadDelta);
+      },
+      addNotification,
+      t,
+    });
   };
 
   return (

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -152,6 +152,8 @@ export const useStore = create((set, get) => ({
   selectedAccountId: localStorage.getItem('mailflow_selected_account') || null, // '' stored as null
   selectedFolder: localStorage.getItem('mailflow_selected_folder') || 'INBOX',
   messagesRefreshToken: 0, // incremented on every nav click so the effect always re-fires
+  searchRefreshToken: 0, // explicit invalidation for mutations that can change active search results
+  threadCacheVersion: 0, // global generation for rejecting thread loads after authoritative resets
   setSelectedAccount: (accountId, folder = 'INBOX') => {
     localStorage.setItem('mailflow_selected_account', accountId ?? '');
     localStorage.setItem('mailflow_selected_folder', folder);
@@ -706,11 +708,11 @@ export const useStore = create((set, get) => ({
   // are the backend section keys whose labels were removed (todo/watch/delegated/…).
   // Delegates to a pure helper (unit-tested in gtd.test.js) that also keeps the deduped
   // Waiting rollup in step so the Waiting badge is correct instantly.
-  removeGtdThread: (identity, states) => {
+  removeGtdThread: (identity, states, accountId = null) => {
     let snapshot = null;
     set(state => {
-      snapshot = snapshotGtdThreadRemoval(state.gtdSections, identity, states);
-      const next = removeGtdThreadFromSections(state.gtdSections, identity, states);
+      snapshot = snapshotGtdThreadRemoval(state.gtdSections, identity, states, accountId);
+      const next = removeGtdThreadFromSections(state.gtdSections, identity, states, accountId);
       return next === state.gtdSections ? {} : { gtdSections: next };
     });
     return snapshot;

--- a/frontend/src/utils/api.ai.test.js
+++ b/frontend/src/utils/api.ai.test.js
@@ -9,6 +9,218 @@ afterEach(() => {
 });
 
 describe('ChatGPT authorization API', () => {
+  it('persists exact per-row keys across mixed bulk retries and clears only completed rows', async () => {
+    const calls = [];
+    const responses = [
+      { archived: ['done-row'] },
+      { archived: ['old-row', 'new-row'] },
+      { archived: ['done-row'] },
+    ];
+    globalThis.fetch = async (url, init) => {
+      calls.push([url, init]);
+      return { ok: true, json: async () => responses.shift() };
+    };
+
+    await api.bulkArchive(['old-row', 'done-row']);
+    await api.bulkArchive(['old-row', 'new-row']);
+    await api.bulkArchive(['done-row']);
+
+    const bodies = calls.map(([, init]) => JSON.parse(init.body));
+    assert.equal(bodies[1].operationKeys['old-row'], bodies[0].operationKeys['old-row']);
+    assert.notEqual(bodies[1].operationKeys['new-row'], bodies[0].operationKeys['old-row']);
+    assert.notEqual(bodies[2].operationKeys['done-row'], bodies[0].operationKeys['done-row']);
+  });
+
+  it('sends per-row operation maps for bulk delete and move', async () => {
+    const calls = [];
+    globalThis.fetch = async (url, init) => {
+      calls.push([url, init]);
+      const body = JSON.parse(init.body);
+      return {
+        ok: true,
+        json: async () => (url.endsWith('bulk-delete')
+          ? { deleted: body.ids }
+          : { moved: body.ids }),
+      };
+    };
+
+    await api.bulkDelete(['delete-row']);
+    await api.bulkMove(['move-row'], 'Archive');
+
+    const bodies = calls.map(([, init]) => JSON.parse(init.body));
+    assert.equal(typeof bodies[0].operationKeys['delete-row'], 'string');
+    assert.equal(typeof bodies[1].operationKeys['move-row'], 'string');
+  });
+
+  it('uses the durable per-row delete map for MessageList unload keepalive', async () => {
+    let call;
+    globalThis.fetch = async (url, init) => {
+      call = { url, init };
+      return { ok: true };
+    };
+
+    await api.bulkDeleteKeepalive(['unload-row']);
+
+    assert.equal(call.url, '/api/mail/messages/bulk-delete');
+    assert.equal(call.init.keepalive, true);
+    assert.equal(typeof JSON.parse(call.init.body).operationKeys['unload-row'], 'string');
+  });
+
+  it('canonicalizes uppercase UUIDs in requests and clears their durable key after success', async () => {
+    const calls = [];
+    const upper = 'BBBBBBBB-BBBB-4BBB-8BBB-BBBBBBBBBBBB';
+    const lower = upper.toLowerCase();
+    globalThis.fetch = async (url, init) => {
+      calls.push([url, init]);
+      return { ok: true, json: async () => ({ archived: [lower] }) };
+    };
+
+    await api.bulkArchive([upper]);
+    await api.bulkArchive([upper]);
+
+    const bodies = calls.map(([, init]) => JSON.parse(init.body));
+    assert.deepEqual(bodies[0].ids, [lower]);
+    assert.deepEqual(Object.keys(bodies[0].operationKeys), [lower]);
+    assert.notEqual(bodies[1].operationKeys[lower], bodies[0].operationKeys[lower]);
+  });
+
+  it('rejects case-variant duplicate UUIDs before any bulk request', async () => {
+    let calls = 0;
+    const upper = 'CCCCCCCC-CCCC-4CCC-8CCC-CCCCCCCCCCCC';
+    globalThis.fetch = async () => {
+      calls += 1;
+      return { ok: true, json: async () => ({ moved: [] }) };
+    };
+
+    await assert.rejects(
+      api.bulkMove([upper, upper.toLowerCase()], 'Archive'),
+      /duplicate row ids/i,
+    );
+    assert.equal(calls, 0);
+  });
+
+  it('sends the caller\'s durable key with each logical draft save', async () => {
+    const calls = [];
+    globalThis.fetch = async (url, init) => {
+      calls.push([url, init]);
+      return { ok: true, json: async () => ({ uid: 1, folder: 'Drafts' }) };
+    };
+
+    await api.saveDraft({ subject: 'same' }, 'draft-save-1');
+    await api.saveDraft({ subject: 'same' }, 'draft-save-2');
+
+    assert.deepEqual(calls.map(([, init]) => init.headers['X-Idempotency-Key']), [
+      'draft-save-1', 'draft-save-2',
+    ]);
+  });
+
+  it('reuses one classify lifecycle key after failure and rotates it after success', async () => {
+    const keys = [];
+    let fail = true;
+    globalThis.fetch = async (_url, init) => {
+      keys.push(init.headers['X-Idempotency-Key']);
+      if (fail) {
+        fail = false;
+        return { ok: false, status: 500, json: async () => ({ error: 'retry' }) };
+      }
+      return { ok: true, json: async () => ({ ok: true }) };
+    };
+
+    await assert.rejects(api.gtdClassify('row-1', 'todo'), /retry/);
+    await api.gtdClassify('row-1', 'todo');
+    await api.gtdClassify('row-1', 'todo');
+
+    assert.equal(keys[1], keys[0]);
+    assert.notEqual(keys[2], keys[1]);
+  });
+
+  it('reuses a Done lifecycle key through incomplete and failed retries, then rotates after completion', async () => {
+    const keys = [];
+    const responses = [
+      { ok: true, json: async () => ({ ok: false, phase: 'archive', inboxCleared: false }) },
+      { ok: false, status: 500, json: async () => ({ error: 'label failed', phase: 'labels', inboxCleared: true }) },
+      { ok: true, json: async () => ({ ok: true, phase: 'completed', inboxCleared: true }) },
+      { ok: true, json: async () => ({ ok: true, phase: 'completed', inboxCleared: true }) },
+    ];
+    globalThis.fetch = async (_url, init) => {
+      keys.push(init.headers['X-Idempotency-Key']);
+      return responses.shift();
+    };
+
+    await api.gtdDone('row-1', ['watch']);
+    const error = await api.gtdDone('row-1', ['watch']).catch(value => value);
+    assert.equal(error.phase, 'labels');
+    assert.equal(error.inboxCleared, true);
+    await api.gtdDone('row-1', ['watch']);
+    await api.gtdDone('row-1', ['watch']);
+
+    assert.equal(keys[1], keys[0]);
+    assert.equal(keys[2], keys[1]);
+    assert.notEqual(keys[3], keys[2]);
+  });
+
+  it('rotates a Done lifecycle after a terminal missing-Archive configuration error', async () => {
+    const keys = [];
+    const responses = [
+      {
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: 'Archive unavailable', code: 'GTD_DONE_ARCHIVE_UNAVAILABLE', retryable: false,
+        }),
+      },
+      { ok: true, json: async () => ({ ok: true, phase: 'completed', inboxCleared: true }) },
+    ];
+    globalThis.fetch = async (_url, init) => {
+      keys.push(init.headers['X-Idempotency-Key']);
+      return responses.shift();
+    };
+
+    await assert.rejects(api.gtdDone('row-missing-archive'), /Archive unavailable/);
+    await api.gtdDone('row-missing-archive');
+
+    assert.notEqual(keys[1], keys[0]);
+  });
+
+  it('rotates Done lifecycles for terminal frozen-provider capability failures', async () => {
+    for (const [index, code] of [
+      'FOLDER_OBSERVATION_UNSAFE',
+      'FOLDER_OBSERVATION_SUPERSEDED',
+      'PROVIDER_NATIVE_MOVE_UNSUPPORTED',
+      'PROVIDER_RECOVERY_MARKER_UNSUPPORTED',
+    ].entries()) {
+      const keys = [];
+      const responses = [
+        { ok: false, status: 500, json: async () => ({ error: code, code, retryable: false }) },
+        { ok: true, json: async () => ({ ok: true, phase: 'completed' }) },
+      ];
+      globalThis.fetch = async (_url, init) => {
+        keys.push(init.headers['X-Idempotency-Key']);
+        return responses.shift();
+      };
+      const rowId = `provider-terminal-${index}`;
+      await assert.rejects(api.gtdDone(rowId), new RegExp(code));
+      await api.gtdDone(rowId);
+      assert.notEqual(keys[1], keys[0]);
+    }
+  });
+
+  it('retains the Done lifecycle for a transient provider transport failure', async () => {
+    const keys = [];
+    const responses = [
+      { ok: false, status: 500, json: async () => ({ error: 'timeout', code: 'ETIMEDOUT', retryable: true }) },
+      { ok: true, json: async () => ({ ok: true, phase: 'completed' }) },
+    ];
+    globalThis.fetch = async (_url, init) => {
+      keys.push(init.headers['X-Idempotency-Key']);
+      return responses.shift();
+    };
+
+    await assert.rejects(api.gtdDone('provider-transient'), /timeout/);
+    await api.gtdDone('provider-transient');
+    assert.equal(keys[1], keys[0]);
+  });
+
   it('uses the admin Codex lifecycle routes with CSRF-aware requests', async () => {
     const calls = [];
     globalThis.fetch = async (url, init) => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,3 +1,8 @@
+import {
+  completeBulkOperationKeys,
+  prepareBulkOperationKeys,
+} from './bulkOperationKeys.js';
+
 const BASE = '/api';
 
 // Sent on every /api request so the backend CSRF guard accepts it. A cross-site
@@ -7,6 +12,20 @@ const BASE = '/api';
 export const CSRF_HEADER = 'X-Requested-With';
 export const CSRF_VALUE = 'MailFlow';
 const messageBodyRequests = new Map();
+const gtdClassifyOperationKeys = new Map();
+
+function newOperationKey() {
+  return globalThis.crypto?.randomUUID?.()
+    ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+async function durableBulkRequest(kind, ids, path, body, resultField, destination = '') {
+  const operationKeys = prepareBulkOperationKeys(kind, ids, destination);
+  const canonicalIds = Object.keys(operationKeys);
+  const result = await request('POST', path, { ...body, ids: canonicalIds, operationKeys });
+  completeBulkOperationKeys(kind, result?.[resultField] || [], destination);
+  return result;
+}
 
 async function request(method, path, body, extraHeaders) {
   const opts = {
@@ -28,7 +47,7 @@ async function request(method, path, body, extraHeaders) {
       window.dispatchEvent(new CustomEvent('mailflow:session_expired'));
     }
     const err = await res.json().catch(() => ({ error: 'Request failed' }));
-    throw new Error(err.error || 'Request failed');
+    throw Object.assign(new Error(err.error || 'Request failed'), err, { status: res.status });
   }
   return res.json();
 }
@@ -239,9 +258,29 @@ export const api = {
   markStarred: (id, starred) => request('PATCH', `/mail/messages/${id}/star`, { starred }),
   markAllRead: (accountId, folder) => request('POST', '/mail/mark-all-read', { accountId, folder }),
   deleteMessage: (id) => request('DELETE', `/mail/messages/${id}`),
-  bulkDelete: (ids) => request('POST', '/mail/messages/bulk-delete', { ids }),
-  bulkMove: (ids, folder) => request('POST', '/mail/messages/bulk-move', { ids, folder }),
-  bulkArchive: (ids) => request('POST', '/mail/messages/bulk-archive', { ids }),
+  bulkDelete: (ids) => durableBulkRequest(
+    'delete', ids, '/mail/messages/bulk-delete', { ids }, 'deleted',
+  ),
+  bulkDeleteKeepalive: (ids) => {
+    const operationKeys = prepareBulkOperationKeys('delete', ids);
+    const canonicalIds = Object.keys(operationKeys);
+    return fetch(`${BASE}/mail/messages/bulk-delete`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        [CSRF_HEADER]: CSRF_VALUE,
+      },
+      body: JSON.stringify({ ids: canonicalIds, operationKeys }),
+      keepalive: true,
+    });
+  },
+  bulkMove: (ids, folder) => durableBulkRequest(
+    'move', ids, '/mail/messages/bulk-move', { ids, folder }, 'moved', folder,
+  ),
+  bulkArchive: (ids) => durableBulkRequest(
+    'archive', ids, '/mail/messages/bulk-archive', { ids }, 'archived',
+  ),
   getUnreadCounts: () => request('GET', '/mail/unread-counts'),
 
   // Mailbox cleanup (read-only analysis; actual cleanup reuses bulkDelete above).
@@ -341,7 +380,9 @@ export const api = {
   runRules:    (accountId) => request('POST',  '/rules/run', accountId ? { accountId } : {}),
 
   // Drafts
-  saveDraft:   (data)              => request('POST',   '/mail/draft', data),
+  saveDraft:   (data, operationKey) => request(
+    'POST', '/mail/draft', data, { 'X-Idempotency-Key': operationKey },
+  ),
   deleteDraft: (accountId, uid, folder) =>
     request('DELETE', `/mail/draft/${uid}?accountId=${encodeURIComponent(accountId)}&folder=${encodeURIComponent(folder)}`),
 
@@ -398,13 +439,40 @@ export const api = {
     const qs = p.toString();
     return request('GET', `/gtd/sections${qs ? '?' + qs : ''}`);
   },
-  gtdClassify: (messageId, state) => request('POST', '/gtd/classify', { messageId, state }),
+  gtdClassify: async (messageId, state) => {
+    const lifecycle = `${messageId}:${state}`;
+    const operationKey = gtdClassifyOperationKeys.get(lifecycle) || newOperationKey();
+    gtdClassifyOperationKeys.set(lifecycle, operationKey);
+    const result = await request(
+      'POST', '/gtd/classify', { messageId, state }, { 'X-Idempotency-Key': operationKey },
+    );
+    gtdClassifyOperationKeys.delete(lifecycle);
+    return result;
+  },
   gtdUndoClassify: (undoToken) => request('POST', '/gtd/classify/undo', undoToken),
   gtdUnclassify: (messageId, state) => request('DELETE', '/gtd/classify', { messageId, state }),
   // GTD "done": strip the row's label(s) for these states, mark read, archive the INBOX
   // copy. id is the rail head's row id (its label-folder copy); the server resolves the
   // INBOX copy from the shared Message-ID.
-  gtdDone: (id, states) => request('POST', '/gtd/done', { id, states }),
+  gtdDone: async (id, states) => {
+    const canonicalStates = Array.isArray(states) ? [...new Set(states)].sort() : (states ?? null);
+    const lifecycle = JSON.stringify(canonicalStates);
+    const operationKey = prepareBulkOperationKeys('gtd-done', [id], lifecycle)[String(id).toLowerCase()];
+    try {
+      const result = await request(
+        'POST', '/gtd/done', { id, states: canonicalStates }, { 'X-Idempotency-Key': operationKey },
+      );
+      if (result?.ok === true && result?.phase === 'completed') {
+        completeBulkOperationKeys('gtd-done', [id], lifecycle);
+      }
+      return result;
+    } catch (error) {
+      if (error?.retryable === false) {
+        completeBulkOperationKeys('gtd-done', [id], lifecycle);
+      }
+      throw error;
+    }
+  },
   gtdEnsureFolders: (accountId, folders) => request('POST', '/gtd/folders/ensure', { accountId, folders }),
 
   // GTD — Inbox-Zero pet. Import uploads your own pet (pet.json text + a base64 spritesheet)

--- a/frontend/src/utils/bulkOperationKeys.js
+++ b/frontend/src/utils/bulkOperationKeys.js
@@ -1,0 +1,114 @@
+const STORAGE_KEY = 'mailflow_bulk_operation_keys_v1';
+const DEFAULT_MAX_ENTRIES = 2000;
+
+function inMemoryStorage() {
+  const values = new Map();
+  return {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+const fallbackStorage = inMemoryStorage();
+
+function defaultStorage() {
+  try {
+    if (typeof window === 'undefined') return fallbackStorage;
+    if (window.localStorage) return window.localStorage;
+    throw new Error('localStorage unavailable');
+  } catch (cause) {
+    return {
+      getItem: () => { throw cause; },
+      setItem: () => { throw cause; },
+    };
+  }
+}
+
+function entryId(kind, destination, rowId) {
+  return JSON.stringify([kind, destination || '', String(rowId).toLowerCase()]);
+}
+
+function canonicalRowIds(rowIds) {
+  const canonical = rowIds.map(rowId => String(rowId).toLowerCase());
+  if (new Set(canonical).size !== rowIds.length) {
+    throw new Error('Duplicate row ids are not allowed');
+  }
+  return canonical;
+}
+
+export function createBulkOperationKeyRegistry({
+  storage = defaultStorage(),
+  maxEntries = DEFAULT_MAX_ENTRIES,
+  createKey = () => globalThis.crypto?.randomUUID?.()
+    ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  now = () => Date.now(),
+} = {}) {
+  const read = () => {
+    try {
+      const raw = storage.getItem(STORAGE_KEY);
+      if (!raw) return {};
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error('Invalid bulk operation registry');
+      }
+      const canonicalEntries = {};
+      for (const [storedId, entry] of Object.entries(parsed)) {
+        const parts = JSON.parse(storedId);
+        if (!Array.isArray(parts) || parts.length !== 3) {
+          throw new Error('Invalid bulk operation registry entry');
+        }
+        const canonicalId = entryId(parts[0], parts[1], parts[2]);
+        if (Object.prototype.hasOwnProperty.call(canonicalEntries, canonicalId)) {
+          throw new Error('Duplicate canonical bulk operation registry entry');
+        }
+        canonicalEntries[canonicalId] = entry;
+      }
+      return canonicalEntries;
+    } catch (cause) {
+      throw new Error('Unable to read bulk operation keys', { cause });
+    }
+  };
+  const write = (entries) => {
+    try {
+      storage.setItem(STORAGE_KEY, JSON.stringify(entries));
+    } catch (cause) {
+      throw new Error('Unable to persist bulk operation keys', { cause });
+    }
+  };
+
+  return {
+    prepare(kind, rowIds, destination = '') {
+      const entries = read();
+      const canonicalIds = canonicalRowIds(rowIds);
+      const newEntryCount = canonicalIds.filter(rowId => (
+        !entries[entryId(kind, destination, rowId)]
+      )).length;
+      if (Object.keys(entries).length + newEntryCount > maxEntries) {
+        throw new Error('Too many unresolved bulk operations; retry or resolve pending rows first');
+      }
+      const operationKeys = {};
+      for (const rowId of canonicalIds) {
+        const id = entryId(kind, destination, rowId);
+        const existing = entries[id];
+        const key = existing?.key || createKey();
+        entries[id] = { key, updatedAt: now() };
+        operationKeys[rowId] = key;
+      }
+      write(entries);
+      return operationKeys;
+    },
+
+    complete(kind, rowIds, destination = '') {
+      const entries = read();
+      for (const rowId of canonicalRowIds(rowIds)) {
+        delete entries[entryId(kind, destination, rowId)];
+      }
+      write(entries);
+    },
+  };
+}
+
+const bulkOperationKeys = createBulkOperationKeyRegistry();
+
+export const prepareBulkOperationKeys = (...args) => bulkOperationKeys.prepare(...args);
+export const completeBulkOperationKeys = (...args) => bulkOperationKeys.complete(...args);

--- a/frontend/src/utils/bulkOperationKeys.test.js
+++ b/frontend/src/utils/bulkOperationKeys.test.js
@@ -1,0 +1,110 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBulkOperationKeyRegistry } from './bulkOperationKeys.js';
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem: key => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe('bulk operation key registry', () => {
+  it('reuses failed row keys across changed subsets and frontend recreation', () => {
+    const storage = memoryStorage();
+    let sequence = 0;
+    const options = { storage, createKey: () => `key-${++sequence}`, now: () => sequence };
+    const firstProcess = createBulkOperationKeyRegistry(options);
+    const first = firstProcess.prepare('archive', ['old-row', 'done-row']);
+    firstProcess.complete('archive', ['done-row']);
+
+    const reloadedProcess = createBulkOperationKeyRegistry(options);
+    const retry = reloadedProcess.prepare('archive', ['old-row', 'new-row']);
+    const laterLifecycle = reloadedProcess.prepare('archive', ['done-row']);
+
+    assert.equal(retry['old-row'], first['old-row']);
+    assert.notEqual(retry['new-row'], first['old-row']);
+    assert.notEqual(laterLifecycle['done-row'], first['done-row']);
+  });
+
+  it('keeps unconfirmed keys and fails closed at the unresolved-row bound', () => {
+    const storage = memoryStorage();
+    let sequence = 0;
+    const registry = createBulkOperationKeyRegistry({
+      storage, maxEntries: 2, createKey: () => `key-${++sequence}`, now: () => sequence,
+    });
+    const first = registry.prepare('delete', ['row-1']);
+    registry.prepare('delete', ['row-2']);
+
+    assert.throws(() => registry.prepare('delete', ['row-3']), /too many unresolved bulk operations/i);
+    assert.equal(registry.prepare('delete', ['row-1'])['row-1'], 'key-1');
+    assert.equal(first['row-1'], 'key-1');
+  });
+
+  it('fails closed when durable storage cannot persist a new row key', () => {
+    const registry = createBulkOperationKeyRegistry({
+      storage: {
+        getItem: () => null,
+        setItem: () => { throw new Error('quota'); },
+      },
+      createKey: () => 'key-1',
+    });
+
+    assert.throws(() => registry.prepare('archive', ['row-1']), /persist bulk operation keys/i);
+  });
+
+  it('fails closed instead of overwriting unreadable unresolved keys', () => {
+    const registry = createBulkOperationKeyRegistry({
+      storage: {
+        getItem: () => '{not-json',
+        setItem: () => {},
+      },
+      createKey: () => 'key-1',
+    });
+
+    assert.throws(() => registry.prepare('move', ['row-1'], 'Archive'), /read bulk operation keys/i);
+  });
+
+  it('canonicalizes UUID row ids across store, reload, and success clearing', () => {
+    const storage = memoryStorage();
+    let sequence = 0;
+    const options = { storage, createKey: () => `key-${++sequence}`, now: () => sequence };
+    const upper = 'AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA';
+    const lower = upper.toLowerCase();
+    const first = createBulkOperationKeyRegistry(options).prepare('archive', [upper]);
+
+    assert.deepEqual(Object.keys(first), [lower]);
+    assert.equal(createBulkOperationKeyRegistry(options).prepare('archive', [lower])[lower], first[lower]);
+
+    createBulkOperationKeyRegistry(options).complete('archive', [lower]);
+    const next = createBulkOperationKeyRegistry(options).prepare('archive', [upper]);
+    assert.notEqual(next[lower], first[lower]);
+  });
+
+  it('rejects case-variant duplicate UUID row ids', () => {
+    const registry = createBulkOperationKeyRegistry({ storage: memoryStorage() });
+    const upper = 'AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA';
+
+    assert.throws(
+      () => registry.prepare('move', [upper, upper.toLowerCase()], 'Archive'),
+      /duplicate row ids/i,
+    );
+  });
+
+  it('migrates a persisted uppercase registry entry before lookup and clearing', () => {
+    const storage = memoryStorage();
+    const upper = 'DDDDDDDD-DDDD-4DDD-8DDD-DDDDDDDDDDDD';
+    const lower = upper.toLowerCase();
+    storage.setItem('mailflow_bulk_operation_keys_v1', JSON.stringify({
+      [JSON.stringify(['delete', '', upper])]: { key: 'persisted-uppercase-key', updatedAt: 1 },
+    }));
+    const registry = createBulkOperationKeyRegistry({
+      storage, createKey: () => 'must-not-create', now: () => 2,
+    });
+
+    assert.equal(registry.prepare('delete', [lower])[lower], 'persisted-uppercase-key');
+    registry.complete('delete', [upper]);
+    assert.deepEqual(JSON.parse(storage.getItem('mailflow_bulk_operation_keys_v1')), {});
+  });
+});

--- a/frontend/src/utils/draftOperation.js
+++ b/frontend/src/utils/draftOperation.js
@@ -1,0 +1,26 @@
+export function selectDraftOperation(previous, payload, createKey) {
+  const payloadIdentity = JSON.stringify(payload);
+  if (previous?.payloadIdentity === payloadIdentity) return previous;
+  return { key: createKey(), payloadIdentity };
+}
+
+export function selectSendOperation(previous, payload, createKey) {
+  const payloadIdentity = JSON.stringify(payload);
+  if (!previous) {
+    return { key: createKey(), payloadIdentity, rotateOnPayloadChange: false };
+  }
+  if (previous.payloadIdentity === payloadIdentity) return previous;
+  if (previous.rotateOnPayloadChange) {
+    return { key: createKey(), payloadIdentity, rotateOnPayloadChange: false };
+  }
+  return previous;
+}
+
+export function recordSendFailure(operation, error) {
+  if (!operation) return operation;
+  return {
+    ...operation,
+    rotateOnPayloadChange:
+      error?.operationKeyDisposition === 'rotate_on_payload_change',
+  };
+}

--- a/frontend/src/utils/draftOperation.test.js
+++ b/frontend/src/utils/draftOperation.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as composeOperations from './draftOperation.js';
+
+const { selectDraftOperation } = composeOperations;
+
+describe('selectDraftOperation', () => {
+  it('reuses the key for an unchanged retry and rotates it after the payload changes', () => {
+    let sequence = 0;
+    const createKey = () => `key-${++sequence}`;
+    const first = selectDraftOperation(null, { subject: 'first', body: 'body' }, createKey);
+    const unchanged = selectDraftOperation(first, { subject: 'first', body: 'body' }, createKey);
+    const edited = selectDraftOperation(unchanged, { subject: 'edited', body: 'body' }, createKey);
+
+    assert.equal(unchanged.key, first.key);
+    assert.notEqual(edited.key, unchanged.key);
+  });
+});
+
+describe('selectSendOperation', () => {
+  it('rotates on edits only after a conclusively pre-provider failure', () => {
+    assert.equal(typeof composeOperations.selectSendOperation, 'function');
+    assert.equal(typeof composeOperations.recordSendFailure, 'function');
+    const { selectSendOperation, recordSendFailure } = composeOperations;
+    let sequence = 0;
+    const createKey = () => `key-${++sequence}`;
+    const originalPayload = { subject: 'first', body: 'body' };
+    const editedPayload = { subject: 'edited', body: 'body' };
+
+    const first = selectSendOperation(null, originalPayload, createKey);
+    const safeFailure = recordSendFailure(first, {
+      operationKeyDisposition: 'rotate_on_payload_change',
+    });
+    const unchangedRetry = selectSendOperation(safeFailure, originalPayload, createKey);
+    const editedRetry = selectSendOperation(safeFailure, editedPayload, createKey);
+
+    assert.equal(unchangedRetry.key, first.key);
+    assert.notEqual(editedRetry.key, first.key);
+
+    const ambiguousFailure = recordSendFailure(first, {
+      operationKeyDisposition: 'retain',
+    });
+    const ambiguousEditedRetry = selectSendOperation(
+      ambiguousFailure, editedPayload, createKey,
+    );
+    assert.equal(ambiguousEditedRetry.key, first.key);
+  });
+});

--- a/frontend/src/utils/gtd.js
+++ b/frontend/src/utils/gtd.js
@@ -246,7 +246,7 @@ export function buildGtdDisplaySections(sections) {
 // both folders is a single Waiting row — so the Waiting badge is correct instantly instead
 // of only after the refetch. Returns the same sections reference when nothing changed, a
 // new object otherwise; never mutates the input.
-export function removeGtdThreadFromSections(sections, identity, states) {
+export function removeGtdThreadFromSections(sections, identity, states, accountId = null) {
   if (!sections || identity == null) return sections;
   const next = { ...sections };
   let changed = false;
@@ -257,7 +257,7 @@ export function removeGtdThreadFromSections(sections, identity, states) {
     if (!sec || !Array.isArray(sec.threads)) continue;
     let removed = 0, removedUnread = 0;
     const threads = sec.threads.filter(th => {
-      if ((th.message_id || th.id) !== identity) return true;
+      if ((th.message_id || th.id) !== identity || (accountId != null && th.account_id !== accountId)) return true;
       removed += 1;
       if (!th.is_read) removedUnread += 1;
       return false;
@@ -284,7 +284,7 @@ export function removeGtdThreadFromSections(sections, identity, states) {
   return changed ? next : sections;
 }
 
-export function snapshotGtdThreadRemoval(sections, identity, states) {
+export function snapshotGtdThreadRemoval(sections, identity, states, accountId = null) {
   if (!sections || identity == null) return null;
   const removedByState = {};
   for (const key of [...new Set(states || [])]) {
@@ -292,11 +292,14 @@ export function snapshotGtdThreadRemoval(sections, identity, states) {
     if (!sec || !Array.isArray(sec.threads)) continue;
     const rows = [];
     sec.threads.forEach((thread, index) => {
-      if ((thread.message_id || thread.id) === identity) rows.push({ index, thread });
+      if (
+        (thread.message_id || thread.id) === identity
+        && (accountId == null || thread.account_id === accountId)
+      ) rows.push({ index, thread });
     });
     if (rows.length) removedByState[key] = rows;
   }
-  return Object.keys(removedByState).length ? { identity, removedByState } : null;
+  return Object.keys(removedByState).length ? { identity, accountId, removedByState } : null;
 }
 
 export function restoreGtdThreadRemoval(sections, snapshot) {

--- a/frontend/src/utils/gtd.test.js
+++ b/frontend/src/utils/gtd.test.js
@@ -920,6 +920,27 @@ describe('GTD row removal rollback', () => {
     assert.equal(restored.delegated.total, 1);
     assert.deepEqual(restored.waiting, { total: 1, unread: 1 });
   });
+
+  it('snapshots and removes only the matching account in unified GTD', () => {
+    const sections = {
+      todo: {
+        total: 2,
+        unread: 2,
+        threads: [
+          { message_id: 'same', account_id: 'account-a', is_read: false },
+          { message_id: 'same', account_id: 'account-b', is_read: false },
+        ],
+      },
+    };
+
+    const snapshot = snapshotGtdThreadRemoval(sections, 'same', ['todo'], 'account-a');
+    const removed = removeGtdThreadFromSections(sections, 'same', ['todo'], 'account-a');
+
+    assert.deepEqual(snapshot.removedByState.todo.map(row => row.thread.account_id), ['account-a']);
+    assert.deepEqual(removed.todo.threads.map(row => row.account_id), ['account-b']);
+    assert.equal(removed.todo.total, 1);
+    assert.equal(removed.todo.unread, 1);
+  });
 });
 
 describe('setGtdThreadReadInSections', () => {

--- a/frontend/src/utils/gtdDone.js
+++ b/frontend/src/utils/gtdDone.js
@@ -4,32 +4,126 @@ import {
   setPendingGtdRemoval,
 } from './pendingGtdRemovals.js';
 
+// New servers report the desired Inbox outcome directly. Keep the legacy flags as a fallback so
+// a rolling frontend/backend upgrade still surfaces an archive problem instead of hiding it.
+export function isGtdArchiveIncomplete(result) {
+  if (!result) return false;
+  if (typeof result.inboxCleared === 'boolean') {
+    return Number(result.archiveTargetCount) > 0 && !result.inboxCleared;
+  }
+  return !!(result.archiveFailed || result.noArchiveFolder);
+}
+
+export function gtdDoneRefreshPatch(state, completedTarget = null) {
+  const visibleMessages = [
+    ...(state.messages || []),
+    ...(state.searchResults || []),
+    ...Object.values(state.threadMessages || {}).flat(),
+  ];
+  const selected = visibleMessages.find(message => message?.id === state.selectedMessageId);
+  const selectedTargetStillMatches = completedTarget != null
+    && completedTarget.id === state.selectedMessageId
+    && selected?.account_id === completedTarget.accountId;
+  const recoveredSameMessage = completedTarget?.messageId
+    && selected?.id !== completedTarget.id
+    && selected?.account_id === completedTarget.accountId
+    && selected?.message_id === completedTarget.messageId;
+  const survivingThreadMessages = recoveredSameMessage
+    ? Object.fromEntries(Object.entries(state.threadMessages || {}).flatMap(([threadId, messages]) => {
+      const retained = messages.filter(message => !(
+        message?.id === completedTarget.id && message.account_id === completedTarget.accountId
+      ));
+      return retained.length ? [[threadId, retained]] : [];
+    }))
+    : {};
+  return {
+    messagesRefreshToken: state.messagesRefreshToken + 1,
+    searchRefreshToken: state.searchRefreshToken + 1,
+    threadCacheVersion: (state.threadCacheVersion || 0) + 1,
+    ...(selectedTargetStillMatches ? { selectedMessageId: null } : {}),
+    threadMessages: survivingThreadMessages,
+    expandedThreadId: null,
+    loadingThread: null,
+  };
+}
+
 export async function doneGtdRow(thread, states, {
   gtdDone,
   removeGtdThread,
-  restoreGtdThread,
   addNotification,
-  scheduleGtdSectionsFetch,
+  refreshGtdSections,
+  refreshMessages,
+  refreshUnreadCounts,
+  refreshFolders,
   t,
 }) {
   const identity = thread.message_id || thread.id;
-  setPendingGtdRemoval(identity, states);
-  const snapshot = removeGtdThread(identity, states);
+  setPendingGtdRemoval(identity, states, thread.account_id);
+  removeGtdThread(identity, states, thread.account_id);
 
   try {
     const result = await gtdDone(thread.id, states);
-    setCompletedGtdRemoval(identity, states);
-    if (result?.archiveFailed) {
+    if (isGtdArchiveIncomplete(result)) {
+      clearGtdRemovalGuard(identity, states, thread.account_id);
       addNotification({ title: t('gtd.doneArchiveFailed'), body: thread.subject || t('common.noSubject') });
+    } else if (result?.ok === true && result?.phase === 'completed') {
+      setCompletedGtdRemoval(identity, states, thread.account_id);
+    } else {
+      clearGtdRemovalGuard(identity, states, thread.account_id);
+      addNotification({ title: t('gtd.doneFailed'), body: thread.subject || t('common.noSubject') });
     }
-    scheduleGtdSectionsFetch();
     return result;
   } catch (err) {
-    clearGtdRemovalGuard(identity, states);
-    restoreGtdThread(snapshot);
+    clearGtdRemovalGuard(identity, states, thread.account_id);
     console.error('GTD done failed:', err.message);
     addNotification({ title: t('gtd.doneFailed'), body: thread.subject || t('common.noSubject') });
-    scheduleGtdSectionsFetch();
     return null;
+  } finally {
+    await Promise.allSettled([
+      Promise.resolve().then(() => refreshMessages({
+        target: { id: thread.id, accountId: thread.account_id, messageId: thread.message_id },
+      })),
+      Promise.resolve().then(refreshUnreadCounts),
+      Promise.resolve().then(() => refreshFolders?.(thread.account_id)),
+      Promise.resolve().then(refreshGtdSections),
+    ]);
   }
+}
+
+// Main-Inbox Done restores its optimistic row only when the backend conclusively says Inbox was
+// not cleared. Ambiguous failures rely on the authoritative refresh instead of resurrecting a row
+// the provider may already have archived.
+export async function doneGtdInboxRow(message, {
+  gtdDone,
+  refreshMessages,
+  refreshUnreadCounts,
+  refreshFolders,
+  scheduleGtdSectionsFetch,
+  refreshGtdSections,
+  restoreInbox,
+  addNotification,
+  t,
+}) {
+  let result = null;
+  try {
+    result = await gtdDone(message.id);
+    if (isGtdArchiveIncomplete(result)) {
+      restoreInbox?.(message);
+      addNotification({ title: t('gtd.doneArchiveFailed'), body: message.subject || t('common.noSubject') });
+    } else if (!(result?.ok === true && result?.phase === 'completed')) {
+      addNotification({ title: t('gtd.doneFailed'), body: message.subject || t('common.noSubject') });
+    }
+  } catch (err) {
+    if (err?.inboxCleared === false) restoreInbox?.(message);
+    console.error('GTD done failed:', err.message);
+    addNotification({ title: t('gtd.doneFailed'), body: message.subject || t('common.noSubject') });
+  } finally {
+    await Promise.allSettled([
+      Promise.resolve().then(refreshMessages),
+      Promise.resolve().then(refreshUnreadCounts),
+      Promise.resolve().then(() => refreshFolders?.(message.account_id)),
+      Promise.resolve().then(refreshGtdSections || scheduleGtdSectionsFetch),
+    ]);
+  }
+  return result;
 }

--- a/frontend/src/utils/gtdDone.test.js
+++ b/frontend/src/utils/gtdDone.test.js
@@ -1,22 +1,30 @@
 import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { doneGtdRow } from './gtdDone.js';
+import {
+  doneGtdInboxRow,
+  doneGtdRow,
+  gtdDoneRefreshPatch,
+  isGtdArchiveIncomplete,
+} from './gtdDone.js';
 import {
   clearGtdRemovalGuard,
   completedGtdRemovalMap,
   pendingGtdRemovalMap,
 } from './pendingGtdRemovals.js';
 
-const thread = { id: 'row-x', message_id: 'x', subject: 'A subject' };
+const thread = { id: 'row-x', account_id: 'account-1', message_id: 'x', subject: 'A subject' };
 const states = ['todo'];
 
 function deps(overrides = {}) {
   return {
-    gtdDone: async () => ({ ok: true }),
+    gtdDone: async () => ({ ok: true, phase: 'completed' }),
     removeGtdThread: () => ({ snapshot: true }),
     restoreGtdThread: () => {},
     addNotification: () => {},
-    scheduleGtdSectionsFetch: () => {},
+    refreshGtdSections: () => {},
+    refreshMessages: () => {},
+    refreshUnreadCounts: () => {},
+    refreshFolders: () => {},
     t: key => key,
     ...overrides,
   };
@@ -25,7 +33,7 @@ function deps(overrides = {}) {
 describe('doneGtdRow', () => {
   afterEach(() => {
     for (const removal of [...pendingGtdRemovalMap.values(), ...completedGtdRemovalMap.values()]) {
-      clearGtdRemovalGuard(removal.identity, removal.states);
+      clearGtdRemovalGuard(removal.identity, removal.states, removal.accountId);
     }
   });
 
@@ -34,32 +42,40 @@ describe('doneGtdRow', () => {
     let resolveRequest;
     const request = new Promise(resolve => { resolveRequest = resolve; });
     const result = doneGtdRow(thread, states, deps({
-      removeGtdThread: (identity, removedStates) => {
-        calls.push(['remove', identity, removedStates]);
+      removeGtdThread: (identity, removedStates, accountId) => {
+        calls.push(['remove', identity, removedStates, accountId]);
         return { snapshot: true };
       },
       gtdDone: async (id, removedStates) => {
         calls.push(['api', id, removedStates]);
         return request;
       },
-      scheduleGtdSectionsFetch: () => calls.push(['schedule']),
+      refreshGtdSections: () => calls.push(['gtd']),
+      refreshMessages: context => calls.push(['messages', context]),
+      refreshUnreadCounts: () => calls.push(['unread']),
+      refreshFolders: accountId => calls.push(['folders', accountId]),
     }));
 
     assert.deepEqual(calls, [
-      ['remove', 'x', states],
+      ['remove', 'x', states, 'account-1'],
       ['api', 'row-x', states],
     ]);
     assert.equal(pendingGtdRemovalMap.size, 1);
     assert.equal(completedGtdRemovalMap.size, 0);
 
-    resolveRequest({ ok: true });
-    assert.deepEqual(await result, { ok: true });
+    resolveRequest({ ok: true, phase: 'completed' });
+    assert.deepEqual(await result, { ok: true, phase: 'completed' });
     assert.equal(pendingGtdRemovalMap.size, 0);
     assert.equal(completedGtdRemovalMap.size, 1);
-    assert.deepEqual(calls.at(-1), ['schedule']);
+    assert.deepEqual(calls.slice(-4), [
+      ['messages', { target: { id: 'row-x', accountId: 'account-1', messageId: 'x' } }],
+      ['unread'],
+      ['folders', 'account-1'],
+      ['gtd'],
+    ]);
   });
 
-  it('clears the guard and restores only the captured row on failure', async () => {
+  it('clears the guard without restoring a possibly stale sidebar snapshot on failure', async () => {
     const snapshot = { identity: 'x', removedByState: { todo: [] } };
     const calls = [];
     const originalError = console.error;
@@ -70,33 +86,305 @@ describe('doneGtdRow', () => {
         gtdDone: async () => { throw new Error('network failed'); },
         restoreGtdThread: value => calls.push(['restore', value]),
         addNotification: notification => calls.push(['notify', notification]),
-        scheduleGtdSectionsFetch: () => calls.push(['schedule']),
+        refreshGtdSections: () => calls.push(['gtd']),
+        refreshMessages: context => calls.push(['messages', context]),
+        refreshUnreadCounts: () => calls.push(['unread']),
+        refreshFolders: accountId => calls.push(['folders', accountId]),
       }));
 
       assert.equal(result, null);
       assert.equal(pendingGtdRemovalMap.size, 0);
       assert.equal(completedGtdRemovalMap.size, 0);
       assert.deepEqual(calls, [
-        ['restore', snapshot],
         ['notify', { title: 'gtd.doneFailed', body: 'A subject' }],
-        ['schedule'],
+        ['messages', { target: { id: 'row-x', accountId: 'account-1', messageId: 'x' } }],
+        ['unread'],
+        ['folders', 'account-1'],
+        ['gtd'],
       ]);
     } finally {
       console.error = originalError;
     }
   });
 
-  it('keeps the row removed but reports a partial archive failure', async () => {
+  it('does not resurrect removed sidebar labels after a partial archive failure', async () => {
     const calls = [];
     await doneGtdRow(thread, states, deps({
       gtdDone: async () => ({ ok: true, archiveFailed: true }),
-      restoreGtdThread: () => calls.push(['restore']),
+      restoreGtdThread: snapshot => calls.push(['restore', snapshot]),
       addNotification: notification => calls.push(['notify', notification]),
     }));
 
     assert.deepEqual(calls, [
       ['notify', { title: 'gtd.doneArchiveFailed', body: 'A subject' }],
     ]);
-    assert.equal(completedGtdRemovalMap.size, 1);
+    assert.equal(pendingGtdRemovalMap.size, 0);
+    assert.equal(completedGtdRemovalMap.size, 0);
+  });
+
+  it('recognizes additive incomplete outcomes while preserving legacy archive-failure handling', () => {
+    assert.equal(isGtdArchiveIncomplete({ archiveTargetCount: 2, inboxCleared: false }), true);
+    assert.equal(isGtdArchiveIncomplete({ archiveTargetCount: 0, inboxCleared: true }), false);
+    assert.equal(isGtdArchiveIncomplete({ archiveFailed: true }), true);
+    assert.equal(isGtdArchiveIncomplete({ noArchiveFolder: true }), true);
+  });
+});
+
+describe('doneGtdInboxRow', () => {
+  it('invalidates both the folder list and an active search snapshot', () => {
+    assert.deepEqual(
+      gtdDoneRefreshPatch({
+        messagesRefreshToken: 4,
+        searchRefreshToken: 7,
+        threadCacheVersion: 2,
+        threadMessages: { 'thread-1': [{ id: 'stale-child' }] },
+        expandedThreadId: 'thread-1',
+        loadingThread: 'thread-1',
+      }),
+      {
+        messagesRefreshToken: 5,
+        searchRefreshToken: 8,
+        threadCacheVersion: 3,
+        threadMessages: {},
+        expandedThreadId: null,
+        loadingThread: null,
+      },
+    );
+  });
+
+  it('clears the selected completed GTD row from the same account while invalidating thread caches', () => {
+    const state = {
+      messagesRefreshToken: 4,
+      searchRefreshToken: 7,
+      threadCacheVersion: 2,
+      selectedMessageId: 'row-x',
+      messages: [],
+      searchResults: [],
+      threadMessages: { 'thread-1': [{ id: 'row-x', account_id: 'account-1' }] },
+      expandedThreadId: 'thread-1',
+      loadingThread: 'thread-1',
+    };
+
+    assert.deepEqual(
+      gtdDoneRefreshPatch(state, { id: 'row-x', accountId: 'account-1' }),
+      {
+        messagesRefreshToken: 5,
+        searchRefreshToken: 8,
+        threadCacheVersion: 3,
+        selectedMessageId: null,
+        threadMessages: {},
+        expandedThreadId: null,
+        loadingThread: null,
+      },
+    );
+  });
+
+  it('preserves a newer or account-mismatched selection while still invalidating thread caches', () => {
+    const base = {
+      messagesRefreshToken: 1,
+      searchRefreshToken: 1,
+      threadCacheVersion: 1,
+      messages: [],
+      searchResults: [],
+      expandedThreadId: 'thread-1',
+      loadingThread: 'thread-1',
+    };
+
+    const newer = gtdDoneRefreshPatch({
+      ...base,
+      selectedMessageId: 'row-new',
+      threadMessages: {
+        old: [{ id: 'row-x', account_id: 'account-1' }],
+        newer: [{ id: 'row-new', account_id: 'account-1' }],
+      },
+    }, { id: 'row-x', accountId: 'account-1' });
+    assert.equal(Object.hasOwn(newer, 'selectedMessageId'), false);
+    assert.deepEqual(newer.threadMessages, {});
+
+    const wrongAccount = gtdDoneRefreshPatch({
+      ...base,
+      selectedMessageId: 'row-x',
+      threadMessages: { old: [{ id: 'row-x', account_id: 'account-2' }] },
+    }, { id: 'row-x', accountId: 'account-1' });
+    assert.equal(Object.hasOwn(wrongAccount, 'selectedMessageId'), false);
+    assert.deepEqual(wrongAccount.threadMessages, {});
+  });
+
+  it('preserves a recovered same-message selection and its thread material after stale-row Done', () => {
+    const recovered = { id: 'row-new', account_id: 'account-1', message_id: '<same@message>' };
+    const unrelated = { id: 'row-other', account_id: 'account-1', message_id: '<other@message>' };
+
+    const patch = gtdDoneRefreshPatch({
+      messagesRefreshToken: 1,
+      searchRefreshToken: 1,
+      threadCacheVersion: 1,
+      selectedMessageId: recovered.id,
+      messages: [],
+      searchResults: [],
+      threadMessages: {
+        recovered: [recovered, unrelated],
+        stale: [{ id: 'row-stale', account_id: 'account-1', message_id: '<same@message>' }],
+      },
+      expandedThreadId: null,
+      loadingThread: null,
+    }, {
+      id: 'row-stale', accountId: 'account-1', messageId: '<same@message>',
+    });
+
+    assert.equal(Object.hasOwn(patch, 'selectedMessageId'), false);
+    assert.deepEqual(patch.threadMessages, { recovered: [recovered, unrelated] });
+  });
+
+  it('preserves the selected row when no terminal Done target is supplied', () => {
+    const patch = gtdDoneRefreshPatch({
+      messagesRefreshToken: 1,
+      searchRefreshToken: 1,
+      threadCacheVersion: 1,
+      selectedMessageId: 'row-x',
+      messages: [],
+      searchResults: [],
+      threadMessages: { old: [{ id: 'row-x', account_id: 'account-1' }] },
+    });
+
+    assert.equal(Object.hasOwn(patch, 'selectedMessageId'), false);
+    assert.deepEqual(patch.threadMessages, {});
+  });
+
+  it('reconciles messages, unread counts, and GTD sections after a complete response', async () => {
+    const calls = [];
+    const result = await doneGtdInboxRow(thread, {
+      gtdDone: async id => { calls.push(['api', id]); return { ok: true, phase: 'completed', inboxCleared: true }; },
+      refreshMessages: () => calls.push(['messages']),
+      refreshUnreadCounts: () => calls.push(['unread']),
+      refreshFolders: accountId => calls.push(['folders', accountId]),
+      refreshGtdSections: () => calls.push(['gtd']),
+      addNotification: value => calls.push(['notify', value]),
+      t: key => key,
+    });
+    assert.deepEqual(result, { ok: true, phase: 'completed', inboxCleared: true });
+    assert.deepEqual(calls, [['api', 'row-x'], ['messages'], ['unread'], ['folders', 'account-1'], ['gtd']]);
+  });
+
+  it('does not restore an ambiguous network failure and still reconciles', async () => {
+    const calls = [];
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      const result = await doneGtdInboxRow(thread, {
+        gtdDone: async () => { throw new Error('request failed'); },
+        restoreInbox: value => calls.push(['restore', value.id]),
+        refreshMessages: () => calls.push(['messages']),
+        refreshUnreadCounts: () => calls.push(['unread']),
+        refreshFolders: accountId => calls.push(['folders', accountId]),
+        refreshGtdSections: () => calls.push(['gtd']),
+        addNotification: value => calls.push(['notify', value]),
+        t: key => key,
+      });
+      assert.equal(result, null);
+      assert.deepEqual(calls, [
+        ['notify', { title: 'gtd.doneFailed', body: 'A subject' }],
+        ['messages'],
+        ['unread'],
+        ['folders', 'account-1'],
+        ['gtd'],
+      ]);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  it('restores the optimistic Inbox row after a structured non-2xx says archive is incomplete', async () => {
+    const calls = [];
+    const originalError = console.error;
+    console.error = () => {};
+    try {
+      await doneGtdInboxRow(thread, {
+        gtdDone: async () => { throw Object.assign(new Error('seen failed'), { phase: 'seen', inboxCleared: false }); },
+        restoreInbox: value => calls.push(['restore', value.id]),
+        refreshMessages: () => calls.push(['messages']),
+        refreshUnreadCounts: () => calls.push(['unread']),
+        refreshFolders: () => calls.push(['folders']),
+        refreshGtdSections: () => calls.push(['gtd']),
+        addNotification: () => calls.push(['notify']),
+        t: key => key,
+      });
+      assert.deepEqual(calls, [['restore', 'row-x'], ['notify'], ['messages'], ['unread'], ['folders'], ['gtd']]);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  it('warns on an incomplete archive and then reconciles authoritatively', async () => {
+    const calls = [];
+    await doneGtdInboxRow(thread, {
+      gtdDone: async () => ({ ok: true, archiveTargetCount: 2, inboxCleared: false }),
+      restoreInbox: value => calls.push(['restore', value.id]),
+      refreshMessages: () => calls.push(['messages']),
+      refreshUnreadCounts: () => calls.push(['unread']),
+      refreshFolders: accountId => calls.push(['folders', accountId]),
+      refreshGtdSections: () => calls.push(['gtd']),
+      addNotification: value => calls.push(['notify', value]),
+      t: key => key,
+    });
+    assert.deepEqual(calls, [
+      ['restore', 'row-x'],
+      ['notify', { title: 'gtd.doneArchiveFailed', body: 'A subject' }],
+      ['messages'],
+      ['unread'],
+      ['folders', 'account-1'],
+      ['gtd'],
+    ]);
+  });
+
+  it('reports a label-incomplete 2xx without restoring a cleared Inbox row', async () => {
+    const calls = [];
+    await doneGtdInboxRow(thread, {
+      gtdDone: async () => ({ ok: false, phase: 'labels', inboxCleared: true }),
+      restoreInbox: () => calls.push(['restore']),
+      refreshMessages: () => {},
+      refreshUnreadCounts: () => {},
+      refreshFolders: () => {},
+      refreshGtdSections: () => {},
+      addNotification: value => calls.push(['notify', value]),
+      t: key => key,
+    });
+    assert.deepEqual(calls, [['notify', { title: 'gtd.doneFailed', body: 'A subject' }]]);
+  });
+
+  it('reports a malformed 2xx and relies on authoritative refresh without restoring', async () => {
+    const calls = [];
+    await doneGtdInboxRow(thread, {
+      gtdDone: async () => ({}),
+      restoreInbox: () => calls.push(['restore']),
+      refreshMessages: () => {},
+      refreshUnreadCounts: () => {},
+      refreshFolders: () => {},
+      refreshGtdSections: () => {},
+      addNotification: value => calls.push(['notify', value]),
+      t: key => key,
+    });
+    assert.deepEqual(calls, [['notify', { title: 'gtd.doneFailed', body: 'A subject' }]]);
+  });
+
+  it('awaits every authoritative cache refresh before settling a terminal failure', async () => {
+    const release = [];
+    const pending = name => new Promise(resolve => release.push(() => resolve(name)));
+    const settled = doneGtdInboxRow(thread, {
+      gtdDone: async () => { throw new Error('uncertain'); },
+      restoreInbox: () => {},
+      refreshMessages: () => pending('messages'),
+      refreshUnreadCounts: () => pending('unread'),
+      refreshFolders: () => pending('folders'),
+      refreshGtdSections: () => pending('gtd'),
+      addNotification: () => {},
+      t: key => key,
+    });
+    let finished = false;
+    settled.then(() => { finished = true; });
+    while (release.length < 4) await new Promise(resolve => setTimeout(resolve, 0));
+    assert.equal(finished, false);
+    for (const resolve of release) resolve();
+    await settled;
+    assert.equal(finished, true);
   });
 });

--- a/frontend/src/utils/pendingGtdRemovals.js
+++ b/frontend/src/utils/pendingGtdRemovals.js
@@ -7,46 +7,46 @@ function normalizeStates(states) {
   return [...new Set((states || []).filter(Boolean))].sort();
 }
 
-function removalKey(identity, states) {
-  return JSON.stringify([identity, normalizeStates(states)]);
+function removalKey(identity, states, accountId = null) {
+  return JSON.stringify([accountId, identity, normalizeStates(states)]);
 }
 
-function setExpiring(map, identity, states, ttlMs) {
+function setExpiring(map, identity, states, accountId, ttlMs) {
   const normalizedStates = normalizeStates(states);
-  const key = removalKey(identity, normalizedStates);
+  const key = removalKey(identity, normalizedStates, accountId);
   const existing = map.get(key);
   if (existing?.timer) clearTimeout(existing.timer);
   const timer = setTimeout(() => map.delete(key), ttlMs);
-  map.set(key, { identity, states: normalizedStates, timer });
+  map.set(key, { identity, states: normalizedStates, accountId, timer });
 }
 
-function clearRemoval(map, identity, states) {
-  const key = removalKey(identity, states);
+function clearRemoval(map, identity, states, accountId = null) {
+  const key = removalKey(identity, states, accountId);
   const existing = map.get(key);
   if (existing?.timer) clearTimeout(existing.timer);
   map.delete(key);
 }
 
-export function setPendingGtdRemoval(identity, states) {
-  clearRemoval(completedGtdRemovalMap, identity, states);
-  setExpiring(pendingGtdRemovalMap, identity, states, 30000);
+export function setPendingGtdRemoval(identity, states, accountId = null) {
+  clearRemoval(completedGtdRemovalMap, identity, states, accountId);
+  setExpiring(pendingGtdRemovalMap, identity, states, accountId, 30000);
 }
 
-export function setCompletedGtdRemoval(identity, states) {
-  clearRemoval(pendingGtdRemovalMap, identity, states);
-  setExpiring(completedGtdRemovalMap, identity, states, 10000);
+export function setCompletedGtdRemoval(identity, states, accountId = null) {
+  clearRemoval(pendingGtdRemovalMap, identity, states, accountId);
+  setExpiring(completedGtdRemovalMap, identity, states, accountId, 10000);
 }
 
-export function clearGtdRemovalGuard(identity, states) {
-  clearRemoval(pendingGtdRemovalMap, identity, states);
-  clearRemoval(completedGtdRemovalMap, identity, states);
+export function clearGtdRemovalGuard(identity, states, accountId = null) {
+  clearRemoval(pendingGtdRemovalMap, identity, states, accountId);
+  clearRemoval(completedGtdRemovalMap, identity, states, accountId);
 }
 
 export function applyGtdRemovalGuard(sections) {
   if (pendingGtdRemovalMap.size === 0 && completedGtdRemovalMap.size === 0) return sections;
   let guarded = sections;
   for (const removal of [...pendingGtdRemovalMap.values(), ...completedGtdRemovalMap.values()]) {
-    guarded = removeGtdThreadFromSections(guarded, removal.identity, removal.states);
+    guarded = removeGtdThreadFromSections(guarded, removal.identity, removal.states, removal.accountId);
   }
   return guarded;
 }

--- a/frontend/src/utils/pendingGtdRemovals.test.js
+++ b/frontend/src/utils/pendingGtdRemovals.test.js
@@ -14,8 +14,8 @@ const makeSections = () => ({
     total: 2,
     unread: 1,
     threads: [
-      { id: 'todo-x', message_id: 'x', is_read: false },
-      { id: 'todo-y', message_id: 'y', is_read: true },
+      { id: 'todo-x', account_id: 'account-1', message_id: 'x', is_read: false },
+      { id: 'todo-y', account_id: 'account-2', message_id: 'y', is_read: true },
     ],
   },
   watch: {
@@ -39,7 +39,7 @@ const makeSections = () => ({
 describe('pending GTD removal guard', () => {
   afterEach(() => {
     for (const removal of [...pendingGtdRemovalMap.values(), ...completedGtdRemovalMap.values()]) {
-      clearGtdRemovalGuard(removal.identity, removal.states);
+      clearGtdRemovalGuard(removal.identity, removal.states, removal.accountId);
     }
   });
 
@@ -90,5 +90,14 @@ describe('pending GTD removal guard', () => {
 
     clearGtdRemovalGuard('x', ['todo']);
     assert.equal(applyGtdRemovalGuard(sections), sections);
+  });
+
+  it('does not hide the same Message-ID from another account in unified GTD', () => {
+    const sections = makeSections();
+    sections.todo.threads.push({ id: 'todo-x-other', account_id: 'account-2', message_id: 'x', is_read: true });
+    sections.todo.total = 3;
+    setPendingGtdRemoval('x', ['todo'], 'account-1');
+    const guarded = applyGtdRemovalGuard(sections);
+    assert.deepEqual(guarded.todo.threads.map(row => row.id), ['todo-y', 'todo-x-other']);
   });
 });

--- a/frontend/src/utils/threadedArchive.js
+++ b/frontend/src/utils/threadedArchive.js
@@ -121,8 +121,15 @@ export function invalidateThreadLoad(versions, threadId) {
   return next;
 }
 
-export function isCurrentThreadLoad(versions, threadId, version) {
-  return currentThreadLoadVersion(versions, threadId) === version;
+export function isCurrentThreadLoad(
+  versions,
+  threadId,
+  version,
+  cacheVersion = null,
+  currentCacheVersion = null,
+) {
+  return currentThreadLoadVersion(versions, threadId) === version
+    && (cacheVersion == null || cacheVersion === currentCacheVersion);
 }
 
 export function removeThreadCacheEntry(cache, threadId) {

--- a/frontend/src/utils/threadedArchive.test.js
+++ b/frontend/src/utils/threadedArchive.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import * as threadedArchive from './threadedArchive.js';
+import { api } from './api.js';
 
 const {
   archiveTargetsForFolder,
@@ -101,6 +102,13 @@ describe('thread load invalidation', () => {
     assert.equal(isCurrentThreadLoad(versions, 'thread-1', captured), true);
     invalidateThreadLoad(versions, 'thread-1');
     assert.equal(isCurrentThreadLoad(versions, 'thread-1', captured), false);
+  });
+
+  it('rejects an in-flight load captured before a global thread-cache reset', () => {
+    const versions = new Map();
+    const captured = currentThreadLoadVersion(versions, 'thread-1');
+    assert.equal(isCurrentThreadLoad(versions, 'thread-1', captured, 2, 2), true);
+    assert.equal(isCurrentThreadLoad(versions, 'thread-1', captured, 2, 3), false);
   });
 
   it('removes a cache key without leaving a non-array sentinel behind', () => {
@@ -244,6 +252,32 @@ describe('archiveInChunks', () => {
     assert.deepEqual(calls.map(chunk => chunk.length), [500, 1]);
     assert.deepEqual(result.archived, ids.slice(0, 499));
     assert.deepEqual(result.noArchiveFolder, [ids[499], ids[500]]);
+  });
+
+  it('preserves an unconfirmed row key across chunked mixed-subset retry', async () => {
+    const ids = Array.from({ length: 501 }, (_, index) => `id-${index}`);
+    const calls = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (_url, init) => {
+      const body = JSON.parse(init.body);
+      calls.push(body);
+      return {
+        ok: true,
+        json: async () => ({
+          archived: calls.length === 2 ? [] : body.ids,
+          noArchiveFolder: [],
+        }),
+      };
+    };
+    try {
+      await threadedArchive.archiveInChunks(ids, api.bulkArchive);
+      await threadedArchive.archiveInChunks(['id-500', 'id-new'], api.bulkArchive);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    assert.deepEqual(calls.map(({ ids: rowIds }) => rowIds.length), [500, 1, 2]);
+    assert.equal(calls[2].operationKeys['id-500'], calls[1].operationKeys['id-500']);
+    assert.notEqual(calls[2].operationKeys['id-new'], calls[1].operationKeys['id-500']);
   });
 
   it('preserves completed chunks and reports the unconfirmed remainder after an error', async () => {


### PR DESCRIPTION
## What changed

- Keep incomplete IMAP envelope rows out of mail, search, category, rule, and GTD read surfaces until backfill verifies them.
- Fence moves, copies, deletes, appends, drafts, sends, flags, and forwarding with exact folder and message snapshots plus durable provider-operation receipts.
- Make rapid archive requests idempotent and reconcile uncertain subsets without replaying completed work.
- Make GTD Done freeze and resume a thread-wide plan: mark every copy read, archive Inbox copies, then remove the requested GTD labels.
- Preserve safe GTD classification undo on the durable COPY path.
- Bind legacy snoozes before topology quarantine, establish UIDVALIDITY before using a newly ensured folder, and defer empty-folder while its backfill is incomplete.
- Repair WebSocket URL construction and reconnect refresh handling so live updates do not degrade into the polling loop that exposed the race.

## Why

An IMAP UID is meaningful only inside one folder and one UIDVALIDITY epoch. During rapid archive bursts or resyncs, MailFlow could list a UID before its envelope was complete, then let later mutations act on stale local identity. That produced transient `Unknown / (no subject)` rows and made archive and GTD retries ambiguous.

This change makes incomplete metadata invisible, carries exact snapshot identity through provider work, and stores enough intent and receipt state to recover without guessing. GTD Done now completes one frozen thread plan instead of chaining best-effort label and archive calls.

## Usage

No usage change.

Closes #407.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.
