### PR TITLE
fix(attachments): keep inline-disposed named text files out of the body

### DIFF
--- a/backend/src/services/imapManager.js
+++ b/backend/src/services/imapManager.js
@@ -553,10 +553,33 @@ function decodeAttachmentBuffer(buf, encoding) {
 }
 
 export function walkStructure(node, results) {
+  walkNode(node, results);
+  // A text part that carries a filename is an attached file (an .html report, a
+  // .txt log) when the message also has an unnamed text part serving as its
+  // body. Senders often mark such files inline or omit the disposition, so the
+  // disposition check alone absorbed them into the body candidates and they
+  // vanished from the attachment list. When every text part is named, leave
+  // them as body — some clients name their body parts.
+  const named = results.textParts.filter(p => p.filename);
+  if (!named.length || named.length === results.textParts.length) return;
+  results.textParts = results.textParts.filter(p => !p.filename);
+  for (const p of named) {
+    results.attachments.push({
+      part: p.part,
+      filename: p.filename,
+      type: p.rawType,
+      encoding: p.encoding || 'base64',
+      size: p.size,
+      disposition: p.disposition,
+    });
+  }
+}
+
+function walkNode(node, results) {
   if (!node) return;
   const type = (node.type || '').toLowerCase();
   if (node.childNodes && node.childNodes.length > 0) {
-    for (const child of node.childNodes) walkStructure(child, results);
+    for (const child of node.childNodes) walkNode(child, results);
     return;
   }
   const disposition = (node.disposition || '').toLowerCase();
@@ -577,23 +600,20 @@ export function walkStructure(node, results) {
       size: node.dispositionParameters?.size ? parseInt(node.dispositionParameters.size) : node.size || 0,
       disposition,
     });
-  } else if (type === 'text/html') {
+  } else if (type === 'text/html' || type === 'application/xhtml+xml' || type === 'text/plain') {
     results.textParts.push({
-      part: node.part || '1', type,
+      part: node.part || '1',
+      type: type === 'text/plain' ? 'text/plain' : 'text/html',
       encoding: node.encoding || '',
       charset: node.parameters?.charset || 'utf-8',
-    });
-  } else if (type === 'application/xhtml+xml') {
-    results.textParts.push({
-      part: node.part || '1', type: 'text/html',
-      encoding: node.encoding || '',
-      charset: node.parameters?.charset || 'utf-8',
-    });
-  } else if (type === 'text/plain') {
-    results.textParts.push({
-      part: node.part || '1', type,
-      encoding: node.encoding || '',
-      charset: node.parameters?.charset || 'utf-8',
+      // A filename marks a possible attached file; walkStructure's post-pass
+      // decides once the whole tree is known.
+      ...(filename ? {
+        filename,
+        rawType: node.type || type,
+        size: node.dispositionParameters?.size ? parseInt(node.dispositionParameters.size) : node.size || 0,
+        disposition,
+      } : {}),
     });
   } else if (type.startsWith('image/') && node.id && disposition !== 'attachment') {
     // Inline image referenced via cid: in the HTML body

--- a/backend/src/services/imapManager.test.js
+++ b/backend/src/services/imapManager.test.js
@@ -1317,6 +1317,49 @@ describe('walkStructure attachment classification', () => {
     expect(results.attachments).toHaveLength(1);
     expect(results.attachments[0].filename).toBe('invoice.pdf');
   });
+
+  it('treats an inline-disposed named HTML file alongside a body as an attachment', () => {
+    const results = walk({
+      type: 'multipart/mixed',
+      childNodes: [
+        { part: '1', type: 'text/html', encoding: 'quoted-printable' },
+        {
+          part: '2', type: 'text/html', encoding: 'base64', size: 4096,
+          disposition: 'inline', dispositionParameters: { filename: 'report.html' },
+        },
+      ],
+    });
+    expect(results.textParts.map(p => p.part)).toEqual(['1']);
+    expect(results.attachments).toHaveLength(1);
+    expect(results.attachments[0]).toMatchObject({
+      part: '2', filename: 'report.html', type: 'text/html', encoding: 'base64', size: 4096,
+    });
+  });
+
+  it('treats an undisposed text part named via Content-Type as an attachment', () => {
+    const results = walk({
+      type: 'multipart/mixed',
+      childNodes: [
+        { part: '1', type: 'text/plain', encoding: '7bit' },
+        { part: '2', type: 'text/plain', encoding: '7bit', parameters: { name: 'server.log' } },
+      ],
+    });
+    expect(results.textParts.map(p => p.part)).toEqual(['1']);
+    expect(results.attachments.map(a => a.filename)).toEqual(['server.log']);
+    expect(results.attachments[0].encoding).toBe('7bit');
+  });
+
+  it('keeps named text parts as body when no unnamed body part exists', () => {
+    const results = walk({
+      type: 'multipart/alternative',
+      childNodes: [
+        { part: '1', type: 'text/plain', encoding: '7bit', parameters: { name: 'body.txt' } },
+        { part: '2', type: 'text/html', encoding: '7bit', parameters: { name: 'body.html' } },
+      ],
+    });
+    expect(results.textParts.map(p => p.type)).toEqual(['text/plain', 'text/html']);
+    expect(results.attachments).toHaveLength(0);
+  });
 });
 
 // ── _shouldAutoBackfillOnConnect — auto-backfill gate (#354) ──────────────────

