### PR TITLE
feat(rules): show ancestor paths in the move-destination dropdown

### DIFF
--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -30,6 +30,7 @@ import DiagnosticsReportModal from './DiagnosticsReportModal.jsx';
 import { getEffectiveShortcuts, getGroupedActions, ACTION_DEFS, SPECIAL_KEY_LABELS, parseModKey, modLabel } from '../utils/defaultShortcuts.js';
 import { unifiedUnreadTotal } from '../utils/unifiedInbox.js';
 import { isValidForwardAddress } from '../utils/ruleActions.js';
+import { folderParentLabel } from '../utils/folderDisplay.js';
 
 // ─── Shared field component ───────────────────────────────────────────────────
 function Field({ label, required, children }) {
@@ -5940,7 +5941,10 @@ function RulesTab() {
     const acts = Array.isArray(rule.actions) ? rule.actions : [];
     if (!acts.length) return '—';
     const labels = { mark_read: t('admin.rules.actionMarkRead'), star: t('admin.rules.actionStar'), forward: t('admin.rules.actionForward'), archive: t('admin.rules.actionArchive'), delete: t('admin.rules.actionDelete'), move: t('admin.rules.actionMove') };
-    return acts.map(a => labels[a.type] || a.type).join(', ');
+    // Show the move destination so same-named rules are tellable apart at a glance.
+    return acts.map(a => a.type === 'move' && a.value
+      ? `${labels.move} → ${a.value}`
+      : (labels[a.type] || a.type)).join(', ');
   }
 
   const FIELDS = [
@@ -6145,11 +6149,24 @@ function RulesTab() {
                         style={{ ...inputStyle, marginTop: 6, marginLeft: 22 }}
                         value={moveVal}
                         onChange={e => setActionValue('move', e.target.value)}
+                        // The closed control clips long paths; surface the full
+                        // selected path as a tooltip. (A native <option> cannot
+                        // host the pickers' two-tone/hover-scroll label.)
+                        title={moveVal || undefined}
                       >
                         <option value="">{t('admin.rules.actionMoveSelectFolder')}</option>
-                        {movableFolders.map(f => (
-                          <option key={f.path} value={f.path}>{f.name || f.path}</option>
-                        ))}
+                        {movableFolders.map(f => {
+                          // Same ancestor-path display as the move pickers, so
+                          // same-named folders under different parents are
+                          // distinguishable when choosing a rule destination.
+                          const parent = folderParentLabel(f);
+                          const name = f.name || f.path;
+                          return (
+                            <option key={f.path} value={f.path}>
+                              {parent ? `${parent} / ${name}` : name}
+                            </option>
+                          );
+                        })}
                       </select>
                     );
                   }

--- a/frontend/src/components/ContextMenu.jsx
+++ b/frontend/src/components/ContextMenu.jsx
@@ -5,6 +5,8 @@ import { api } from '../utils/api.js';
 import { getContextMenuPolicy, resolveContextMenuMessage } from '../utils/contextMenuPolicy.js';
 import { usePluginCollected } from '../plugins/PluginSlot.jsx';
 import MessageHeaderModal from './MessageHeaderModal.jsx';
+import FolderPathLabel from './FolderPathLabel.jsx';
+import { folderMatchesQuery } from '../utils/folderDisplay.js';
 import { useUiScale, descale } from '../hooks/useUiScale.js';
 import { useMobile } from '../hooks/useMobile.js';
 
@@ -629,7 +631,7 @@ export default function ContextMenu({ x, y, message, onClose, onAction, defaultM
                 const searchQuery = folderSearch.trim().toLowerCase();
                 if (searchQuery) {
                   const filtered = (moveFolders || [])
-                    .filter(f => f.path !== message.folder && f.name.toLowerCase().includes(searchQuery));
+                    .filter(f => f.path !== message.folder && folderMatchesQuery(f, searchQuery));
                   return filtered.length === 0 ? (
                     <div style={{ padding: '12px 14px', color: 'var(--text-tertiary)', fontSize: 12 }}>
                       {t('contextMenu.folders.empty')}
@@ -799,9 +801,7 @@ function FolderMenuItem({ folder, onClick }) {
       }}
     >
       <span style={{ flexShrink: 0, color: 'var(--text-tertiary)', display: 'flex' }}>{icon}</span>
-      <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {folder.name || folder.path}
-      </span>
+      <FolderPathLabel folder={folder} />
     </div>
   );
 }

--- a/frontend/src/components/FolderPathLabel.jsx
+++ b/frontend/src/components/FolderPathLabel.jsx
@@ -1,0 +1,21 @@
+import { folderParentLabel } from '../utils/folderDisplay';
+
+// Folder name prefixed with its muted ancestor path ("Personal / Insurance"),
+// used by every move-to-folder picker so duplicate names under different
+// parents stay distinguishable. The parent shrinks/truncates first; the name
+// itself only truncates once the parent is fully collapsed.
+export default function FolderPathLabel({ folder }) {
+  const parent = folderParentLabel(folder);
+  return (
+    <span style={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center', whiteSpace: 'nowrap' }}>
+      {parent && (
+        <span style={{ color: 'var(--text-tertiary)', overflow: 'hidden', textOverflow: 'ellipsis', flexShrink: 1, minWidth: 0 }}>
+          {parent}{' / '}
+        </span>
+      )}
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        {folder.name || folder.path}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/components/MessageList.jsx
+++ b/frontend/src/components/MessageList.jsx
@@ -18,6 +18,8 @@ import { formatDate } from '../utils/formatDate.js';
 import { advanceSelectionAfterRemoval } from '../utils/listSelection.js';
 import { openReplyFromMessage, openForwardFromMessage } from '../utils/composeFromMessage.js';
 import SenderAvatarImage from './SenderAvatarImage.jsx';
+import FolderPathLabel from './FolderPathLabel.jsx';
+import { folderMatchesQuery } from '../utils/folderDisplay.js';
 import { shortcutBus } from '../utils/shortcutBus.js';
 import { createLatestRequest } from '../utils/latestRequest.js';
 import { pendingMarkReadMap, completedMarkReadMap, setPending } from '../utils/pendingReads.js';
@@ -3464,7 +3466,7 @@ export default function MessageList() {
                       {(() => {
                         const q = pickerSearch.trim().toLowerCase();
                         const displayed = pickerFolders
-                          .filter(f => f.path !== selectedFolder && (!q || f.name.toLowerCase().includes(q)));
+                          .filter(f => f.path !== selectedFolder && (!q || folderMatchesQuery(f, q)));
                         return displayed.length === 0 ? (
                           <div style={{ padding: '12px 12px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 12 }}>
                             {t('contextMenu.folders.empty')}
@@ -3494,9 +3496,7 @@ export default function MessageList() {
                                 <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}>
                                   <FolderIcon specialUse={f.special_use} />
                                 </span>
-                                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                  {f.name}
-                                </span>
+                                <FolderPathLabel folder={f} />
                               </button>
                             ))}
                           </>
@@ -3561,7 +3561,7 @@ export default function MessageList() {
                       ) : (() => {
                         const q = pickerSearch.trim().toLowerCase();
                         const displayed = pickerFolders
-                          .filter(f => f.path !== selectedFolder && (!q || f.name.toLowerCase().includes(q)));
+                          .filter(f => f.path !== selectedFolder && (!q || folderMatchesQuery(f, q)));
                         return displayed.length === 0 ? (
                           <div style={{ padding: '24px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
                             {t('contextMenu.folders.empty')}
@@ -3583,9 +3583,7 @@ export default function MessageList() {
                             <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}>
                               <FolderIcon specialUse={f.special_use} />
                             </span>
-                            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                              {f.name}
-                            </span>
+                            <FolderPathLabel folder={f} />
                           </button>
                         ));
                       })()}

--- a/frontend/src/components/MessagePane.jsx
+++ b/frontend/src/components/MessagePane.jsx
@@ -13,6 +13,8 @@ import { BUILTIN_SUMMARIZE, summarizePromptForLocale } from '../aiActions.js';
 import { getResults, saveResult, removeResult } from '../aiResults.js';
 import { renderMarkdown } from '../utils/renderMarkdown.js';
 import { pickReplyAlias } from '../utils/replyAlias.js';
+import { folderMatchesQuery } from '../utils/folderDisplay.js';
+import FolderPathLabel from './FolderPathLabel.jsx';
 const USE_DIV_RENDER = import.meta.env.VITE_EMAIL_DIV_RENDER === 'true';
 const MESSAGE_OPENING_EVENT = 'mailflow:message-opening';
 
@@ -2062,7 +2064,7 @@ ${bodyContent}
                     const q = moveSearch.trim().toLowerCase();
                     if (q) {
                       const filtered = movePickerFolders
-                        .filter(f => f.path !== message.folder && f.name.toLowerCase().includes(q));
+                        .filter(f => f.path !== message.folder && folderMatchesQuery(f, q));
                       return filtered.length === 0 ? (
                         <div style={{ padding: '12px 12px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 12 }}>
                           {t('contextMenu.folders.empty')}
@@ -2076,7 +2078,7 @@ ${bodyContent}
                           onMouseLeave={e => e.currentTarget.style.background = 'none'}
                         >
                           <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} /></span>
-                          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                          <FolderPathLabel folder={f} />
                         </button>
                       ));
                     }
@@ -2096,7 +2098,7 @@ ${bodyContent}
                                 onMouseLeave={e => e.currentTarget.style.background = 'none'}
                               >
                                 <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} /></span>
-                                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                                <FolderPathLabel folder={f} />
                               </button>
                             ))}
                             <div style={{ height: 1, background: 'var(--border-subtle)', margin: '3px 0' }} />
@@ -2116,7 +2118,7 @@ ${bodyContent}
                                 onMouseLeave={e => e.currentTarget.style.background = 'none'}
                               >
                                 <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} /></span>
-                                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                                <FolderPathLabel folder={f} />
                               </button>
                             ))}
                             <div style={{ height: 1, background: 'var(--border-subtle)', margin: '3px 0' }} />
@@ -2133,7 +2135,7 @@ ${bodyContent}
                               onMouseLeave={e => e.currentTarget.style.background = 'none'}
                             >
                               <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} /></span>
