### PR TITLE
fix(sidebar): make the subfolder-create input appear and stay usable

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -700,6 +700,10 @@ export default function Sidebar() {
           setCreatingFolder({ accountId, parentPath: folderObj.path });
           setCreateName('');
           if (!expandedAccounts[accountId]) setExpandedAccounts(prev => ({ ...prev, [accountId]: true }));
+          // Un-collapse the target folder so the input isn't hidden with it.
+          if (collapsedFolders.includes(`${accountId}:${folderObj.path}`)) {
+            toggleCollapsedFolder(accountId, folderObj.path);
+          }
         },
       },
       { separator: true },
@@ -1224,7 +1228,9 @@ export default function Sidebar() {
                     display: 'flex', alignItems: 'center', gap: 8,
                     padding: `6px 10px 6px ${indent}px`, borderRadius: 7,
                   }}>
-                    <span style={{ color: 'var(--text-tertiary)', flexShrink: 0, display: 'flex' }}>{ICONS.folder}</span>
+                    {/* No folder icon here: at deep indents its footprint squeezes
+                        the input to a sliver, and the indent alone already places
+                        the row among its future siblings. */}
                     <input
                       ref={createInputRef}
                       value={createName}
@@ -1453,12 +1459,13 @@ export default function Sidebar() {
 
                       {/* Children — shown when expanded */}
                       {hasChildren && isExpanded && (
-                        <>
-                          {visibleChildren.map(child => renderNode(child, depth + 1, visibleChildren))}
-                          {creatingFolder?.accountId === account.id && creatingFolder?.parentPath === folder.path &&
-                            createFolderInput(BASE_INDENT + (depth + 1) * DEPTH_INDENT)}
-                        </>
+                        visibleChildren.map(child => renderNode(child, depth + 1, visibleChildren))
                       )}
+                      {/* Subfolder-create input — outside the children block so it
+                          also renders on leaf folders (gated inside it, "New
+                          subfolder" on a childless folder silently did nothing). */}
+                      {creatingFolder?.accountId === account.id && creatingFolder?.parentPath === folder.path &&
+                        createFolderInput(BASE_INDENT + (depth + 1) * DEPTH_INDENT)}
                     </div>
                   );
                 };


### PR DESCRIPTION
## Summary

Follow-up to #395, which fixed the backend half of subfolder creation. The UI half has a matching bug: right-clicking a folder and choosing "New subfolder" on a folder that has **no children yet** silently does nothing — no input, no error. The create input is rendered inside the children block, which only exists when the folder already has visible children and is expanded, so on a leaf folder the click sets state and nothing appears. Since every freshly created folder is a leaf, subfolders of new folders cannot be created from the UI at all.

## Changes

- Render the create input whenever creation targets the folder, outside the children block, so it appears on leaf folders too.
- Un-collapse a collapsed target folder when creation starts, so the input isn't hidden along with its children.
- Drop the input row's decorative folder icon: its footprint squeezed the text field to a sliver once the parent sits a few levels deep (indent grows 14px per level while the row width is fixed), and the indent alone already places the row among its future siblings.

## Testing

- Reproduced on a live self-hosted instance (source build) against Gmail: "New subfolder" on any childless folder was a silent no-op; after the fix the input appears indented under the target at any depth, with usable width, and creation works end-to-end with #395's backend fix.
- `npm run lint` clean; full frontend suite passes (1801/1801).

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
