### PR TITLE
fix(folders): create folders at the server's real path, not a guessed one

### DIFF
--- a/backend/src/routes/mail.createFolder.test.js
+++ b/backend/src/routes/mail.createFolder.test.js
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/db.js', () => ({ query: vi.fn() }));
+vi.mock('../middleware/auth.js', () => ({
+  requireAuth: (req, _res, next) => { req.session = { userId: 'user-1' }; next(); },
+}));
+vi.mock('../index.js', () => ({ imapManager: { ensureFolder: vi.fn(), broadcast: vi.fn() } }));
+
+import express from 'express';
+import mailRoutes from './mail.js';
+import { query } from '../services/db.js';
+import { imapManager } from '../index.js';
+
+const ACCOUNT_ID = 'd4d4d4d4-4444-4444-8444-d4d4d4d4d4d4';
+const ACCOUNT = { id: ACCOUNT_ID, user_id: 'user-1' };
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/mail', mailRoutes);
+  return app;
+}
+
+const insertedFolderCall = () =>
+  query.mock.calls.find(([sql]) => sql.includes('INSERT INTO folders'));
+
+describe('POST /api/mail/folders — create through ensureFolder', () => {
+  let server, base;
+  let accountDelimiter;
+  beforeAll(async () => { await new Promise(r => { server = buildApp().listen(0, r); }); base = `http://127.0.0.1:${server.address().port}`; });
+  afterAll(async () => { await new Promise(r => server.close(r)); });
+  beforeEach(() => {
+    query.mockReset(); imapManager.ensureFolder.mockReset();
+    accountDelimiter = '.';
+    query.mockImplementation((sql) => {
+      if (sql.includes('FROM email_accounts WHERE id = $1 AND user_id = $2')) return Promise.resolve({ rows: [ACCOUNT] });
+      if (sql.includes('SELECT delimiter FROM folders')) {
+        return Promise.resolve({ rows: accountDelimiter ? [{ delimiter: accountDelimiter }] : [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+  });
+
+  const create = (body) => fetch(`${base}/api/mail/folders`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ accountId: ACCOUNT_ID, ...body }),
+  });
+
+  it('joins parent and leaf with a slash and stores the real server path', async () => {
+    // Dot-delimited, INBOX-prefixed server: the server's real path differs
+    // from the requested one — the DB must store what the server created.
+    imapManager.ensureFolder.mockResolvedValue({ path: 'INBOX.Foo.Bar', created: true });
+    const res = await create({ name: 'Bar', parentPath: 'INBOX.Foo' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, path: 'INBOX.Foo.Bar' });
+    expect(imapManager.ensureFolder).toHaveBeenCalledWith(ACCOUNT, 'INBOX.Foo/Bar', { resolvePath: true });
+    const [, params] = insertedFolderCall();
+    expect(params).toEqual([ACCOUNT_ID, 'INBOX.Foo.Bar', 'Bar', '.']);
+  });
+
+  it('creates root folders from the bare name', async () => {
+    accountDelimiter = '/';
+    imapManager.ensureFolder.mockResolvedValue({ path: 'Projects', created: true });
+    const res = await create({ name: 'Projects' });
+    expect(res.status).toBe(200);
+    expect(imapManager.ensureFolder).toHaveBeenCalledWith(ACCOUNT, 'Projects', { resolvePath: true });
+    const [, params] = insertedFolderCall();
+    expect(params).toEqual([ACCOUNT_ID, 'Projects', 'Projects', '/']);
+  });
+
+  it('stores a NULL delimiter when the account has no delimiter rows yet', async () => {
+    accountDelimiter = null;
+    imapManager.ensureFolder.mockResolvedValue({ path: 'Solo', created: true });
+    const res = await create({ name: 'Solo' });
+    expect(res.status).toBe(200);
+    const [, params] = insertedFolderCall();
+    expect(params).toEqual([ACCOUNT_ID, 'Solo', 'Solo', null]);
+  });
+
+  it('reports failure without inserting a DB row when the IMAP create throws', async () => {
+    imapManager.ensureFolder.mockRejectedValue(new Error('NO create denied'));
+    const res = await create({ name: 'Nope', parentPath: 'INBOX.Foo' });
+    expect(res.status).toBe(500);
+    expect(insertedFolderCall()).toBeUndefined();
+  });
+});

--- a/backend/src/routes/mail.js
+++ b/backend/src/routes/mail.js
@@ -887,20 +887,30 @@ router.post('/folders', async (req, res) => {
   const check = await query('SELECT * FROM email_accounts WHERE id = $1 AND user_id = $2', [accountId, req.session.userId]);
   if (!check.rows.length) return res.status(404).json({ error: 'Account not found' });
 
-  // Build path: if parentPath given, look up the delimiter used by this account's folders
-  let path = name.trim();
-  if (parentPath) {
-    const delimResult = await query('SELECT delimiter FROM folders WHERE account_id = $1 LIMIT 1', [accountId]);
-    const delim = delimResult.rows[0]?.delimiter || '/';
-    path = `${parentPath}${delim}${name.trim()}`;
-  }
+  // Join parent and leaf with '/' and let ensureFolder translate: it splits on
+  // '/' and imapflow joins the segments with the server's real hierarchy
+  // delimiter and namespace, so a parent stored in native form (INBOX.Foo)
+  // plus a new leaf lands at INBOX.Foo.Bar on a dot-delimited server. The raw
+  // mailboxCreate this replaces ignored both, so a folder created through
+  // MailFlow could be stored under a path the server never had — and creating
+  // a subfolder beneath such a ghost silently vanished on the next
+  // folder-structure sync.
+  const requested = parentPath ? `${parentPath}/${name.trim()}` : name.trim();
 
   try {
-    await imapManager.createFolder(check.rows[0], path);
+    const { path } = await imapManager.ensureFolder(check.rows[0], requested, { resolvePath: true });
+    // Store the account's delimiter too — rows inserted without one (NULL)
+    // poison later delimiter lookups for subfolder creation and rename.
+    const delimResult = await query(
+      `SELECT delimiter FROM folders
+       WHERE account_id = $1 AND delimiter IS NOT NULL AND delimiter <> ''
+       LIMIT 1`,
+      [accountId]
+    );
     await query(
-      `INSERT INTO folders (account_id, path, name) VALUES ($1, $2, $3)
+      `INSERT INTO folders (account_id, path, name, delimiter) VALUES ($1, $2, $3, $4)
        ON CONFLICT (account_id, path) DO NOTHING`,
-      [accountId, path, name.trim()]
+      [accountId, path, name.trim(), delimResult.rows[0]?.delimiter || null]
     );
     res.json({ ok: true, path });
   } catch (err) {

--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -4688,12 +4688,6 @@ export class ImapManager {
     throw lastErr;
   }
 
-  async createFolder(account, path) {
-    return withFreshClient(account, async (client) => {
-      await client.mailboxCreate(path);
-    });
-  }
-
   // Ensure a mailbox exists, returning { path, created }: `path` is the real server path
   // the mailbox has under this account's personal namespace (e.g. 'INBOX.Todo' on a
   // prefixed server), `created` is true only when THIS call made it. The "create missing


### PR DESCRIPTION
## Summary

Completes #395 on the server side. The create-folder route called raw `mailboxCreate` with a locally built path: no namespace handling, so on prefixed servers (e.g. everything under `INBOX.`) the folder was created at a different real path than the DB stored — a ghost row pointing at a path the server never had. The row was also inserted with a NULL delimiter, and the subfolder delimiter lookup was an unordered `LIMIT 1` that could land on such a NULL row and fall back to `/` on a dot-delimited server. Chained together: creating a subfolder under a MailFlow-created folder built a wrong-format path, and the next folder-structure sync pruned it — a silent failure.

## Changes

- Route creation through `ensureFolder` — the existing namespace/delimiter/already-exists handling the GTD plugin already relies on — joining parent and leaf with `/` for it to translate, and store the **returned real server path** in the DB.
- Store the account's delimiter on the inserted row (previously NULL, poisoning later subfolder/rename path building), resolved via a delimiter lookup that skips NULL/empty rows.
- Delete the now-unused raw `createFolder` method so nothing regresses to it.

## Testing

- New `mail.createFolder.test.js` (4 tests, modeled on the emptyFolder route tests): prefixed-server path translation (`INBOX.Foo/Bar` request → `INBOX.Foo.Bar` stored), root creation, NULL-delimiter fallback for accounts with no synced folders, and no DB insert when the IMAP create throws.
- Running in production on my instance; combined with the UI fix, subfolder creation works end-to-end including under folders MailFlow itself created.
- `npm run lint` clean; full backend suite passes (1251/1251).

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