-                              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                              <FolderPathLabel folder={f} />
                             </button>
                           ))
                         }
@@ -2989,7 +2991,7 @@ ${bodyContent}
                 const q = moveSearch.trim().toLowerCase();
                 if (q) {
                   const filtered = movePickerFolders
-                    .filter(f => f.path !== message.folder && f.name.toLowerCase().includes(q));
+                    .filter(f => f.path !== message.folder && folderMatchesQuery(f, q));
                   return filtered.length === 0 ? (
                     <div style={{ padding: '24px', textAlign: 'center', color: 'var(--text-tertiary)', fontSize: 13 }}>
                       {t('contextMenu.folders.empty')}
@@ -3001,7 +3003,7 @@ ${bodyContent}
                       style={{ display: 'flex', alignItems: 'center', gap: 14, width: '100%', minHeight: 48, padding: '0 20px', background: 'none', border: 'none', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)', fontSize: 15, cursor: 'pointer', textAlign: 'left' }}
                     >
                       <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} size={18} /></span>
-                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                      <FolderPathLabel folder={f} />
                     </button>
                   ));
                 }
@@ -3019,7 +3021,7 @@ ${bodyContent}
                             style={{ display: 'flex', alignItems: 'center', gap: 14, width: '100%', minHeight: 48, padding: '0 20px', background: 'none', border: 'none', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)', fontSize: 15, cursor: 'pointer', textAlign: 'left' }}
                           >
                             <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} size={18} /></span>