--- a/backend/src/services/messageParser.attachments.test.js
+++ b/backend/src/services/messageParser.attachments.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { detectAttachments } from './messageParser.js';
+
+describe('detectAttachments', () => {
+  it('flags an explicit attachment disposition anywhere in the tree', () => {
+    expect(detectAttachments({
+      type: 'multipart/mixed',
+      childNodes: [
+        { type: 'text/plain' },
+        { type: 'application/pdf', disposition: 'attachment', dispositionParameters: { filename: 'a.pdf' } },
+      ],
+    })).toBe(true);
+  });
+
+  it('flags a named inline text part alongside an unnamed body part', () => {
+    expect(detectAttachments({
+      type: 'multipart/mixed',
+      childNodes: [
+        { type: 'text/html' },
+        { type: 'text/html', disposition: 'inline', dispositionParameters: { filename: 'report.html' } },
+      ],
+    })).toBe(true);
+    expect(detectAttachments({
+      type: 'multipart/mixed',
+      childNodes: [
+        { type: 'text/plain' },
+        { type: 'text/plain', parameters: { name: 'server.log' } },
+      ],
+    })).toBe(true);
+  });
+
+  it('does not flag an ordinary multipart/alternative body', () => {
+    expect(detectAttachments({
+      type: 'multipart/alternative',
+      childNodes: [{ type: 'text/plain' }, { type: 'text/html' }],
+    })).toBe(false);
+  });
+
+  it('does not flag a message whose only text parts are named', () => {
+    expect(detectAttachments({
+      type: 'multipart/alternative',
+      childNodes: [
+        { type: 'text/plain', parameters: { name: 'body.txt' } },
+        { type: 'text/html', parameters: { name: 'body.html' } },
+      ],
+    })).toBe(false);
+  });
+
+  it('is false for missing structure', () => {
+    expect(detectAttachments(null)).toBe(false);
+  });
+});

--- a/backend/src/services/messageParser.js
+++ b/backend/src/services/messageParser.js
@@ -673,11 +673,26 @@ export async function parseMessage(msg) {
   };
 }
 
-function detectAttachments(structure) {
+// Mirrors walkStructure's classification (imapManager.js) so the paperclip flag
+// agrees with the attachment list: an explicit attachment disposition anywhere,
+// or a text part carrying a filename alongside an unnamed text part serving as
+// the body (an inline .html report or .txt log the sender didn't dispose as an
+// attachment). Exported for tests.
+export function detectAttachments(structure) {
   if (!structure) return false;
-  if (structure.disposition === 'attachment') return true;
-  if (structure.childNodes) {
-    return structure.childNodes.some(child => detectAttachments(child));
-  }
-  return false;
+  let explicit = false;
+  let namedText = 0;
+  let unnamedText = 0;
+  const visit = (node) => {
+    if (!node) return;
+    if (node.disposition === 'attachment') { explicit = true; return; }
+    if (node.childNodes?.length) { node.childNodes.forEach(visit); return; }
+    const type = (node.type || '').toLowerCase();
+    if (type === 'text/plain' || type === 'text/html' || type === 'application/xhtml+xml') {
+      if (node.dispositionParameters?.filename || node.parameters?.name) namedText += 1;
+      else unnamedText += 1;
+    }
+  };
+  visit(structure);
+  return explicit || (namedText > 0 && unnamedText > 0);
 }


### PR DESCRIPTION
## Summary

An attached `.html` (or `.txt`) file that the sender marks `Content-Disposition: inline` — or leaves without a disposition — never appears in the attachment list and cannot be downloaded, while the message body itself renders fine. `walkStructure` routes every `text/html` / `text/plain` leaf into the body candidates before ever looking at the filename, so such a part is absorbed as a spare body part and dropped; only parts with an explicit `attachment` disposition escape that. Whether a given email is affected depends purely on how the sending client labels the part, which makes it look intermittent.

## Changes

- Text leaves now record their filename (from the disposition or the Content-Type `name` param). After the walk, a post-pass reclassifies **named** text parts as attachments — but only when an **unnamed** text part exists to serve as the body. If every text part is named (some clients name their body parts), nothing changes, so ordinary rendering can't regress.
- `walkStructure` becomes a thin wrapper (walk + post-pass) around the recursion, so all five consumers — sync-time body extraction, on-demand body fetch, attachment lookups — get the same classification with no call-site changes.
- `detectAttachments` (the paperclip flag) mirrors the rule so the icon agrees with the list.

## Testing

- Reproduced on a live self-hosted instance with a forwarded email carrying an inline-disposed HTML attachment: the body rendered but the attachment list was empty; after the fix the file lists and downloads. Messages with attachment-disposed files and plain multipart/alternative bodies behave exactly as before.
- New `walkStructure` cases: inline-disposed named HTML alongside a body → attachment; Content-Type-named text part → attachment (encoding preserved for download decoding); all-named text parts → body. New `messageParser.attachments.test.js` (5 cases) covers the paperclip rule.
- `npm run lint` clean; full backend suite passes (1255/1255).

---

### Contributor License Agreement

By submitting this pull request I confirm that:

- [x] I have read and agree to the [Contributor License Agreement](../CLA.md).
- [x] My contribution is my own original work (or I have identified any
      third-party material and confirmed it is compatible with the CLA).
- [x] I have the right to submit this contribution under the terms of the CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
