### PR TITLE
build: make the frontend nginx base image overridable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,14 @@ DOMAIN=mail.yourdomain.com
 ACME_EMAIL=you@yourdomain.com
 
 
+# ── Source-build tuning (advanced) ────────────────────────────────────────────
+# Base image for the frontend (nginx) stage when building from source. Some
+# hosts with older kernels (e.g. NAS units) cannot execute binaries from the
+# newest Alpine package repo — `apk add` in the build dies with "killed by
+# signal 9". Point this at an older tag to fix that. Default: nginx:alpine.
+# NGINX_BASE=nginx:1.27-alpine
+
+
 # ── IMAP tuning ───────────────────────────────────────────────────────────────
 # Max always-on IMAP connections MailFlow keeps per provider host. Each enabled
 # account normally holds one persistent (IDLE) connection, so many accounts on

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       args:
         VITE_BUILD_SHA: ${GIT_SHA:-dev}
         VITE_EMAIL_DIV_RENDER: ${VITE_EMAIL_DIV_RENDER:-false}
+        NGINX_BASE: ${NGINX_BASE:-nginx:alpine}
     container_name: mailflow-frontend
     restart: unless-stopped
     ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,8 @@
+# Overridable nginx base for hosts whose older kernels cannot exec binaries from
+# the newest Alpine package repo (e.g. some NAS units) — set to an older tag like
+# nginx:1.27-alpine via the NGINX_BASE build arg.
+ARG NGINX_BASE=nginx:alpine
+
 FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 
 WORKDIR /app
@@ -19,7 +24,7 @@ ENV VITE_EMAIL_DIV_RENDER=${VITE_EMAIL_DIV_RENDER:-false}
 
 RUN npm run build
 
-FROM nginx:alpine
+FROM ${NGINX_BASE}
 
 RUN apk add --no-cache openssl
 


### PR DESCRIPTION
## Summary

Self-hosters on devices with older kernels (common on NAS units) can't build the frontend image: the kernel can't exec binaries from the newest Alpine package repo, so `RUN apk add --no-cache openssl` in the `nginx:alpine` stage dies with `busybox-1.37.0-r30.trigger: killed by signal 9` (reproducible with a plain `docker run --rm nginx:alpine sh -c 'apk add openssl'` on such hosts, so it's not a BuildKit issue). Binaries baked into images run fine; only freshly installed packages from the current Alpine branch die.

## Changes

- Expose the frontend's nginx base as a build arg: `ARG NGINX_BASE=nginx:alpine` in `frontend/Dockerfile`, passed through `docker-compose.yml` from the environment, documented in `.env.example`.
- Default behavior is byte-identical (`nginx:alpine`); affected hosts set e.g. `NGINX_BASE=nginx:1.27-alpine` in `.env` — whose Alpine 3.21 branch packages still exec on older kernels — instead of patching the Dockerfile.

## Testing

- In production on my instance for weeks: an ASUSTOR NAS that fails the default build cleanly builds and runs with `NGINX_BASE=nginx:1.27-alpine`; a default build elsewhere is unchanged.
- No JS changes; lint/test suites unaffected.

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