-                            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                            <FolderPathLabel folder={f} />
                           </button>
                         ))}
                         <div style={{ height: 1, background: 'var(--border-subtle)', margin: '3px 0' }} />
@@ -3037,7 +3039,7 @@ ${bodyContent}
                             style={{ display: 'flex', alignItems: 'center', gap: 14, width: '100%', minHeight: 48, padding: '0 20px', background: 'none', border: 'none', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)', fontSize: 15, cursor: 'pointer', textAlign: 'left' }}
                           >
                             <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} size={18} /></span>
-                            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                            <FolderPathLabel folder={f} />
                           </button>
                         ))}
                         <div style={{ height: 1, background: 'var(--border-subtle)', margin: '3px 0' }} />
@@ -3052,7 +3054,7 @@ ${bodyContent}
                           style={{ display: 'flex', alignItems: 'center', gap: 14, width: '100%', minHeight: 48, padding: '0 20px', background: 'none', border: 'none', borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-primary)', fontSize: 15, cursor: 'pointer', textAlign: 'left' }}
                         >
                           <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}><FolderIcon specialUse={f.special_use} size={18} /></span>
-                          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+                          <FolderPathLabel folder={f} />
                         </button>
                       ))
                     }

--- a/frontend/src/utils/folderDisplay.js
+++ b/frontend/src/utils/folderDisplay.js
@@ -1,0 +1,39 @@
+// Display + search helpers for the move-to-folder pickers, built on the same
+// delimiter primitives the sidebar tree uses (sidebar.js imports them from
+// here) so the pickers and the folder tree can never disagree about hierarchy.
+// Accounts differ in IMAP delimiter ('/', '.', ...), so the display and search
+// helpers normalize paths to '/' for humans.
+
+// Preferred IMAP delimiter of a single folder row ('/' fallback).
+export function folderDelimiter(folder) {
+  return (typeof folder?.delimiter === 'string' && folder.delimiter) || '/';
+}
+
+// Parent path of an IMAP folder path, or null for a root-level path.
+export function folderParentPath(path, delimiter) {
+  const index = path.lastIndexOf(delimiter);
+  return index === -1 ? null : path.slice(0, index);
+}
+
+// Muted ancestor chain shown before a folder's name ("Personal / Insurance"),
+// so same-named folders under different parents stay distinguishable.
+// Empty string for root-level folders.
+export function folderParentLabel(folder) {
+  const path = typeof folder?.path === 'string' ? folder.path : '';
+  const delimiter = folderDelimiter(folder);
+  const parent = path ? folderParentPath(path, delimiter) : null;
+  if (!parent) return '';
+  return parent.split(delimiter).join(' / ');
+}
+
+// Search matches the folder name or any part of its path, with the path also
+// matchable in normalized "parent/child" form regardless of account delimiter.
+export function folderMatchesQuery(folder, query) {
+  const q = String(query ?? '').trim().toLowerCase();
+  if (!q) return true;
+  const name = String(folder?.name ?? '').toLowerCase();
+  if (name.includes(q)) return true;
+  const path = String(folder?.path ?? '').toLowerCase();
+  if (path.includes(q)) return true;
+  return path.split(folderDelimiter(folder).toLowerCase()).join('/').includes(q);
+}

--- a/frontend/src/utils/folderDisplay.test.js
+++ b/frontend/src/utils/folderDisplay.test.js
@@ -1,0 +1,111 @@
+// Run with: node --test src/utils/folderDisplay.test.js
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  folderDelimiter,
+  folderMatchesQuery,
+  folderParentLabel,
+  folderParentPath,
+} from './folderDisplay.js';
+
+describe('folderDelimiter', () => {
+  it('uses the folder delimiter and falls back to a slash', () => {
+    assert.equal(folderDelimiter({ delimiter: '.' }), '.');
+    assert.equal(folderDelimiter({ delimiter: '' }), '/');
+    assert.equal(folderDelimiter({}), '/');
+    assert.equal(folderDelimiter(null), '/');
+  });
+});
+
+describe('folderParentPath', () => {
+  it('returns the parent path and null at the root', () => {
+    assert.equal(folderParentPath('Projects/Alpha', '/'), 'Projects');
+    assert.equal(folderParentPath('INBOX.Receipts.Amazon', '.'), 'INBOX.Receipts');
+    assert.equal(folderParentPath('Archive', '/'), null);
+  });
+});
+
+describe('folderParentLabel', () => {
+  it('is empty for root-level folders', () => {
+    assert.equal(folderParentLabel({ path: 'Archive', name: 'Archive', delimiter: '/' }), '');
+  });
+
+  it('shows the parent for one level of nesting', () => {
+    assert.equal(
+      folderParentLabel({ path: 'ML Vending/SeedLive', name: 'SeedLive', delimiter: '/' }),
+      'ML Vending',
+    );
+  });
+
+  it('joins deeper ancestor chains for humans', () => {
+    assert.equal(
+      folderParentLabel({ path: 'Personal/Insurance/2024', name: '2024', delimiter: '/' }),
+      'Personal / Insurance',
+    );
+  });
+
+  it('respects dot-delimiter accounts', () => {
+    assert.equal(
+      folderParentLabel({ path: 'INBOX.Receipts.Amazon', name: 'Amazon', delimiter: '.' }),
+      'INBOX / Receipts',
+    );
+  });
+
+  it('tolerates folders without a path', () => {
+    assert.equal(folderParentLabel({ name: 'Orphan' }), '');
+    assert.equal(folderParentLabel(null), '');
+  });
+});
+
+describe('folderMatchesQuery', () => {
+  const folder = { path: 'ML Vending/SeedLive', name: 'SeedLive', delimiter: '/' };
+
+  it('matches everything on an empty query', () => {
+    assert.equal(folderMatchesQuery(folder, ''), true);
+    assert.equal(folderMatchesQuery(folder, '   '), true);
+    assert.equal(folderMatchesQuery(folder, null), true);
+  });
+
+  it('matches the folder name case-insensitively', () => {
+    assert.equal(folderMatchesQuery(folder, 'seedlive'), true);
+    assert.equal(folderMatchesQuery(folder, 'SEED'), true);
+  });
+
+  it('matches the parent segment of the path', () => {
+    assert.equal(folderMatchesQuery(folder, 'vending'), true);
+  });
+
+  it('matches a parent/child query across the delimiter', () => {
+    assert.equal(folderMatchesQuery(folder, 'vending/seed'), true);
+  });
+
+  it('matches parent/child queries on dot-delimiter accounts too', () => {
+    const dotted = { path: 'INBOX.Receipts.Amazon', name: 'Amazon', delimiter: '.' };
+    assert.equal(folderMatchesQuery(dotted, 'receipts/amazon'), true);
+    assert.equal(folderMatchesQuery(dotted, 'receipts.amazon'), true);
+  });
+
+  it('rejects folders that match nowhere', () => {
+    assert.equal(folderMatchesQuery(folder, 'taxes'), false);
+  });
+
+  it('does not false-match a slash query against a name containing a dot', () => {
+    // '/'-delimited account whose folder NAME contains a '.' — the '.' is part
+    // of the name, not hierarchy, so a '/'-separated query must not split it.
+    const dotted = { path: 'Reports/2024.05', name: '2024.05', delimiter: '/' };
+    assert.equal(folderMatchesQuery(dotted, '2024/05'), false);
+    assert.equal(folderMatchesQuery(dotted, '2024.05'), true);
+    assert.equal(folderMatchesQuery(dotted, 'reports/2024'), true);
+    assert.equal(folderParentLabel(dotted), 'Reports');
+  });
+
+  it('matches the literal name of a folder whose name contains a slash', () => {
+    // '.'-delimited account whose folder NAME contains a '/'. Its literal name
+    // must stay searchable, and the parent chain must come from the real
+    // delimiter, not the slash inside the name.
+    const slashed = { path: 'INBOX.a/b', name: 'a/b', delimiter: '.' };
+    assert.equal(folderMatchesQuery(slashed, 'a/b'), true);
+    assert.equal(folderMatchesQuery(slashed, 'inbox.a'), true);
+    assert.equal(folderParentLabel(slashed), 'INBOX');
+  });
+});

--- a/frontend/src/utils/sidebar.js
+++ b/frontend/src/utils/sidebar.js
@@ -1,3 +1,7 @@
+// Delimiter and parent-path primitives are shared with the move-picker label
+// and search helpers so the tree and the pickers can never disagree.
+import { folderDelimiter, folderParentPath as folderParent } from './folderDisplay.js';
+
 export function collapsedTooltip(label, collapsed) {
   if (!collapsed) return undefined;
   // An empty title suppresses the browser's own tooltip, so drop the attribute.
@@ -15,14 +19,9 @@ export function activateOnKey(activate) {
 export const FOLDER_ORDER_DRAG_TYPE = 'application/x-mailflow-folder-order';
 
 function delimiterFor(folders) {
-  return folders.find(folder => (
+  return folderDelimiter(folders.find(folder => (
     typeof folder?.delimiter === 'string' && folder.delimiter
-  ))?.delimiter || '/';
-}
-
-function folderParent(path, delimiter) {
-  const index = path.lastIndexOf(delimiter);
-  return index === -1 ? null : path.slice(0, index);
+  )));
 }
 
 function folderPathsWithAncestors(folders) {


### PR DESCRIPTION
## Summary

Companion to #410, applying the same ancestor-path treatment to the inbox-rules form. The rule editor's move-destination dropdown listed bare folder names, so an account with `INBOX/Archive` and a root `Archive` (or `Personal/Insurance` vs `Business/Insurance`) showed identical entries and picking the right destination was guesswork. The rules list also summarized any move rule as just "Move", with no destination.

**Stacked on #410** — the first commit here is that PR's commit (this reuses its `folderParentLabel` util so the rules form, the pickers, and the sidebar tree all derive hierarchy from one source). Only the `AdminPanel.jsx` commit is new; happy to rebase once the base lands.

## Changes

- The move-destination `<select>` labels each option with its ancestor chain: `Ice Rentals / Groups / Beacon Hill` instead of `Beacon Hill`, via the shared `folderParentLabel`.
- The closed control gets a `title` tooltip with the selected folder's full path (a native `<option>` cannot host the pickers' two-tone label, but the opened dropdown already shows the full text untruncated).
- The rules list's action summary shows the move destination (`Move → Ice Rentals/Groups`) so rules are tellable apart at a glance.

## Testing

- Running in production on my instance: creating and editing move rules against a Gmail account with duplicate folder names under different parents — destinations are now unambiguous in the dropdown and visible in the rules list.
- `npm run lint` clean; full frontend suite passes (1686/1686).

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
